### PR TITLE
fix: fixes trailing release in changelog

### DIFF
--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -3,6 +3,7 @@ description: "Sets up rust for an environment"
 runs:
   using: "composite"
   steps:
+    - uses: Swatinem/rust-cache@v2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: 1.89.0

--- a/src/analyzer/cliff.rs
+++ b/src/analyzer/cliff.rs
@@ -66,9 +66,6 @@ impl CliffAnalyzer {
 
         // loop commits in reverse oldest -> newest
         for git_commit in commits.iter().rev() {
-            // TODO: figure out how to omit tagged commit parent when we have
-            // a starting point
-
             // get release at end of list
             let release = releases.last_mut().unwrap();
             // add commit details to release
@@ -166,7 +163,11 @@ impl CliffAnalyzer {
         let mut buf = BufWriter::new(Vec::new());
         changelog.generate(&mut buf)?;
         let bytes = buf.into_inner()?;
-        let out = String::from_utf8(bytes)?;
+        let mut out = String::from_utf8(bytes)?;
+
+        if self.starting_point.is_some() {
+            out = cliff_helpers::strip_trailing_previous_release(&out);
+        }
 
         let mut projected_release = None;
 

--- a/src/analyzer/cliff_helpers.rs
+++ b/src/analyzer/cliff_helpers.rs
@@ -225,6 +225,15 @@ pub fn parse_projected_release_notes(changelog: &str) -> String {
     notes[1].to_string()
 }
 
+pub fn strip_trailing_previous_release(changelog: &str) -> String {
+    let starting_flag = Regex::new(r"(?m)^#\s").unwrap();
+    let stripped: Vec<&str> = starting_flag
+        .splitn(changelog.trim(), 3)
+        .map(|c| c.trim())
+        .collect();
+    format!("# {}\n\n", stripped[1])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
When we detect a starting point from previous tag, we start from the parent of the tagged commit so we can included the actual tagged commit when generating pervious releases and calculating next version. But this causes the trailing parent commit from the previous release to be included even though it already exists in the changelog. So this commit removes that trailing commit in that case.