### PR TITLE
feat: add support for skipping some groups and including author

### DIFF
--- a/book/src/basic-configuration.md
+++ b/book/src/basic-configuration.md
@@ -88,12 +88,23 @@ first_release_search_depth = 400
 
 ### `[changelog]` Section (Optional)
 
-Controls how changelogs are generated:
+Controls how changelogs are generated and which commits to include:
 
 ```toml
 [changelog]
+skip_ci = false              # Optional: exclude CI commits from changelog
+skip_chore = false           # Optional: exclude chore commits from changelog
+skip_miscellaneous = false   # Optional: exclude non-conventional commits
+include_author = false       # Optional: show commit author names
 # body template is available for advanced users
 ```
+
+**Common changelog options:**
+
+- `skip_ci`: Exclude CI/CD commits (e.g., "ci: update workflow")
+- `skip_chore`: Exclude maintenance commits (e.g., "chore: update deps")
+- `skip_miscellaneous`: Exclude commits without conventional type prefixes
+- `include_author`: Add author names to changelog entries
 
 ### `[[package]]` Sections (Required)
 
@@ -170,6 +181,37 @@ release_type = "Rust"
 tag_prefix = "lib-"
 ```
 
+### Clean Changelog (Filtered Commits)
+
+```toml
+# Focus on user-facing changes only
+[changelog]
+skip_ci = true
+skip_chore = true
+skip_miscellaneous = true
+
+[[package]]
+path = "."
+release_type = "Rust"
+tag_prefix = "v"
+```
+
+### Changelog with all commits and author attribution
+
+```toml
+# Show who contributed each change
+[changelog]
+skip_ci = false
+skip_chore = false
+skip_miscellaneous = false
+include_author = true
+
+[[package]]
+path = "."
+release_type = "Python"
+tag_prefix = "v"
+```
+
 ## Testing Your Configuration
 
 After creating your configuration file:
@@ -212,6 +254,10 @@ When you don't specify values, these defaults are used:
 first_release_search_depth = 400
 
 [changelog]
+skip_ci = false
+skip_chore = false
+skip_miscellaneous = false
+include_author = false
 body = """# [{{ version  }}]({{ link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
 ### {{ group | striptags | trim }}

--- a/book/src/quick-start.md
+++ b/book/src/quick-start.md
@@ -160,6 +160,33 @@ if:
   analysis
 - **You're in a CI/CD environment** - Use a smaller depth for faster builds
 
+### Filtering Changelog Commits
+
+You can also control which commits appear in your changelog by adding filtering
+options to the `[changelog]` section:
+
+```toml
+[changelog]
+skip_ci = true              # Exclude CI/CD commits
+skip_chore = true           # Exclude chore/maintenance commits
+skip_miscellaneous = true   # Exclude non-conventional commits
+include_author = true       # Show commit author names
+
+[[package]]
+path = "."
+release_type = "Node"
+```
+
+These options help you:
+
+- **`skip_ci`** - Remove CI/CD related commits (e.g., "ci: update workflow")
+- **`skip_chore`** - Remove maintenance commits (e.g., "chore: update deps")
+- **`skip_miscellaneous`** - Remove commits without conventional type prefixes
+- **`include_author`** - Add author attribution to each changelog entry
+
+This keeps your changelog focused on user-facing changes. See the
+[Configuration](./configuration.md) guide for more details and examples.
+
 ## Common Patterns
 
 ### Workflow Integration

--- a/releasaurus.toml
+++ b/releasaurus.toml
@@ -1,0 +1,8 @@
+[changelog]
+skip_ci = false
+skip_chore = false
+skip_miscellaneous = false
+include_author = true
+
+[[package]]
+path = "."

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Releasaurs TOML Configuration Schema",
+  "description": "Releasaurus TOML configuration.",
+  "type": "object",
+  "properties": {
+    "first_release_search_depth": {
+      "type": "number",
+      "description": "Configures commit search depth for first release. After the first release releasaurus will always parse all the commits since the last release"
+    },
+    "changelog": {
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "Tera template for generating changelog body"
+        },
+        "skip_ci": {
+          "type": "boolean",
+          "description": "Skips including \"ci\" commits in changelog"
+        },
+        "skip_chore": {
+          "type": "boolean",
+          "description": "Skips including \"chore\" commits in changelog"
+        },
+        "skip_miscellaneous": {
+          "type": "boolean",
+          "description": "Skips including miscellaneous commits in changelog. Miscellaneous commits are commits that do not conform to conventional commits standard"
+        },
+        "include_author": {
+          "type": "boolean",
+          "description": "Includes the author name for each commit in the generated changelog"
+        }
+      }
+    },
+    "packages": {
+      "type": "array",
+      "description": "A list of packages to generate releases for in this repository",
+      "items": {
+        "type": "object",
+        "description": "package config",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The relative path to the package directory starting from root of repository"
+          },
+          "release_type": {
+            "type": "string",
+            "description": "The release type to use when updating package version files",
+            "enum": ["Generic", "Java", "Node", "Php", "Python", "Ruby", "Rust"]
+          },
+          "tag_prefix": {
+            "type": "string",
+            "description": "The tag prefix to use for this package: default (\"v\")"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/analyzer/config.rs
+++ b/src/analyzer/config.rs
@@ -6,7 +6,7 @@ pub const DEFAULT_BODY: &str = r#"# [{{ version  }}]({{ link }}) - {{ timestamp 
 ### {{ group | striptags | trim }}
 {% for commit in commits %}
 {% if commit.breaking -%}
-{% if commit.scope %}_({{ commit.scope }})_ {% endif -%}[**breaking**]: {{ commit.message }} [_({{ commit.id | truncate(length=8, end="") }})_]({{ commit.link }})
+{% if commit.scope %}_({{ commit.scope }})_ {% endif -%}[**breaking**]: {{ commit.message }} [_({{ commit.id | truncate(length=8, end="") }})_]({{ commit.link }}){{% if include_author }} <{{ commit.author_name }}>{{% endif }}
 {% if commit.body -%}
 > {{ commit.body }}
 {% endif -%}
@@ -14,7 +14,7 @@ pub const DEFAULT_BODY: &str = r#"# [{{ version  }}]({{ link }}) - {{ timestamp 
 > {{ commit.breaking_description }}
 {% endif -%}
 {% else -%}
-- {% if commit.scope %}_({{ commit.scope }})_ {% endif %}{{ commit.message }} [_({{ commit.id | truncate(length=8, end="") }})_]({{ commit.link }})
+- {% if commit.scope %}_({{ commit.scope }})_ {% endif %}{{ commit.message }} [_({{ commit.id | truncate(length=8, end="") }})_]({{ commit.link }}){{% if include_author }} <{{ commit.author_name }}>{{% endif }}
 {% endif -%}
 {% endfor %}
 {% endfor %}
@@ -25,6 +25,14 @@ pub const DEFAULT_BODY: &str = r#"# [{{ version  }}]({{ link }}) - {{ timestamp 
 pub struct AnalyzerConfig {
     /// Tera template string for changelog body format.
     pub body: String,
+    /// Skips including ci commits in changelog (default: false)
+    pub skip_ci: bool,
+    /// Skips including ci commits in changelog (default: false)
+    pub skip_chore: bool,
+    /// Skips including miscellaneous commits in changelog (default: false)
+    pub skip_miscellaneous: bool,
+    /// Includes commit author in default body template (default: false)
+    pub include_author: bool,
     /// Optional prefix for package tags.
     pub tag_prefix: Option<String>,
     /// Base URL for release links in changelog.
@@ -35,6 +43,10 @@ impl Default for AnalyzerConfig {
     fn default() -> Self {
         Self {
             body: DEFAULT_BODY.into(),
+            skip_ci: false,
+            skip_chore: false,
+            skip_miscellaneous: false,
+            include_author: false,
             tag_prefix: None,
             release_link_base_url: "".into(),
         }

--- a/src/analyzer/group.rs
+++ b/src/analyzer/group.rs
@@ -21,7 +21,7 @@ pub enum Group {
     Chore,
     Ci,
     #[default]
-    Other,
+    Miscellaneous,
 }
 
 impl Serialize for Group {
@@ -85,7 +85,7 @@ impl Serialize for Group {
                 10,
                 "<!-- 10 -->⏩ CI/CD",
             ),
-            Group::Other => serializer.serialize_unit_variant(
+            Group::Miscellaneous => serializer.serialize_unit_variant(
                 "Group",
                 11,
                 "<!-- 11 -->⚙️ Miscellaneous Tasks",
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn test_group_default() {
         let group = Group::default();
-        assert_eq!(group, Group::Other);
+        assert_eq!(group, Group::Miscellaneous);
     }
 
     #[test]
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(Group::Fix, Group::Fix);
         assert_eq!(Group::Breaking, Group::Breaking);
         assert_ne!(Group::Feat, Group::Fix);
-        assert_ne!(Group::Breaking, Group::Other);
+        assert_ne!(Group::Breaking, Group::Miscellaneous);
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod tests {
         // Test other orderings
         assert!(Group::Breaking < Group::Feat);
         assert!(Group::Feat < Group::Fix);
-        assert!(Group::Other > Group::Ci); // Other should be last
+        assert!(Group::Miscellaneous > Group::Ci); // Other should be last
     }
 
     #[test]
@@ -276,7 +276,7 @@ mod tests {
             (Group::Test, "🧪 Testing"),
             (Group::Chore, "🧹 Chore"),
             (Group::Ci, "⏩ CI/CD"),
-            (Group::Other, "⚙️ Miscellaneous Tasks"),
+            (Group::Miscellaneous, "⚙️ Miscellaneous Tasks"),
         ];
 
         for (group, expected) in test_cases {
@@ -384,7 +384,7 @@ mod tests {
         let parser = GroupParser::new();
         let commit = create_test_commit("random: unknown type", false);
         let group = parser.parse(&commit);
-        assert_eq!(group, Group::Other);
+        assert_eq!(group, Group::Miscellaneous);
     }
 
     #[test]
@@ -392,7 +392,7 @@ mod tests {
         let parser = GroupParser::new();
         let commit = create_test_commit("", false);
         let group = parser.parse(&commit);
-        assert_eq!(group, Group::Other);
+        assert_eq!(group, Group::Miscellaneous);
     }
 
     #[test]
@@ -414,7 +414,7 @@ mod tests {
 
         // Uppercase should not match (our regexes are case-sensitive)
         let commit2 = create_test_commit("FEAT: uppercase", false);
-        assert_eq!(parser.parse(&commit2), Group::Other);
+        assert_eq!(parser.parse(&commit2), Group::Miscellaneous);
     }
 
     #[test]

--- a/src/analyzer/release.rs
+++ b/src/analyzer/release.rs
@@ -49,6 +49,8 @@ pub struct Release {
     pub sha: String,
     /// Commits included in this release.
     pub commits: Vec<Commit>,
+    /// Whether or not to include author name for each commit in changelog
+    pub include_author: bool,
     /// Generated release notes.
     pub notes: String,
     /// Release timestamp.
@@ -61,6 +63,7 @@ impl std::fmt::Debug for Release {
             .field("tag", &self.tag)
             .field("link", &self.link)
             .field("sha", &self.sha)
+            .field("include_author", &self.include_author)
             .field("timestamp", &self.timestamp)
             .finish()
     }
@@ -80,6 +83,7 @@ impl Serialize for Release {
         s.serialize_field("link", &self.link)?;
         s.serialize_field("version", &tag.semver.to_string())?;
         s.serialize_field("sha", &self.sha)?;
+        s.serialize_field("include_author", &self.include_author)?;
         s.serialize_field("commits", &self.commits)?;
         s.serialize_field("timestamp", &self.timestamp)?;
         s.end()

--- a/src/command/common.rs
+++ b/src/command/common.rs
@@ -1,7 +1,11 @@
 //! Common functionality shared between release commands
 use std::path::Path;
 
-use crate::config;
+use crate::{
+    analyzer::config::AnalyzerConfig,
+    config::{self, Config},
+    forge::config::RemoteConfig,
+};
 
 /// Resolve tag prefix for package from config or generate default based on
 /// package path for monorepo support.
@@ -12,4 +16,22 @@ pub fn get_tag_prefix(package: &config::PackageConfig) -> String {
         default_for_package = format!("{}-v", basename.display());
     }
     package.tag_prefix.clone().unwrap_or(default_for_package)
+}
+
+/// Generates [`AnalyzerConfig`] from [`Config`], [`RemoteConfig`],
+/// and tag_prefix [`String`]
+pub fn generate_analyzer_config(
+    config: &Config,
+    remote_config: &RemoteConfig,
+    tag_prefix: String,
+) -> AnalyzerConfig {
+    AnalyzerConfig {
+        body: config.changelog.body.clone(),
+        include_author: config.changelog.include_author,
+        skip_chore: config.changelog.skip_chore,
+        skip_ci: config.changelog.skip_ci,
+        skip_miscellaneous: config.changelog.skip_miscellaneous,
+        release_link_base_url: remote_config.release_link_base_url.clone(),
+        tag_prefix: Some(tag_prefix),
+    }
 }

--- a/src/command/release_pr.rs
+++ b/src/command/release_pr.rs
@@ -4,7 +4,7 @@ use log::*;
 use std::{collections::HashMap, path::Path};
 
 use crate::{
-    analyzer::{Analyzer, config::AnalyzerConfig, release::Release},
+    analyzer::{Analyzer, release::Release},
     command::common,
     forge::{
         config::{DEFAULT_PR_BRANCH_PREFIX, PENDING_LABEL},
@@ -43,11 +43,11 @@ pub async fn execute(
 
         info!("processing commits for package: {}", package.path);
 
-        let analyzer_config = AnalyzerConfig {
-            body: config.changelog.body.clone(),
-            release_link_base_url: remote_config.release_link_base_url.clone(),
-            tag_prefix: Some(tag_prefix),
-        };
+        let analyzer_config = common::generate_analyzer_config(
+            &config,
+            &remote_config,
+            tag_prefix,
+        );
 
         let analyzer = Analyzer::new(analyzer_config)?;
         let release = analyzer.analyze(commits, current_tag)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,12 +15,24 @@ pub const DEFAULT_CONFIG_FILE: &str = "releasaurus.toml";
 pub struct ChangelogConfig {
     /// Main changelog body template.
     pub body: String,
+    /// Skips including ci commits in changelog (default: false)
+    pub skip_ci: bool,
+    /// Skips including ci commits in changelog (default: false)
+    pub skip_chore: bool,
+    /// Skips including miscellaneous commits in changelog (default: false)
+    pub skip_miscellaneous: bool,
+    /// Includes commit author in default body template (default: false)
+    pub include_author: bool,
 }
 
 impl Default for ChangelogConfig {
     fn default() -> Self {
         Self {
             body: DEFAULT_BODY.into(),
+            skip_ci: false,
+            skip_chore: false,
+            skip_miscellaneous: false,
+            include_author: false,
         }
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -54,6 +54,10 @@ pub fn create_test_config(packages: Vec<PackageConfig>) -> Config {
         first_release_search_depth: 100,
         changelog: ChangelogConfig {
             body: "## Changes\n{{ commits }}".to_string(),
+            skip_ci: false,
+            skip_chore: false,
+            skip_miscellaneous: false,
+            include_author: false,
         },
         packages,
     }
@@ -79,6 +83,10 @@ pub fn create_test_config_simple(packages: Vec<(&str, ReleaseType)>) -> Config {
         first_release_search_depth: 100,
         changelog: ChangelogConfig {
             body: "## Changes\n{{ commits }}".to_string(),
+            skip_ci: false,
+            skip_chore: false,
+            skip_miscellaneous: false,
+            include_author: false,
         },
         packages: packages
             .into_iter()
@@ -201,6 +209,7 @@ pub fn create_test_release(version: &str, has_tag: bool) -> Release {
         link: String::new(),
         sha: "test-sha".to_string(),
         commits: vec![],
+        include_author: false,
         notes: String::new(),
         timestamp: 0,
     }
@@ -216,6 +225,10 @@ pub fn create_test_analyzer_config() -> AnalyzerConfig {
     AnalyzerConfig {
         tag_prefix: None,
         body: "Release version {{ version }}".to_string(),
+        skip_ci: false,
+        skip_chore: false,
+        skip_miscellaneous: false,
+        include_author: false,
         release_link_base_url: "https://github.com/test/repo/releases/tag"
             .to_string(),
     }
@@ -236,6 +249,10 @@ pub fn create_test_analyzer_config_with_prefix(
     AnalyzerConfig {
         tag_prefix,
         body: "Release version {{ version }}".to_string(),
+        skip_ci: false,
+        skip_chore: false,
+        skip_miscellaneous: false,
+        include_author: false,
         release_link_base_url: "https://github.com/test/repo/releases/tag"
             .to_string(),
     }


### PR DESCRIPTION
## Description

- Adds support for skipping ci, chore, and miscellaneous commits in changelog generation
- Adds support for including commit author name in generated changelog via simple config option

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)