### PR TITLE
feat: adds support for workspace_root config option

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -320,11 +320,90 @@ specifying the `release_type` for version file management.
 
 ### `path`
 
-The directory path to the package, relative to the repository root.
+The directory path to the package, relative to the `workspace_root` path
+(or relative to the repository root if `workspace_root` is not specified).
 
 ```toml
 [[package]]
-path = "."  # Root of repository
+path = "."
+```
+
+```toml
+[[package]]
+workspace_root = "rust-workspace"
+path = "packages/api"  # Relative to rust-workspace directory
+```
+
+### `workspace_root` (Optional)
+
+The directory path to the workspace root for this package, relative to the
+repository root. This allows you to define workspace packages that are in
+subdirectories of the repository.
+
+```toml
+[[package]]
+workspace_root = "."  # Default: repository root
+path = "packages/api"
+release_type = "rust"
+```
+
+**When to use:**
+
+- **Multi-workspace repositories**: When you have multiple independent
+  workspaces in one repository i.e. A rust workspace in a subdirectory
+
+**Default**: If not specified, defaults to `"."` (the repository root).
+
+**How it works:**
+
+The `workspace_root` and `path` are combined to locate package files:
+
+- Version files are located at: `workspace_root + path + <version-file>`
+- Workspace-level files are located at: `workspace_root + <workspace-file>`
+
+**Example: Rust workspace in subdirectory**
+
+```toml
+[[package]]
+name = "api-server-1"
+workspace_root = "backend"  # Workspace is in backend/ directory
+path = "packages/api1"      # Package is in backend/packages/api1/
+release_type = "rust"
+tag_prefix = "api1-v"
+
+name = "api-server-2"
+workspace_root = "backend"  # Workspace is in backend/ directory
+path = "packages/api2"      # Package is in backend/packages/api2/
+release_type = "rust"
+tag_prefix = "api2-v"
+```
+
+This configuration will:
+
+- Update `backend/packages/api1/Cargo.toml`
+- Update `backend/packages/api2/Cargo.toml`
+- Update `backend/Cargo.lock` (workspace-level lock file)
+- Update `backend/packages/api1/Cargo.lock` (if it exists)
+- Update `backend/packages/api2/Cargo.lock` (if it exists)
+
+**Example: Multiple workspaces in one repository**
+
+```toml
+# Rust workspace
+[[package]]
+name = "rust-core"
+workspace_root = "rust-workspace"
+path = "."
+release_type = "rust"
+tag_prefix = "rust-v"
+
+# Node workspace
+[[package]]
+name = "web-app"
+workspace_root = "node-workspace"
+path = "packages/web"
+release_type = "node"
+tag_prefix = "web-v"
 ```
 
 ### `name` (Optional)

--- a/src/command/release_pr.rs
+++ b/src/command/release_pr.rs
@@ -294,6 +294,7 @@ async fn generate_manifest(
         manifest.push(ReleasablePackage {
             name: package.name.clone(),
             path: package.path.clone(),
+            workspace_root: package.workspace_root.clone(),
             release_type,
             release,
         });
@@ -328,6 +329,7 @@ mod tests {
         ReleasablePackage {
             name: name.to_string(),
             path: path.to_string(),
+            workspace_root: ".".into(),
             release_type: ReleaseType::Generic,
             release: Release {
                 tag: Some(Tag {

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,8 +58,10 @@ pub enum ReleaseType {
 pub struct PackageConfig {
     /// Name for this package
     pub name: String,
-    /// Package directory path relative to repository root.
+    /// Path to package directory relative to workspace_root path
     pub path: String,
+    /// Path to the workspace root directory for this package relative to the repository root
+    pub workspace_root: String,
     /// Release type for determining which version files to update.
     pub release_type: Option<ReleaseType>,
     /// Git tag prefix for this package (e.g., "v" or "api-v").
@@ -73,6 +75,7 @@ impl Default for PackageConfig {
         Self {
             name: "".into(),
             path: ".".into(),
+            workspace_root: ".".into(),
             release_type: None,
             tag_prefix: None,
             prerelease: None,

--- a/src/result.rs
+++ b/src/result.rs
@@ -8,9 +8,15 @@ use crate::{analyzer::release::Release, config::ReleaseType};
 /// Represents a release-able package in manifest
 #[derive(Debug)]
 pub struct ReleasablePackage {
+    /// The name of this package
     pub name: String,
+    /// Path to package directory relative to workspace_root path
     pub path: String,
+    /// Path to the workspace root directory for this package relative to the repository root
+    pub workspace_root: String,
+    /// The [`ReleaseType`] for this package
     pub release_type: ReleaseType,
+    /// The computed [`Release`] for this package
     pub release: Release,
 }
 

--- a/src/updater/framework.rs
+++ b/src/updater/framework.rs
@@ -84,8 +84,10 @@ impl Framework {
 pub struct UpdaterPackage {
     /// Package name derived from manifest or directory.
     pub name: String,
-    /// Path to package directory relative to repository root.
+    /// Path to package directory relative to workspace_root path
     pub path: String,
+    /// Path to the workspace root directory for this package relative to the repository root
+    pub workspace_root: String,
     /// Next version to update to based on commit analysis.
     pub next_version: Tag,
     /// Language/framework for selecting appropriate updater.
@@ -104,9 +106,37 @@ impl UpdaterPackage {
         Ok(Self {
             name: pkg.name.clone(),
             path: pkg.path.clone(),
+            workspace_root: pkg.workspace_root.clone(),
             next_version,
             framework,
         })
+    }
+
+    /// Construct a normalized file path by joining workspace_root, path, and filename.
+    /// Strips leading "./" from the result for consistency.
+    pub fn get_file_path(&self, filename: &str) -> String {
+        use std::path::Path;
+
+        let full_path = Path::new(&self.workspace_root)
+            .join(&self.path)
+            .join(filename);
+
+        let path_str = full_path.display().to_string();
+
+        // Strip leading "./" for normalized paths
+        path_str.strip_prefix("./").unwrap_or(&path_str).to_string()
+    }
+
+    /// Construct a normalized workspace-level file path.
+    /// Strips leading "./" from the result for consistency.
+    pub fn get_workspace_file_path(&self, filename: &str) -> String {
+        use std::path::Path;
+
+        let full_path = Path::new(&self.workspace_root).join(filename);
+        let path_str = full_path.display().to_string();
+
+        // Strip leading "./" for normalized paths
+        path_str.strip_prefix("./").unwrap_or(&path_str).to_string()
     }
 }
 
@@ -120,4 +150,115 @@ pub fn updater_packages_from_manifest(
     }
 
     Ok(packages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use semver::Version as SemVer;
+
+    #[test]
+    fn test_updater_package_get_file_path() {
+        let package = UpdaterPackage {
+            name: "test-package".to_string(),
+            path: "packages/test".to_string(),
+            workspace_root: ".".to_string(),
+            next_version: Tag {
+                sha: "abc123".to_string(),
+                name: "v1.0.0".to_string(),
+                semver: SemVer::parse("1.0.0").unwrap(),
+            },
+            framework: Framework::Rust,
+        };
+
+        assert_eq!(
+            package.get_file_path("Cargo.toml"),
+            "packages/test/Cargo.toml"
+        );
+        assert_eq!(
+            package.get_file_path("package.json"),
+            "packages/test/package.json"
+        );
+    }
+
+    #[test]
+    fn test_updater_package_get_file_path_with_empty_workspace() {
+        let package = UpdaterPackage {
+            name: "test-package".to_string(),
+            path: "packages/test".to_string(),
+            workspace_root: "".to_string(),
+            next_version: Tag {
+                sha: "abc123".to_string(),
+                name: "v1.0.0".to_string(),
+                semver: SemVer::parse("1.0.0").unwrap(),
+            },
+            framework: Framework::Rust,
+        };
+
+        assert_eq!(
+            package.get_file_path("Cargo.toml"),
+            "packages/test/Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn test_updater_package_get_file_path_with_custom_workspace() {
+        let package = UpdaterPackage {
+            name: "test-package".to_string(),
+            path: "api".to_string(),
+            workspace_root: "rust-workspace".to_string(),
+            next_version: Tag {
+                sha: "abc123".to_string(),
+                name: "v1.0.0".to_string(),
+                semver: SemVer::parse("1.0.0").unwrap(),
+            },
+            framework: Framework::Rust,
+        };
+
+        assert_eq!(
+            package.get_file_path("Cargo.toml"),
+            "rust-workspace/api/Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn test_updater_package_get_workspace_file_path() {
+        let package = UpdaterPackage {
+            name: "test-package".to_string(),
+            path: "packages/test".to_string(),
+            workspace_root: ".".to_string(),
+            next_version: Tag {
+                sha: "abc123".to_string(),
+                name: "v1.0.0".to_string(),
+                semver: SemVer::parse("1.0.0").unwrap(),
+            },
+            framework: Framework::Rust,
+        };
+
+        assert_eq!(package.get_workspace_file_path("Cargo.lock"), "Cargo.lock");
+        assert_eq!(
+            package.get_workspace_file_path("package-lock.json"),
+            "package-lock.json"
+        );
+    }
+
+    #[test]
+    fn test_updater_package_get_workspace_file_path_with_custom_workspace() {
+        let package = UpdaterPackage {
+            name: "test-package".to_string(),
+            path: "api".to_string(),
+            workspace_root: "rust-workspace".to_string(),
+            next_version: Tag {
+                sha: "abc123".to_string(),
+                name: "v1.0.0".to_string(),
+                semver: SemVer::parse("1.0.0").unwrap(),
+            },
+            framework: Framework::Rust,
+        };
+
+        assert_eq!(
+            package.get_workspace_file_path("Cargo.lock"),
+            "rust-workspace/Cargo.lock"
+        );
+    }
 }

--- a/src/updater/node.rs
+++ b/src/updater/node.rs
@@ -1,3 +1,6 @@
 //! Node.js package updater supporting npm, yarn, and pnpm projects.
 
+pub mod package_json;
+pub mod package_lock;
 pub mod updater;
+pub mod yarn_lock;

--- a/src/updater/node/package_json.rs
+++ b/src/updater/node/package_json.rs
@@ -1,0 +1,111 @@
+use log::*;
+use serde_json::{Value, json};
+
+use crate::{
+    forge::{
+        request::{FileChange, FileUpdateType},
+        traits::FileLoader,
+    },
+    result::Result,
+    updater::framework::UpdaterPackage,
+};
+
+/// Handles package.json file parsing and version updates for Node.js packages.
+pub struct PackageJson {}
+
+impl PackageJson {
+    /// Create package.json handler for version updates.
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Update version fields in package.json files for all Node packages.
+    pub async fn process_packages(
+        &self,
+        packages: &[(String, UpdaterPackage)],
+        loader: &dyn FileLoader,
+    ) -> Result<Option<Vec<FileChange>>> {
+        let mut file_changes: Vec<FileChange> = vec![];
+
+        for (package_name, package) in packages.iter() {
+            let pkg_json = package.get_file_path("package.json");
+
+            let pkg_doc = self.load_doc(&pkg_json, loader).await?;
+            if pkg_doc.is_none() {
+                continue;
+            }
+
+            let mut pkg_doc = pkg_doc.unwrap();
+            pkg_doc["version"] = json!(package.next_version.semver.to_string());
+
+            let other_pkgs = packages
+                .iter()
+                .filter(|(n, _)| n != package_name)
+                .cloned()
+                .collect::<Vec<(String, UpdaterPackage)>>();
+
+            self.update_deps(&mut pkg_doc, "dependencies", &other_pkgs)?;
+            self.update_deps(&mut pkg_doc, "devDependencies", &other_pkgs)?;
+
+            let formatted_json = serde_json::to_string_pretty(&pkg_doc)?;
+
+            file_changes.push(FileChange {
+                path: pkg_json,
+                content: formatted_json,
+                update_type: FileUpdateType::Replace,
+            });
+        }
+
+        if file_changes.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(file_changes))
+    }
+
+    fn update_deps(
+        &self,
+        doc: &mut Value,
+        dep_type: &str,
+        other_packages: &[(String, UpdaterPackage)],
+    ) -> Result<()> {
+        if doc.get(dep_type).is_none() {
+            return Ok(());
+        }
+
+        // Skip if this is a workspace package
+        if let Some(workspaces) = doc.get("workspaces")
+            && (workspaces.is_array() || workspaces.is_object())
+        {
+            debug!("skipping workspace package.json");
+            return Ok(());
+        }
+
+        if let Some(deps) = doc[dep_type].as_object_mut() {
+            for (dep_name, _) in deps.clone() {
+                if let Some((_, package)) =
+                    other_packages.iter().find(|(n, _)| n == &dep_name)
+                {
+                    deps[&dep_name] =
+                        json!(format!("^{}", package.next_version.semver));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn load_doc(
+        &self,
+        file_path: &str,
+        loader: &dyn FileLoader,
+    ) -> Result<Option<Value>> {
+        let content = loader.get_file_content(file_path).await?;
+        if content.is_none() {
+            return Ok(None);
+        }
+        let content = content.unwrap();
+        let doc = serde_json::from_str(&content)?;
+        Ok(Some(doc))
+    }
+}

--- a/src/updater/node/package_lock.rs
+++ b/src/updater/node/package_lock.rs
@@ -1,0 +1,216 @@
+use log::*;
+use serde_json::{Value, json};
+use std::collections::HashSet;
+
+use crate::{
+    forge::{
+        request::{FileChange, FileUpdateType},
+        traits::FileLoader,
+    },
+    result::Result,
+    updater::framework::UpdaterPackage,
+};
+
+/// Handles package-lock.json file parsing and version updates for Node.js packages.
+pub struct PackageLock {}
+
+impl PackageLock {
+    /// Create package-lock.json handler for version updates.
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Update version fields in package-lock.json files for all Node packages.
+    pub async fn process_packages(
+        &self,
+        packages: &[(String, UpdaterPackage)],
+        loader: &dyn FileLoader,
+    ) -> Result<Option<Vec<FileChange>>> {
+        let mut file_changes: Vec<FileChange> = vec![];
+        let mut processed_paths = HashSet::new();
+
+        // First, handle workspace-level package-lock.json files
+        let mut workspace_roots: Vec<&str> = packages
+            .iter()
+            .map(|(_, p)| p.workspace_root.as_str())
+            .collect();
+        workspace_roots.sort_unstable();
+        workspace_roots.dedup();
+
+        for workspace_root in workspace_roots {
+            // Get a package from this workspace to use its helper method
+            let workspace_package = packages
+                .iter()
+                .find(|(_, p)| p.workspace_root == workspace_root)
+                .map(|(_, p)| p);
+
+            if workspace_package.is_none() {
+                continue;
+            }
+
+            let workspace_package = workspace_package.unwrap();
+            let workspace_lock_path =
+                workspace_package.get_workspace_file_path("package-lock.json");
+
+            let workspace_packages: Vec<(String, UpdaterPackage)> = packages
+                .iter()
+                .filter(|(_, p)| p.workspace_root == workspace_root)
+                .cloned()
+                .collect();
+
+            if let Some(change) = self
+                .update_lock_file(
+                    &workspace_lock_path,
+                    &workspace_packages,
+                    loader,
+                )
+                .await?
+            {
+                processed_paths.insert(change.path.clone());
+                file_changes.push(change);
+            }
+        }
+
+        // Then handle package-level package-lock.json files
+        for (package_name, package) in packages.iter() {
+            let path_str = package.get_file_path("package-lock.json");
+
+            // Skip if this path was already processed as a workspace lock file
+            if processed_paths.contains(&path_str) {
+                continue;
+            }
+
+            if let Some(change) = self
+                .update_lock_file(
+                    &path_str,
+                    &[(package_name.clone(), package.clone())],
+                    loader,
+                )
+                .await?
+            {
+                file_changes.push(change);
+            }
+        }
+
+        if file_changes.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(file_changes))
+    }
+
+    /// Update a single package-lock.json file
+    async fn update_lock_file(
+        &self,
+        lock_path: &str,
+        all_packages: &[(String, UpdaterPackage)],
+        loader: &dyn FileLoader,
+    ) -> Result<Option<FileChange>> {
+        let lock_doc = self.load_doc(lock_path, loader).await?;
+
+        if lock_doc.is_none() {
+            return Ok(None);
+        }
+
+        info!("Updating package-lock.json at {}", lock_path);
+        let mut lock_doc = lock_doc.unwrap();
+
+        // Get root package name for later use
+        let root_name = lock_doc
+            .get("name")
+            .and_then(|n| n.as_str())
+            .map(|s| s.to_string());
+
+        // Update root level version if this lock file corresponds to one of our packages
+        if let Some(ref name) = root_name
+            && let Some((_, package)) =
+                all_packages.iter().find(|(n, _)| n == name)
+        {
+            lock_doc["version"] =
+                json!(package.next_version.semver.to_string());
+        }
+
+        // Update packages section
+        if let Some(packages) = lock_doc.get_mut("packages")
+            && let Some(packages_obj) = packages.as_object_mut()
+        {
+            for (key, package_info) in packages_obj {
+                if key.is_empty() {
+                    // Root package entry - update version if this corresponds to one of our packages
+                    if let Some(ref name) = root_name
+                        && let Some((_, package)) =
+                            all_packages.iter().find(|(n, _)| n == name)
+                    {
+                        package_info["version"] =
+                            json!(package.next_version.semver.to_string());
+                    }
+
+                    // Update dependencies within root package entry
+                    if let Some(deps) = package_info.get_mut("dependencies")
+                        && let Some(deps_obj) = deps.as_object_mut()
+                    {
+                        for (dep_name, dep_info) in deps_obj {
+                            if let Some((_, package)) =
+                                all_packages.iter().find(|(n, _)| n == dep_name)
+                            {
+                                *dep_info = json!(format!(
+                                    "^{}",
+                                    package.next_version.semver.to_string()
+                                ));
+                            }
+                        }
+                    }
+
+                    // Update devDependencies within root package entry
+                    if let Some(dev_deps) =
+                        package_info.get_mut("devDependencies")
+                        && let Some(dev_deps_obj) = dev_deps.as_object_mut()
+                    {
+                        for (dep_name, dep_info) in dev_deps_obj {
+                            if let Some((_, package)) =
+                                all_packages.iter().find(|(n, _)| n == dep_name)
+                            {
+                                *dep_info = json!(format!(
+                                    "^{}",
+                                    package.next_version.semver.to_string()
+                                ));
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                // Extract package name from node_modules/ key
+                if let Some(package_name) = key.strip_prefix("node_modules/")
+                    && let Some((_, package)) =
+                        all_packages.iter().find(|(n, _)| n == package_name)
+                {
+                    package_info["version"] =
+                        json!(package.next_version.semver.to_string());
+                }
+            }
+        }
+
+        let formatted_json = serde_json::to_string_pretty(&lock_doc)?;
+
+        Ok(Some(FileChange {
+            path: lock_path.to_string(),
+            content: formatted_json,
+            update_type: FileUpdateType::Replace,
+        }))
+    }
+
+    async fn load_doc(
+        &self,
+        file_path: &str,
+        loader: &dyn FileLoader,
+    ) -> Result<Option<Value>> {
+        let content = loader.get_file_content(file_path).await?;
+        if content.is_none() {
+            return Ok(None);
+        }
+        let content = content.unwrap();
+        let doc = serde_json::from_str(&content)?;
+        Ok(Some(doc))
+    }
+}

--- a/src/updater/node/updater.rs
+++ b/src/updater/node/updater.rs
@@ -1,14 +1,9 @@
 use async_trait::async_trait;
 use log::*;
-use regex::Regex;
-use serde_json::{Value, json};
-use std::path::Path;
+use serde_json::Value;
 
 use crate::{
-    forge::{
-        request::{FileChange, FileUpdateType},
-        traits::FileLoader,
-    },
+    forge::{request::FileChange, traits::FileLoader},
     result::Result,
     updater::{
         framework::{Framework, UpdaterPackage},
@@ -16,23 +11,34 @@ use crate::{
     },
 };
 
+use super::package_json::PackageJson;
+use super::package_lock::PackageLock;
+use super::yarn_lock::YarnLock;
+
 /// Node.js package updater for npm, yarn, and pnpm projects.
-pub struct NodeUpdater {}
+pub struct NodeUpdater {
+    package_json: PackageJson,
+    package_lock: PackageLock,
+    yarn_lock: YarnLock,
+}
 
 impl NodeUpdater {
     /// Create Node.js updater for package.json and lock file management.
     pub fn new() -> Self {
-        Self {}
+        Self {
+            package_json: PackageJson::new(),
+            package_lock: PackageLock::new(),
+            yarn_lock: YarnLock::new(),
+        }
     }
 
     /// Load and parse JSON file from repository into serde_json Value.
-    async fn load_doc<P: AsRef<Path>>(
+    async fn load_doc(
         &self,
-        file_path: P,
+        file_path: &str,
         loader: &dyn FileLoader,
     ) -> Result<Option<Value>> {
-        let file_path = file_path.as_ref().display().to_string();
-        let content = loader.get_file_content(&file_path).await?;
+        let content = loader.get_file_content(file_path).await?;
         if content.is_none() {
             return Ok(None);
         }
@@ -41,45 +47,15 @@ impl NodeUpdater {
         Ok(Some(doc))
     }
 
-    /// Update dependency versions in package.json, skipping workspace
-    /// protocol references.
-    fn update_deps(
-        &self,
-        doc: &mut Value,
-        dep_kind: &str,
-        other_packages: &[(String, UpdaterPackage)],
-    ) -> Result<()> {
-        if let Some(deps) = doc[dep_kind].as_object_mut() {
-            for (key, value) in deps {
-                if let Some((_, other_package)) =
-                    other_packages.iter().find(|(n, _)| n == key)
-                {
-                    // Skip workspace dependencies
-                    if let Some(version_str) = value.as_str()
-                        && version_str.starts_with("workspace:")
-                    {
-                        continue;
-                    }
-
-                    *value =
-                        json!(other_package.next_version.semver.to_string());
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Extract package names from package.json files and pair with Package
-    /// structs.
+    /// Extract package names from package.json files and pair with Package structs.
     async fn get_packages_with_names(
         &self,
         packages: Vec<UpdaterPackage>,
         loader: &dyn FileLoader,
     ) -> Vec<(String, UpdaterPackage)> {
         let results = packages.into_iter().map(|p| async {
-            let manifest_path = Path::new(&p.path).join("package.json");
-            let content = self.load_doc(manifest_path, loader).await;
+            let manifest_path = p.get_file_path("package.json");
+            let content = self.load_doc(&manifest_path, loader).await;
             if let Ok(content) = content
                 && let Some(doc) = content
                 && let Some(name) = doc["name"].as_str()
@@ -91,457 +67,6 @@ impl NodeUpdater {
         });
 
         futures::future::join_all(results).await
-    }
-
-    /// Update package-lock.json file for a specific package
-    async fn update_package_lock_json_for_package(
-        &self,
-        current_package: (&str, &UpdaterPackage),
-        other_packages: &[(String, UpdaterPackage)],
-        loader: &dyn FileLoader,
-    ) -> Result<Option<FileChange>> {
-        let lock_path =
-            Path::new(&current_package.1.path).join("package-lock.json");
-
-        let lock_doc = self.load_doc(lock_path.clone(), loader).await?;
-
-        if lock_doc.is_none() {
-            return Ok(None);
-        }
-
-        info!("Updating package-lock.json at {}", lock_path.display());
-        let mut lock_doc = lock_doc.unwrap();
-
-        // Get root package name for later use
-        let root_name = lock_doc
-            .get("name")
-            .and_then(|n| n.as_str())
-            .map(|s| s.to_string());
-
-        // Update root level version if this lock file corresponds to the
-        // current package
-        if let Some(ref name) = root_name
-            && current_package.0 == name
-        {
-            lock_doc["version"] =
-                json!(current_package.1.next_version.semver.to_string());
-        }
-
-        // Update packages section
-        if let Some(packages) = lock_doc.get_mut("packages")
-            && let Some(packages_obj) = packages.as_object_mut()
-        {
-            for (key, package_info) in packages_obj {
-                if key.is_empty() {
-                    // Root package entry - update version if this corresponds
-                    // to the current package
-                    if let Some(ref name) = root_name
-                        && current_package.0 == name
-                    {
-                        package_info["version"] = json!(
-                            current_package.1.next_version.semver.to_string()
-                        );
-                    }
-
-                    // Update dependencies within root package entry
-                    if let Some(deps) = package_info.get_mut("dependencies")
-                        && let Some(deps_obj) = deps.as_object_mut()
-                    {
-                        for (dep_name, dep_info) in deps_obj {
-                            if current_package.0 == dep_name {
-                                *dep_info = json!(format!(
-                                    "^{}",
-                                    current_package
-                                        .1
-                                        .next_version
-                                        .semver
-                                        .to_string()
-                                ));
-                            } else if let Some((_, package)) = other_packages
-                                .iter()
-                                .find(|(n, _)| n == dep_name)
-                            {
-                                *dep_info = json!(format!(
-                                    "^{}",
-                                    package.next_version.semver.to_string()
-                                ));
-                            }
-                        }
-                    }
-
-                    // Update devDependencies within root package entry
-                    if let Some(dev_deps) =
-                        package_info.get_mut("devDependencies")
-                        && let Some(dev_deps_obj) = dev_deps.as_object_mut()
-                    {
-                        for (dep_name, dep_info) in dev_deps_obj {
-                            if current_package.0 == dep_name {
-                                *dep_info = json!(format!(
-                                    "^{}",
-                                    current_package
-                                        .1
-                                        .next_version
-                                        .semver
-                                        .to_string()
-                                ));
-                            } else if let Some((_, package)) = other_packages
-                                .iter()
-                                .find(|(n, _)| n == dep_name)
-                            {
-                                *dep_info = json!(format!(
-                                    "^{}",
-                                    package.next_version.semver.to_string()
-                                ));
-                            }
-                        }
-                    }
-                    continue;
-                }
-
-                // Extract package name from node_modules/ key
-                if let Some(package_name) = key.strip_prefix("node_modules/") {
-                    // Check if it's the current package
-                    if current_package.0 == package_name {
-                        package_info["version"] = json!(
-                            current_package.1.next_version.semver.to_string()
-                        );
-                    }
-                    // Check if it's one of the other packages
-                    else if let Some((_, package)) =
-                        other_packages.iter().find(|(n, _)| n == package_name)
-                    {
-                        package_info["version"] =
-                            json!(package.next_version.semver.to_string());
-                    }
-                }
-            }
-        }
-
-        let formatted_json = serde_json::to_string_pretty(&lock_doc)?;
-
-        Ok(Some(FileChange {
-            path: lock_path.display().to_string(),
-            content: formatted_json,
-            update_type: crate::forge::request::FileUpdateType::Replace,
-        }))
-    }
-
-    /// Update package-lock.json file at root path
-    async fn update_package_lock_json_for_root(
-        &self,
-        root_path: &Path,
-        all_packages: &[(String, UpdaterPackage)],
-        loader: &dyn FileLoader,
-    ) -> Result<Option<FileChange>> {
-        let lock_path = root_path.join("package-lock.json");
-        let lock_doc = self.load_doc(lock_path.clone(), loader).await?;
-        if lock_doc.is_none() {
-            return Ok(None);
-        }
-        info!("Updating package-lock.json at {}", lock_path.display());
-        let mut lock_doc = lock_doc.unwrap();
-
-        // Get root package name for later use
-        let root_name = lock_doc
-            .get("name")
-            .and_then(|n| n.as_str())
-            .map(|s| s.to_string());
-
-        // Update root level version if this lock file corresponds to one of
-        // our packages
-        if let Some(ref name) = root_name
-            && let Some((_, package)) =
-                all_packages.iter().find(|(n, _)| n == name)
-        {
-            lock_doc["version"] =
-                json!(package.next_version.semver.to_string());
-        }
-
-        // Update packages section
-        if let Some(packages) = lock_doc.get_mut("packages")
-            && let Some(packages_obj) = packages.as_object_mut()
-        {
-            for (key, package_info) in packages_obj {
-                if key.is_empty() {
-                    // Root package entry - update version if this corresponds
-                    // to one of our packages
-                    if let Some(ref name) = root_name
-                        && let Some((_, package)) =
-                            all_packages.iter().find(|(n, _)| n == name)
-                    {
-                        package_info["version"] =
-                            json!(package.next_version.semver.to_string());
-                    }
-
-                    // Update dependencies within root package entry
-                    if let Some(deps) = package_info.get_mut("dependencies")
-                        && let Some(deps_obj) = deps.as_object_mut()
-                    {
-                        for (dep_name, dep_info) in deps_obj {
-                            if let Some((_, package)) =
-                                all_packages.iter().find(|(n, _)| n == dep_name)
-                            {
-                                *dep_info = json!(format!(
-                                    "^{}",
-                                    package.next_version.semver.to_string()
-                                ));
-                            }
-                        }
-                    }
-
-                    // Update devDependencies within root package entry
-                    if let Some(dev_deps) =
-                        package_info.get_mut("devDependencies")
-                        && let Some(dev_deps_obj) = dev_deps.as_object_mut()
-                    {
-                        for (dep_name, dep_info) in dev_deps_obj {
-                            if let Some((_, package)) =
-                                all_packages.iter().find(|(n, _)| n == dep_name)
-                            {
-                                *dep_info = json!(format!(
-                                    "^{}",
-                                    package.next_version.semver.to_string()
-                                ));
-                            }
-                        }
-                    }
-                    continue;
-                }
-
-                // Extract package name from node_modules/ key
-                if let Some(package_name) = key.strip_prefix("node_modules/")
-                    && let Some((_, package)) =
-                        all_packages.iter().find(|(n, _)| n == package_name)
-                {
-                    package_info["version"] =
-                        json!(package.next_version.semver.to_string());
-                }
-            }
-        }
-
-        let formatted_json = serde_json::to_string_pretty(&lock_doc)?;
-
-        Ok(Some(FileChange {
-            path: lock_path.display().to_string(),
-            content: formatted_json,
-            update_type: crate::forge::request::FileUpdateType::Replace,
-        }))
-    }
-
-    /// Update yarn.lock file for a specific package
-    async fn update_yarn_lock_for_package(
-        &self,
-        current_package: (&str, &UpdaterPackage),
-        other_packages: &[(String, UpdaterPackage)],
-        loader: &dyn FileLoader,
-    ) -> Result<Option<FileChange>> {
-        let lock_path = Path::new(&current_package.1.path).join("yarn.lock");
-        let lock_path = lock_path.display().to_string();
-
-        let content = loader.get_file_content(&lock_path).await?;
-
-        if content.is_none() {
-            return Ok(None);
-        }
-
-        info!("Updating yarn.lock at {lock_path}");
-        let content = content.unwrap();
-        let mut lines: Vec<String> = vec![];
-
-        // Regex to match package entries like "package@^1.0.0:"
-        let package_regex = Regex::new(r#"^"?([^@"]+)@[^"]*"?:$"#)?;
-        let version_regex = Regex::new(r#"^(\s+version\s+)"(.*)""#)?;
-
-        let mut current_yarn_package: Option<String> = None;
-
-        for line in content.lines() {
-            // Check if this line starts a new package entry
-            if let Some(caps) = package_regex.captures(line) {
-                current_yarn_package = Some(caps[1].to_string());
-                lines.push(line.to_string());
-                continue;
-            }
-
-            // Check if this is a version line and we're in a relevant package
-            if let (Some(pkg_name), Some(caps)) =
-                (current_yarn_package.as_ref(), version_regex.captures(line))
-            {
-                // Check if it matches the current package
-                if current_package.0 == pkg_name {
-                    let new_line = format!(
-                        "{}\"{}\"",
-                        &caps[1], current_package.1.next_version.semver
-                    );
-                    lines.push(new_line);
-                    continue;
-                }
-                // Check if it matches one of the other packages
-                else if let Some((_, package)) =
-                    other_packages.iter().find(|(n, _)| n == pkg_name)
-                {
-                    let new_line = format!(
-                        "{}\"{}\"",
-                        &caps[1], package.next_version.semver
-                    );
-                    lines.push(new_line);
-                    continue;
-                }
-            }
-
-            // Reset current package when we hit an empty line or start of
-            // new entry
-            if line.trim().is_empty()
-                || (!line.starts_with(' ')
-                    && !line.starts_with('\t')
-                    && line.contains(':'))
-            {
-                current_yarn_package = None;
-            }
-
-            lines.push(line.to_string());
-        }
-
-        let updated_content = lines.join("\n");
-        Ok(Some(FileChange {
-            path: lock_path,
-            content: updated_content,
-            update_type: FileUpdateType::Replace,
-        }))
-    }
-
-    /// Update yarn.lock file at root path
-    async fn update_yarn_lock_for_root(
-        &self,
-        root_path: &Path,
-        all_packages: &[(String, UpdaterPackage)],
-        loader: &dyn FileLoader,
-    ) -> Result<Option<FileChange>> {
-        let lock_path = root_path.join("yarn.lock");
-        let lock_path = lock_path.display().to_string();
-        let content = loader.get_file_content(&lock_path).await?;
-
-        if content.is_none() {
-            return Ok(None);
-        }
-
-        info!("Updating yarn.lock at {lock_path}");
-
-        let content = content.unwrap();
-        let mut lines: Vec<String> = vec![];
-
-        // Regex to match package entries like "package@^1.0.0:"
-        let package_regex = Regex::new(r#"^"?([^@"]+)@[^"]*"?:$"#)?;
-        let version_regex = Regex::new(r#"^(\s+version\s+)"(.*)""#)?;
-
-        let mut current_yarn_package: Option<String> = None;
-
-        for line in content.lines() {
-            // Check if this line starts a new package entry
-            if let Some(caps) = package_regex.captures(line) {
-                current_yarn_package = Some(caps[1].to_string());
-                lines.push(line.to_string());
-                continue;
-            }
-
-            // Check if this is a version line and we're in a relevant package
-            if let (Some(pkg_name), Some(caps)) =
-                (current_yarn_package.as_ref(), version_regex.captures(line))
-                && let Some((_, package)) =
-                    all_packages.iter().find(|(n, _)| n == pkg_name)
-            {
-                let new_line =
-                    format!("{}\"{}\"", &caps[1], package.next_version.semver);
-                lines.push(new_line);
-                continue;
-            }
-
-            // Reset current package when we hit an empty line or start of new entry
-            if line.trim().is_empty()
-                || (!line.starts_with(' ')
-                    && !line.starts_with('\t')
-                    && line.contains(':'))
-            {
-                current_yarn_package = None;
-            }
-
-            lines.push(line.to_string());
-        }
-
-        let updated_content = lines.join("\n");
-
-        Ok(Some(FileChange {
-            path: lock_path,
-            content: updated_content,
-            update_type: FileUpdateType::Replace,
-        }))
-    }
-
-    /// Update lock files for a specific package
-    async fn update_package_lock_files(
-        &self,
-        current_package: (&str, &UpdaterPackage),
-        other_packages: &[(String, UpdaterPackage)],
-        loader: &dyn FileLoader,
-    ) -> Result<Option<Vec<FileChange>>> {
-        let mut changes: Vec<FileChange> = vec![];
-
-        if let Some(change) = self
-            .update_package_lock_json_for_package(
-                current_package,
-                other_packages,
-                loader,
-            )
-            .await?
-        {
-            changes.push(change);
-        }
-
-        if let Some(change) = self
-            .update_yarn_lock_for_package(
-                current_package,
-                other_packages,
-                loader,
-            )
-            .await?
-        {
-            changes.push(change);
-        }
-
-        if changes.is_empty() {
-            return Ok(None);
-        }
-
-        Ok(Some(changes))
-    }
-
-    /// Update lock files at root path
-    async fn update_root_lock_files(
-        &self,
-        root_path: &Path,
-        all_packages: &[(String, UpdaterPackage)],
-        loader: &dyn FileLoader,
-    ) -> Result<Option<Vec<FileChange>>> {
-        let mut changes: Vec<FileChange> = vec![];
-
-        if let Some(change) = self
-            .update_package_lock_json_for_root(root_path, all_packages, loader)
-            .await?
-        {
-            changes.push(change);
-        }
-
-        if let Some(change) = self
-            .update_yarn_lock_for_root(root_path, all_packages, loader)
-            .await?
-        {
-            changes.push(change);
-        }
-
-        if changes.is_empty() {
-            return Ok(None);
-        }
-
-        Ok(Some(changes))
     }
 }
 
@@ -568,52 +93,28 @@ impl PackageUpdater for NodeUpdater {
         let packages_with_names =
             self.get_packages_with_names(node_packages, loader).await;
 
-        for (package_name, package) in packages_with_names.iter() {
-            let pkg_json = Path::new(&package.path).join("package.json");
-            let pkg_doc = self.load_doc(pkg_json.clone(), loader).await?;
-            if pkg_doc.is_none() {
-                continue;
-            }
-            let mut pkg_doc = pkg_doc.unwrap();
-            pkg_doc["version"] = json!(package.next_version.semver.to_string());
-
-            let other_pkgs = packages_with_names
-                .iter()
-                .filter(|(n, _)| n != package_name)
-                .cloned()
-                .collect::<Vec<(String, UpdaterPackage)>>();
-
-            self.update_deps(&mut pkg_doc, "dependencies", &other_pkgs)?;
-            self.update_deps(&mut pkg_doc, "dev_dependencies", &other_pkgs)?;
-
-            let formatted_json = serde_json::to_string_pretty(&pkg_doc)?;
-
-            file_changes.push(FileChange {
-                path: pkg_json.display().to_string(),
-                content: formatted_json,
-                update_type: FileUpdateType::Replace,
-            });
-
-            // Update lock files in this package directory
-            if let Some(changes) = self
-                .update_package_lock_files(
-                    (package_name, package),
-                    &other_pkgs,
-                    loader,
-                )
-                .await?
-            {
-                file_changes.extend(changes);
-            }
+        // Update package.json files
+        if let Some(changes) = self
+            .package_json
+            .process_packages(&packages_with_names, loader)
+            .await?
+        {
+            file_changes.extend(changes);
         }
 
-        // Update lock files at root path
+        // Update package-lock.json files
         if let Some(changes) = self
-            .update_root_lock_files(
-                Path::new("."),
-                &packages_with_names,
-                loader,
-            )
+            .package_lock
+            .process_packages(&packages_with_names, loader)
+            .await?
+        {
+            file_changes.extend(changes);
+        }
+
+        // Update yarn.lock files
+        if let Some(changes) = self
+            .yarn_lock
+            .process_packages(&packages_with_names, loader)
             .await?
         {
             file_changes.extend(changes);
@@ -632,498 +133,141 @@ mod tests {
     use super::*;
     use crate::analyzer::release::Tag;
     use crate::forge::traits::MockFileLoader;
+    use crate::test_helpers::create_test_updater_package;
     use semver::Version as SemVer;
-
-    fn create_test_package(
-        name: &str,
-        path: &str,
-        next_version: &str,
-    ) -> UpdaterPackage {
-        UpdaterPackage {
-            name: name.to_string(),
-            path: path.to_string(),
-            framework: Framework::Node,
-            next_version: Tag {
-                sha: "test-sha".to_string(),
-                name: format!("v{}", next_version),
-                semver: SemVer::parse(next_version).unwrap(),
-            },
-        }
-    }
-
-    #[tokio::test]
-    async fn test_load_doc() {
-        let updater = NodeUpdater::new();
-        let package_json = r#"{
-  "name": "test-package",
-  "version": "1.0.0"
-}"#;
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("test-package/package.json"))
-            .times(1)
-            .returning(move |_| Ok(Some(package_json.to_string())));
-
-        let result = updater
-            .load_doc("test-package/package.json", &mock_loader)
-            .await
-            .unwrap();
-
-        assert!(result.is_some());
-        let doc = result.unwrap();
-        assert_eq!(doc["name"], "test-package");
-        assert_eq!(doc["version"], "1.0.0");
-    }
-
-    #[tokio::test]
-    async fn test_load_doc_file_not_found() {
-        let updater = NodeUpdater::new();
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("test-package/package.json"))
-            .times(1)
-            .returning(|_| Ok(None));
-
-        let result = updater
-            .load_doc("test-package/package.json", &mock_loader)
-            .await
-            .unwrap();
-
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_update_deps() {
-        let updater = NodeUpdater::new();
-        let mut doc = json!({
-            "name": "test-package",
-            "version": "1.0.0",
-            "dependencies": {
-                "other-package": "^1.0.0",
-                "external-package": "^2.0.0"
-            }
-        });
-
-        let other_packages = vec![(
-            "other-package".to_string(),
-            create_test_package("other-package", "packages/other", "2.0.0"),
-        )];
-
-        updater
-            .update_deps(&mut doc, "dependencies", &other_packages)
-            .unwrap();
-
-        assert_eq!(doc["dependencies"]["other-package"], "2.0.0");
-        assert_eq!(doc["dependencies"]["external-package"], "^2.0.0");
-    }
-
-    #[tokio::test]
-    async fn test_update_deps_skips_workspace() {
-        let updater = NodeUpdater::new();
-        let mut doc = json!({
-            "name": "test-package",
-            "version": "1.0.0",
-            "dependencies": {
-                "other-package": "workspace:*",
-                "another-package": "^1.0.0"
-            }
-        });
-
-        let other_packages = vec![
-            (
-                "other-package".to_string(),
-                create_test_package("other-package", "packages/other", "2.0.0"),
-            ),
-            (
-                "another-package".to_string(),
-                create_test_package(
-                    "another-package",
-                    "packages/another",
-                    "3.0.0",
-                ),
-            ),
-        ];
-
-        updater
-            .update_deps(&mut doc, "dependencies", &other_packages)
-            .unwrap();
-
-        // workspace dependency should not be updated
-        assert_eq!(doc["dependencies"]["other-package"], "workspace:*");
-        // regular dependency should be updated
-        assert_eq!(doc["dependencies"]["another-package"], "3.0.0");
-    }
-
-    #[tokio::test]
-    async fn test_update_package_json() {
-        let updater = NodeUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
-
-        let package_json = r#"{
-  "name": "test-package",
-  "version": "1.0.0",
-  "dependencies": {
-    "other-package": "^1.0.0"
-  }
-}"#;
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/test/package.json"))
-            .times(2) // Called twice: once in get_packages_with_names, once in update
-            .returning(move |_| Ok(Some(package_json.to_string())));
-
-        // Mock for other files (none exist)
-        mock_loader
-            .expect_get_file_content()
-            .returning(|_path| Ok(None));
-
-        let packages = vec![package];
-        let result = updater.update(packages, &mock_loader).await.unwrap();
-
-        assert!(result.is_some());
-        let changes = result.unwrap();
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].path, "packages/test/package.json");
-        assert!(changes[0].content.contains("\"version\": \"2.0.0\""));
-    }
-
-    #[tokio::test]
-    async fn test_update_package_lock_json_for_package() {
-        let updater = NodeUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
-
-        let lock_json = r#"{
-  "name": "test-package",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
-  "packages": {
-    "": {
-      "name": "test-package",
-      "version": "1.0.0"
-    },
-    "node_modules/test-package": {
-      "version": "1.0.0"
-    }
-  }
-}"#;
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/test/package-lock.json"))
-            .times(1)
-            .returning(move |_| Ok(Some(lock_json.to_string())));
-
-        let result = updater
-            .update_package_lock_json_for_package(
-                ("test-package", &package),
-                &[],
-                &mock_loader,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_some());
-        let change = result.unwrap();
-        assert_eq!(change.path, "packages/test/package-lock.json");
-        assert!(change.content.contains("\"version\": \"2.0.0\""));
-    }
-
-    #[tokio::test]
-    async fn test_update_package_lock_json_updates_dependencies() {
-        let updater = NodeUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
-
-        let lock_json = r#"{
-  "name": "test-package",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
-  "packages": {
-    "": {
-      "name": "test-package",
-      "version": "1.0.0",
-      "dependencies": {
-        "other-package": "^1.0.0"
-      }
-    },
-    "node_modules/other-package": {
-      "version": "1.0.0"
-    }
-  }
-}"#;
-
-        let other_packages = vec![(
-            "other-package".to_string(),
-            create_test_package("other-package", "packages/other", "3.0.0"),
-        )];
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/test/package-lock.json"))
-            .times(1)
-            .returning(move |_| Ok(Some(lock_json.to_string())));
-
-        let result = updater
-            .update_package_lock_json_for_package(
-                ("test-package", &package),
-                &other_packages,
-                &mock_loader,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_some());
-        let change = result.unwrap();
-        // Should update the root package version
-        assert!(change.content.contains("\"version\": \"2.0.0\""));
-        // Should update dependency reference
-        assert!(change.content.contains("\"other-package\": \"^3.0.0\""));
-        // Should update node_modules version
-        assert!(change.content.contains("\"version\": \"3.0.0\""));
-    }
-
-    #[tokio::test]
-    async fn test_update_package_lock_json_file_not_found() {
-        let updater = NodeUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/test/package-lock.json"))
-            .times(1)
-            .returning(|_| Ok(None));
-
-        let result = updater
-            .update_package_lock_json_for_package(
-                ("test-package", &package),
-                &[],
-                &mock_loader,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_update_yarn_lock_for_package() {
-        let updater = NodeUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
-
-        let yarn_lock = r#"# THIS IS AN AUTOGENERATED FILE.
-# yarn lockfile v1
-
-"test-package@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/test-package/-/test-package-1.0.0.tgz"
-
-"other-package@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/other-package/-/other-package-1.0.0.tgz"
-"#;
-
-        let other_packages = vec![(
-            "other-package".to_string(),
-            create_test_package("other-package", "packages/other", "3.0.0"),
-        )];
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/test/yarn.lock"))
-            .times(1)
-            .returning(move |_| Ok(Some(yarn_lock.to_string())));
-
-        let result = updater
-            .update_yarn_lock_for_package(
-                ("test-package", &package),
-                &other_packages,
-                &mock_loader,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_some());
-        let change = result.unwrap();
-        assert_eq!(change.path, "packages/test/yarn.lock");
-        assert!(change.content.contains("version \"2.0.0\""));
-        assert!(change.content.contains("version \"3.0.0\""));
-    }
-
-    #[tokio::test]
-    async fn test_update_yarn_lock_file_not_found() {
-        let updater = NodeUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/test/yarn.lock"))
-            .times(1)
-            .returning(|_| Ok(None));
-
-        let result = updater
-            .update_yarn_lock_for_package(
-                ("test-package", &package),
-                &[],
-                &mock_loader,
-            )
-            .await
-            .unwrap();
-
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_update_root_lock_files() {
-        let updater = NodeUpdater::new();
-
-        let lock_json = r#"{
-  "name": "root",
-  "version": "1.0.0",
-  "lockfileVersion": 2,
-  "packages": {
-    "": {
-      "name": "root",
-      "version": "1.0.0"
-    },
-    "node_modules/test-package": {
-      "version": "1.0.0"
-    }
-  }
-}"#;
-
-        let yarn_lock = r#"# yarn lockfile v1
-
-"test-package@^1.0.0":
-  version "1.0.0"
-"#;
-
-        let packages = vec![(
-            "test-package".to_string(),
-            create_test_package("test-package", "packages/test", "2.0.0"),
-        )];
-
-        let mut mock_loader = MockFileLoader::new();
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("./package-lock.json"))
-            .times(1)
-            .returning({
-                let content = lock_json.to_string();
-                move |_| Ok(Some(content.clone()))
-            });
-
-        mock_loader
-            .expect_get_file_content()
-            .with(mockall::predicate::eq("./yarn.lock"))
-            .times(1)
-            .returning({
-                let content = yarn_lock.to_string();
-                move |_| Ok(Some(content.clone()))
-            });
-
-        let result = updater
-            .update_root_lock_files(Path::new("."), &packages, &mock_loader)
-            .await
-            .unwrap();
-
-        assert!(result.is_some());
-        let changes = result.unwrap();
-        assert_eq!(changes.len(), 2);
-
-        // Check package-lock.json was updated
-        assert!(changes.iter().any(|c| c.path == "./package-lock.json"
-            && c.content.contains("\"version\": \"2.0.0\"")));
-
-        // Check yarn.lock was updated
-        assert!(changes.iter().any(|c| c.path == "./yarn.lock"
-            && c.content.contains("version \"2.0.0\"")));
-    }
 
     #[tokio::test]
     async fn test_update_multiple_packages() {
         let updater = NodeUpdater::new();
 
-        let package1_json = r#"{
-  "name": "package-one",
+        let packages = vec![
+            create_test_updater_package(
+                "package-a",
+                "packages/a",
+                "2.0.0",
+                Framework::Node,
+            ),
+            create_test_updater_package(
+                "package-b",
+                "packages/b",
+                "3.0.0",
+                Framework::Node,
+            ),
+        ];
+
+        let package_a_json = r#"{
+  "name": "package-a",
   "version": "1.0.0",
   "dependencies": {
-    "package-two": "^1.0.0"
+    "package-b": "^1.0.0"
   }
 }"#;
 
-        let package2_json = r#"{
-  "name": "package-two",
+        let package_b_json = r#"{
+  "name": "package-b",
   "version": "1.0.0"
 }"#;
 
-        let packages = vec![
-            create_test_package("package-one", "packages/one", "2.0.0"),
-            create_test_package("package-two", "packages/two", "3.0.0"),
-        ];
-
         let mut mock_loader = MockFileLoader::new();
 
-        // Mock for package-one's package.json
+        // Get package names
         mock_loader
             .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/one/package.json"))
-            .times(2) // Called twice: once in get_packages_with_names, once in update
+            .with(mockall::predicate::eq("packages/a/package.json"))
+            .times(1)
             .returning({
-                let content = package1_json.to_string();
+                let content = package_a_json.to_string();
                 move |_| Ok(Some(content.clone()))
             });
 
-        // Mock for package-two's package.json
         mock_loader
             .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/two/package.json"))
-            .times(2)
+            .with(mockall::predicate::eq("packages/b/package.json"))
+            .times(1)
             .returning({
-                let content = package2_json.to_string();
+                let content = package_b_json.to_string();
                 move |_| Ok(Some(content.clone()))
             });
 
-        // Mock for other files (none exist)
+        // Update package.json files
         mock_loader
             .expect_get_file_content()
-            .returning(|_path| Ok(None));
+            .with(mockall::predicate::eq("packages/a/package.json"))
+            .times(1)
+            .returning({
+                let content = package_a_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/b/package.json"))
+            .times(1)
+            .returning({
+                let content = package_b_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        // Check for workspace-level package-lock.json
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("package-lock.json"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Check for package-level package-lock.json files
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/a/package-lock.json"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/b/package-lock.json"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Check for workspace-level yarn.lock
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("yarn.lock"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Check for package-level yarn.lock files
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/a/yarn.lock"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/b/yarn.lock"))
+            .times(1)
+            .returning(|_| Ok(None));
 
         let result = updater.update(packages, &mock_loader).await.unwrap();
 
         assert!(result.is_some());
         let changes = result.unwrap();
-        assert_eq!(changes.len(), 2);
+        assert_eq!(changes.len(), 2); // 2 package.json files
 
-        // Check package-one was updated
-        let pkg1_change = changes
+        // Check package-a was updated
+        let change_a = changes
             .iter()
-            .find(|c| c.path == "packages/one/package.json")
+            .find(|c| c.path == "packages/a/package.json")
             .unwrap();
-        assert!(pkg1_change.content.contains("\"version\": \"2.0.0\""));
-        assert!(pkg1_change.content.contains("\"package-two\": \"3.0.0\""));
+        assert!(change_a.content.contains("\"version\": \"2.0.0\""));
+        assert!(change_a.content.contains("\"package-b\": \"^3.0.0\""));
 
-        // Check package-two was updated
-        let pkg2_change = changes
+        // Check package-b was updated
+        let change_b = changes
             .iter()
-            .find(|c| c.path == "packages/two/package.json")
+            .find(|c| c.path == "packages/b/package.json")
             .unwrap();
-        assert!(pkg2_change.content.contains("\"version\": \"3.0.0\""));
+        assert!(change_b.content.contains("\"version\": \"3.0.0\""));
     }
 
     #[tokio::test]
@@ -1131,122 +275,321 @@ mod tests {
         let updater = NodeUpdater::new();
 
         let packages = vec![
-            create_test_package("node-package", "packages/node", "2.0.0"),
+            create_test_updater_package(
+                "node-package",
+                "packages/node",
+                "2.0.0",
+                Framework::Node,
+            ),
             UpdaterPackage {
-                name: "java-package".to_string(),
-                path: "packages/java".to_string(),
+                name: "java-package".into(),
+                path: "packages/java".into(),
+                workspace_root: ".".into(),
                 framework: Framework::Java,
                 next_version: Tag {
-                    sha: "test-sha".to_string(),
-                    name: "v1.0.0".to_string(),
+                    sha: "test-sha".into(),
+                    name: "v1.0.0".into(),
                     semver: SemVer::parse("1.0.0").unwrap(),
                 },
             },
         ];
 
+        let node_json = r#"{
+  "name": "node-package",
+  "version": "1.0.0"
+}"#;
+
         let mut mock_loader = MockFileLoader::new();
+
+        // Get package names
         mock_loader
             .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/node/package.json"))
+            .times(1)
+            .returning({
+                let content = node_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        // Update package.json
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/node/package.json"))
+            .times(1)
+            .returning({
+                let content = node_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        // Check for workspace-level package-lock.json
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("package-lock.json"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Check for package-level package-lock.json
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/node/package-lock.json"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Check for workspace-level yarn.lock
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("yarn.lock"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Check for package-level yarn.lock
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("packages/node/yarn.lock"))
+            .times(1)
             .returning(|_| Ok(None));
 
         let result = updater.update(packages, &mock_loader).await.unwrap();
 
-        // Should return None when no package.json files are found
-        assert!(result.is_none());
+        assert!(result.is_some());
+        let changes = result.unwrap();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].path, "packages/node/package.json");
     }
 
     #[tokio::test]
     async fn test_get_packages_with_names() {
         let updater = NodeUpdater::new();
 
-        let package1_json = r#"{
-  "name": "custom-name",
+        let packages = vec![
+            create_test_updater_package(
+                "pkg-a",
+                "packages/a",
+                "2.0.0",
+                Framework::Node,
+            ),
+            create_test_updater_package(
+                "pkg-b",
+                "packages/b",
+                "3.0.0",
+                Framework::Node,
+            ),
+        ];
+
+        let package_a_json = r#"{
+  "name": "actual-name-a",
   "version": "1.0.0"
 }"#;
 
-        let packages = vec![
-            create_test_package("package-one", "packages/one", "2.0.0"),
-            create_test_package("package-two", "packages/two", "3.0.0"),
-        ];
+        let package_b_json = r#"{
+  "name": "actual-name-b",
+  "version": "1.0.0"
+}"#;
 
         let mut mock_loader = MockFileLoader::new();
 
-        // First package has a custom name in package.json
         mock_loader
             .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/one/package.json"))
+            .with(mockall::predicate::eq("packages/a/package.json"))
             .times(1)
             .returning({
-                let content = package1_json.to_string();
+                let content = package_a_json.to_string();
                 move |_| Ok(Some(content.clone()))
             });
 
-        // Second package doesn't have package.json
         mock_loader
             .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/two/package.json"))
+            .with(mockall::predicate::eq("packages/b/package.json"))
             .times(1)
-            .returning(|_| Ok(None));
+            .returning({
+                let content = package_b_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
 
         let result = updater
             .get_packages_with_names(packages, &mock_loader)
             .await;
 
         assert_eq!(result.len(), 2);
-        // First package should use name from package.json
-        assert_eq!(result[0].0, "custom-name");
-        // Second package should use package name as fallback
-        assert_eq!(result[1].0, "package-two");
+        assert_eq!(result[0].0, "actual-name-a");
+        assert_eq!(result[1].0, "actual-name-b");
     }
 
     #[tokio::test]
-    async fn test_update_package_lock_json_with_dev_dependencies() {
+    async fn test_update_workspace_lock_files() {
         let updater = NodeUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
 
-        let lock_json = r#"{
-  "name": "test-package",
+        // Create packages with custom workspace_root
+        let mut package_a = create_test_updater_package(
+            "package-a",
+            "packages/a",
+            "2.0.0",
+            Framework::Node,
+        );
+        package_a.workspace_root = "node-workspace".to_string();
+
+        let mut package_b = create_test_updater_package(
+            "package-b",
+            "packages/b",
+            "3.0.0",
+            Framework::Node,
+        );
+        package_b.workspace_root = "node-workspace".to_string();
+
+        let packages = vec![package_a, package_b];
+
+        let package_a_json = r#"{
+  "name": "package-a",
+  "version": "1.0.0",
+  "dependencies": {
+    "package-b": "^1.0.0"
+  }
+}"#;
+
+        let package_b_json = r#"{
+  "name": "package-b",
+  "version": "1.0.0"
+}"#;
+
+        let workspace_lock = r#"{
+  "name": "workspace",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "packages": {
-    "": {
-      "name": "test-package",
-      "version": "1.0.0",
-      "devDependencies": {
-        "other-package": "^1.0.0"
-      }
+    "node_modules/package-a": {
+      "version": "1.0.0"
     },
-    "node_modules/other-package": {
+    "node_modules/package-b": {
       "version": "1.0.0"
     }
   }
 }"#;
 
-        let other_packages = vec![(
-            "other-package".to_string(),
-            create_test_package("other-package", "packages/other", "3.0.0"),
-        )];
-
         let mut mock_loader = MockFileLoader::new();
+
+        // Get package names
         mock_loader
             .expect_get_file_content()
-            .with(mockall::predicate::eq("packages/test/package-lock.json"))
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/a/package.json",
+            ))
             .times(1)
-            .returning(move |_| Ok(Some(lock_json.to_string())));
+            .returning({
+                let content = package_a_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
 
-        let result = updater
-            .update_package_lock_json_for_package(
-                ("test-package", &package),
-                &other_packages,
-                &mock_loader,
-            )
-            .await
-            .unwrap();
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/b/package.json",
+            ))
+            .times(1)
+            .returning({
+                let content = package_b_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        // Update package.json files
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/a/package.json",
+            ))
+            .times(1)
+            .returning({
+                let content = package_a_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/b/package.json",
+            ))
+            .times(1)
+            .returning({
+                let content = package_b_json.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        // Workspace-level package-lock.json
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("node-workspace/package-lock.json"))
+            .times(1)
+            .returning({
+                let content = workspace_lock.to_string();
+                move |_| Ok(Some(content.clone()))
+            });
+
+        // Package-level package-lock.json files (don't exist)
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/a/package-lock.json",
+            ))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/b/package-lock.json",
+            ))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Workspace-level yarn.lock (doesn't exist)
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq("node-workspace/yarn.lock"))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        // Package-level yarn.lock files (don't exist)
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/a/yarn.lock",
+            ))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        mock_loader
+            .expect_get_file_content()
+            .with(mockall::predicate::eq(
+                "node-workspace/packages/b/yarn.lock",
+            ))
+            .times(1)
+            .returning(|_| Ok(None));
+
+        let result = updater.update(packages, &mock_loader).await.unwrap();
 
         assert!(result.is_some());
-        let change = result.unwrap();
-        // Should update devDependency reference
-        assert!(change.content.contains("\"other-package\": \"^3.0.0\""));
+        let changes = result.unwrap();
+
+        // Should have workspace lock + 2 package.json files = 3 changes
+        assert_eq!(changes.len(), 3);
+
+        // Check workspace lock was updated
+        let lock_change = changes
+            .iter()
+            .find(|c| c.path == "node-workspace/package-lock.json")
+            .unwrap();
+        assert!(lock_change.content.contains("\"version\": \"2.0.0\""));
+        assert!(lock_change.content.contains("\"version\": \"3.0.0\""));
+
+        // Check package.json files were updated
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.path == "node-workspace/packages/a/package.json")
+        );
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.path == "node-workspace/packages/b/package.json")
+        );
     }
 }

--- a/src/updater/node/yarn_lock.rs
+++ b/src/updater/node/yarn_lock.rs
@@ -1,0 +1,166 @@
+use log::*;
+use regex::Regex;
+use std::collections::HashSet;
+
+use crate::{
+    forge::{
+        request::{FileChange, FileUpdateType},
+        traits::FileLoader,
+    },
+    result::Result,
+    updater::framework::UpdaterPackage,
+};
+
+/// Handles yarn.lock file parsing and version updates for Node.js packages.
+pub struct YarnLock {}
+
+impl YarnLock {
+    /// Create yarn.lock handler for version updates.
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Update version fields in yarn.lock files for all Node packages.
+    pub async fn process_packages(
+        &self,
+        packages: &[(String, UpdaterPackage)],
+        loader: &dyn FileLoader,
+    ) -> Result<Option<Vec<FileChange>>> {
+        let mut file_changes: Vec<FileChange> = vec![];
+        let mut processed_paths = HashSet::new();
+
+        // First, handle workspace-level yarn.lock files
+        let mut workspace_roots: Vec<&str> = packages
+            .iter()
+            .map(|(_, p)| p.workspace_root.as_str())
+            .collect();
+        workspace_roots.sort_unstable();
+        workspace_roots.dedup();
+
+        for workspace_root in workspace_roots {
+            // Get a package from this workspace to use its helper method
+            let workspace_package = packages
+                .iter()
+                .find(|(_, p)| p.workspace_root == workspace_root)
+                .map(|(_, p)| p);
+
+            if workspace_package.is_none() {
+                continue;
+            }
+
+            let workspace_package = workspace_package.unwrap();
+            let workspace_lock_path =
+                workspace_package.get_workspace_file_path("yarn.lock");
+
+            let workspace_packages: Vec<(String, UpdaterPackage)> = packages
+                .iter()
+                .filter(|(_, p)| p.workspace_root == workspace_root)
+                .cloned()
+                .collect();
+
+            if let Some(change) = self
+                .update_lock_file(
+                    &workspace_lock_path,
+                    &workspace_packages,
+                    loader,
+                )
+                .await?
+            {
+                processed_paths.insert(change.path.clone());
+                file_changes.push(change);
+            }
+        }
+
+        // Then handle package-level yarn.lock files
+        for (package_name, package) in packages.iter() {
+            let path_str = package.get_file_path("yarn.lock");
+
+            // Skip if this path was already processed as a workspace lock file
+            if processed_paths.contains(&path_str) {
+                continue;
+            }
+
+            if let Some(change) = self
+                .update_lock_file(
+                    &path_str,
+                    &[(package_name.clone(), package.clone())],
+                    loader,
+                )
+                .await?
+            {
+                file_changes.push(change);
+            }
+        }
+
+        if file_changes.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(file_changes))
+    }
+
+    /// Update a single yarn.lock file
+    async fn update_lock_file(
+        &self,
+        lock_path: &str,
+        all_packages: &[(String, UpdaterPackage)],
+        loader: &dyn FileLoader,
+    ) -> Result<Option<FileChange>> {
+        let content = loader.get_file_content(lock_path).await?;
+
+        if content.is_none() {
+            return Ok(None);
+        }
+
+        info!("Updating yarn.lock at {lock_path}");
+
+        let content = content.unwrap();
+        let mut lines: Vec<String> = vec![];
+
+        // Regex to match package entries like "package@^1.0.0:"
+        let package_regex = Regex::new(r#"^"?([^@"]+)@[^"]*"?:$"#)?;
+        let version_regex = Regex::new(r#"^(\s+version\s+)"(.*)""#)?;
+
+        let mut current_yarn_package: Option<String> = None;
+
+        for line in content.lines() {
+            // Check if this line starts a new package entry
+            if let Some(caps) = package_regex.captures(line) {
+                current_yarn_package = Some(caps[1].to_string());
+                lines.push(line.to_string());
+                continue;
+            }
+
+            // Check if this is a version line and we're in a relevant package
+            if let (Some(pkg_name), Some(caps)) =
+                (current_yarn_package.as_ref(), version_regex.captures(line))
+                && let Some((_, package)) =
+                    all_packages.iter().find(|(n, _)| n == pkg_name)
+            {
+                let new_line =
+                    format!("{}\"{}\"", &caps[1], package.next_version.semver);
+                lines.push(new_line);
+                continue;
+            }
+
+            // Reset current package when we hit an empty line or start of new entry
+            if line.trim().is_empty()
+                || (!line.starts_with(' ')
+                    && !line.starts_with('\t')
+                    && line.contains(':'))
+            {
+                current_yarn_package = None;
+            }
+
+            lines.push(line.to_string());
+        }
+
+        let updated_content = lines.join("\n");
+
+        Ok(Some(FileChange {
+            path: lock_path.to_string(),
+            content: updated_content,
+            update_type: FileUpdateType::Replace,
+        }))
+    }
+}

--- a/src/updater/python/pyproject.rs
+++ b/src/updater/python/pyproject.rs
@@ -1,5 +1,5 @@
 use log::*;
-use std::path::Path;
+
 use toml_edit::{DocumentMut, value};
 
 use crate::{
@@ -26,7 +26,7 @@ impl PyProject {
         let mut file_changes: Vec<FileChange> = vec![];
 
         for package in packages {
-            let file_path = Path::new(&package.path).join("pyproject.toml");
+            let file_path = package.get_file_path("pyproject.toml");
 
             let doc = self.load_doc(&file_path, loader).await?;
 
@@ -48,15 +48,14 @@ impl PyProject {
 
                 info!(
                     "updating {} project version to {}",
-                    file_path.display(),
-                    package.next_version.semver
+                    file_path, package.next_version.semver
                 );
 
                 project["version"] =
                     value(package.next_version.semver.to_string());
 
                 file_changes.push(FileChange {
-                    path: file_path.display().to_string(),
+                    path: file_path,
                     content: doc.to_string(),
                     update_type: FileUpdateType::Replace,
                 });
@@ -76,15 +75,14 @@ impl PyProject {
 
                 info!(
                     "updating {} tool.poetry version to {}",
-                    file_path.display(),
-                    package.next_version.semver
+                    file_path, package.next_version.semver
                 );
 
                 project["version"] =
                     value(package.next_version.semver.to_string());
 
                 file_changes.push(FileChange {
-                    path: file_path.display().to_string(),
+                    path: file_path,
                     content: doc.to_string(),
                     update_type: FileUpdateType::Replace,
                 });
@@ -100,11 +98,10 @@ impl PyProject {
 
     async fn load_doc(
         &self,
-        file_path: &Path,
+        file_path: &str,
         loader: &dyn FileLoader,
     ) -> Result<Option<DocumentMut>> {
-        let file_path = file_path.display().to_string();
-        let content = loader.get_file_content(&file_path).await?;
+        let content = loader.get_file_content(file_path).await?;
         if content.is_none() {
             return Ok(None);
         }

--- a/src/updater/python/setupcfg.rs
+++ b/src/updater/python/setupcfg.rs
@@ -1,6 +1,6 @@
 use log::*;
 use regex::Regex;
-use std::{path::Path, sync::LazyLock};
+use std::sync::LazyLock;
 
 use crate::{
     forge::{
@@ -30,7 +30,7 @@ impl SetupCfg {
         let mut file_changes: Vec<FileChange> = vec![];
 
         for package in packages {
-            let file_path = Path::new(&package.path).join("setup.cfg");
+            let file_path = package.get_file_path("setup.cfg");
 
             let doc = self.load_doc(&file_path, loader).await?;
 
@@ -49,7 +49,7 @@ impl SetupCfg {
                 VERSION_REGEX.replace(&doc, updated_version).to_string();
 
             file_changes.push(FileChange {
-                path: file_path.display().to_string(),
+                path: file_path,
                 content,
                 update_type: FileUpdateType::Replace,
             });
@@ -64,11 +64,10 @@ impl SetupCfg {
 
     async fn load_doc(
         &self,
-        file_path: &Path,
+        file_path: &str,
         loader: &dyn FileLoader,
     ) -> Result<Option<String>> {
-        let file_path = file_path.display().to_string();
-        let content = loader.get_file_content(&file_path).await?;
+        let content = loader.get_file_content(file_path).await?;
         if content.is_none() {
             return Ok(None);
         }

--- a/src/updater/python/setuppy.rs
+++ b/src/updater/python/setuppy.rs
@@ -1,6 +1,6 @@
 use log::*;
 use regex::Regex;
-use std::{path::Path, sync::LazyLock};
+use std::sync::LazyLock;
 
 use crate::{
     forge::{
@@ -30,7 +30,7 @@ impl SetupPy {
         let mut file_changes: Vec<FileChange> = vec![];
 
         for package in packages {
-            let file_path = Path::new(&package.path).join("setup.py");
+            let file_path = package.get_file_path("setup.py");
 
             let content = self.load_doc(&file_path, loader).await?;
 
@@ -49,7 +49,7 @@ impl SetupPy {
                 VERSION_REGEX.replace(&content, updated_version).to_string();
 
             file_changes.push(FileChange {
-                path: file_path.display().to_string(),
+                path: file_path,
                 content,
                 update_type: FileUpdateType::Replace,
             });
@@ -64,11 +64,10 @@ impl SetupPy {
 
     async fn load_doc(
         &self,
-        file_path: &Path,
+        file_path: &str,
         loader: &dyn FileLoader,
     ) -> Result<Option<String>> {
-        let file_path = file_path.display().to_string();
-        let content = loader.get_file_content(&file_path).await?;
+        let content = loader.get_file_content(file_path).await?;
         if content.is_none() {
             return Ok(None);
         }

--- a/src/updater/python/updater.rs
+++ b/src/updater/python/updater.rs
@@ -51,6 +51,7 @@ impl PackageUpdater for PythonUpdater {
         }
 
         let mut file_changes: Vec<FileChange> = vec![];
+
         if let Some(changes) = self
             .pyproject
             .process_packages(&python_packages, loader)
@@ -88,30 +89,18 @@ mod tests {
     use super::*;
     use crate::analyzer::release::Tag;
     use crate::forge::traits::MockFileLoader;
+    use crate::test_helpers::create_test_updater_package;
     use semver::Version as SemVer;
-
-    fn create_test_package(
-        name: &str,
-        path: &str,
-        next_version: &str,
-    ) -> UpdaterPackage {
-        UpdaterPackage {
-            name: name.to_string(),
-            path: path.to_string(),
-            framework: Framework::Python,
-            next_version: Tag {
-                sha: "test-sha".to_string(),
-                name: format!("v{}", next_version),
-                semver: SemVer::parse(next_version).unwrap(),
-            },
-        }
-    }
 
     #[tokio::test]
     async fn test_update_pyproject_toml_project_section() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.0.0",
+            Framework::Python,
+        );
 
         let pyproject_toml = r#"[project]
 name = "test-package"
@@ -156,8 +145,12 @@ requests = "^2.28.0"
     #[tokio::test]
     async fn test_update_pyproject_toml_poetry_section() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "3.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "3.0.0",
+            Framework::Python,
+        );
 
         let pyproject_toml = r#"[tool.poetry]
 name = "test-package"
@@ -201,8 +194,12 @@ requests = "^2.28.0"
     #[tokio::test]
     async fn test_update_pyproject_toml_skips_dynamic_version() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.0.0",
+            Framework::Python,
+        );
 
         let pyproject_toml = r#"[project]
 name = "test-package"
@@ -239,8 +236,12 @@ description = "A test package with dynamic version"
     #[tokio::test]
     async fn test_update_setup_py() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.0.0",
+            Framework::Python,
+        );
 
         let setup_py = r#"from setuptools import setup, find_packages
 
@@ -285,8 +286,12 @@ setup(
     #[tokio::test]
     async fn test_update_setup_py_with_single_quotes() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "3.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "3.0.0",
+            Framework::Python,
+        );
 
         let setup_py = r#"from setuptools import setup
 
@@ -328,8 +333,12 @@ setup(
     #[tokio::test]
     async fn test_update_setup_cfg() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.0.0",
+            Framework::Python,
+        );
 
         let setup_cfg = r#"[metadata]
 name = test-package
@@ -374,8 +383,12 @@ python_requires = >=3.8
     #[tokio::test]
     async fn test_update_multiple_files_in_one_package() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.0.0",
+            Framework::Python,
+        );
 
         let pyproject_toml = r#"[project]
 name = "test-package"
@@ -443,8 +456,18 @@ version = 1.0.0
     async fn test_update_multiple_packages() {
         let updater = PythonUpdater::new();
         let packages = vec![
-            create_test_package("package-one", "packages/one", "2.0.0"),
-            create_test_package("package-two", "packages/two", "3.0.0"),
+            create_test_updater_package(
+                "package-one",
+                "packages/one",
+                "2.0.0",
+                Framework::Python,
+            ),
+            create_test_updater_package(
+                "package-two",
+                "packages/two",
+                "3.0.0",
+                Framework::Python,
+            ),
         ];
 
         let pyproject1 = r#"[project]
@@ -529,14 +552,20 @@ version = "1.0.0"
         let updater = PythonUpdater::new();
 
         let packages = vec![
-            create_test_package("python-package", "packages/python", "2.0.0"),
+            create_test_updater_package(
+                "python-package",
+                "packages/python",
+                "2.0.0",
+                Framework::Python,
+            ),
             UpdaterPackage {
-                name: "rust-package".to_string(),
-                path: "packages/rust".to_string(),
+                name: "rust-package".into(),
+                path: "packages/rust".into(),
+                workspace_root: ".".into(),
                 framework: Framework::Rust,
                 next_version: Tag {
-                    sha: "test-sha".to_string(),
-                    name: "v1.0.0".to_string(),
+                    sha: "test-sha".into(),
+                    name: "v1.0.0".into(),
                     semver: SemVer::parse("1.0.0").unwrap(),
                 },
             },
@@ -556,8 +585,12 @@ version = "1.0.0"
     #[tokio::test]
     async fn test_update_no_files_found() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.0.0",
+            Framework::Python,
+        );
 
         let mut mock_loader = MockFileLoader::new();
         mock_loader
@@ -573,8 +606,12 @@ version = "1.0.0"
     #[tokio::test]
     async fn test_update_setup_py_with_indentation() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.5.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.5.0",
+            Framework::Python,
+        );
 
         let setup_py = r#"from setuptools import setup
 
@@ -618,8 +655,12 @@ setup(
     #[tokio::test]
     async fn test_pyproject_toml_preserves_structure() {
         let updater = PythonUpdater::new();
-        let package =
-            create_test_package("test-package", "packages/test", "2.0.0");
+        let package = create_test_updater_package(
+            "test-package",
+            "packages/test",
+            "2.0.0",
+            Framework::Python,
+        );
 
         let pyproject_toml = r#"[build-system]
 requires = ["setuptools>=42", "wheel"]


### PR DESCRIPTION
## Description

Allows users to specify a workspace_root for each package to handle workspace configurations that are in subdirectories of the repo root. Defaults to repository root if not specified.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)
