### PR TITLE
feat: adds new options to changelog config

### DIFF
--- a/book/src/basic-configuration.md
+++ b/book/src/basic-configuration.md
@@ -112,6 +112,8 @@ Controls how changelogs are generated and which commits to include:
 skip_ci = false              # Optional: exclude CI commits from changelog
 skip_chore = false           # Optional: exclude chore commits from changelog
 skip_miscellaneous = false   # Optional: exclude non-conventional commits
+skip_merge_commits = true    # Optional: exclude merge commits from changelog
+skip_release_commits = true  # Optional: exclude release commits from changelog
 include_author = false       # Optional: show commit author names
 # body template is available for advanced users
 ```
@@ -121,6 +123,8 @@ include_author = false       # Optional: show commit author names
 - `skip_ci`: Exclude CI/CD commits (e.g., "ci: update workflow")
 - `skip_chore`: Exclude maintenance commits (e.g., "chore: update deps")
 - `skip_miscellaneous`: Exclude commits without conventional type prefixes
+- `skip_merge_commits`: Exclude merge commits (default: true)
+- `skip_release_commits`: Exclude automated release commits (default: true)
 - `include_author`: Add author names to changelog entries
 
 ### `[[package]]` Sections (Required)
@@ -252,6 +256,8 @@ This ensures packages are released when:
 skip_ci = true
 skip_chore = true
 skip_miscellaneous = true
+skip_merge_commits = true
+skip_release_commits = true
 
 [[package]]
 path = "."
@@ -267,6 +273,8 @@ tag_prefix = "v"
 skip_ci = false
 skip_chore = false
 skip_miscellaneous = false
+skip_merge_commits = false
+skip_release_commits = false
 include_author = true
 
 [[package]]
@@ -422,13 +430,15 @@ separate_pull_requests = false
 skip_ci = false
 skip_chore = false
 skip_miscellaneous = false
+skip_merge_commits = true
+skip_release_commits = true
 include_author = false
 body = """# [{{ version  }}]({{ link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | filter(attribute="merge_commit", value=false) | group_by(attribute="group") %}
 ### {{ group | striptags | trim }}
 {% for commit in commits %}
 {% if commit.breaking -%}
-{% if commit.scope %}_({{ commit.scope }})_ {% endif -%}[**breaking**]: {{ commit.message }} [_({{ commit.id | truncate(length=8, end="") }})_]({{ commit.link }})
+{% if commit.scope %}_({{ commit.scope }})_ {% endif -%}[**breaking**]: {{ commit.title }} [_({{ commit.short_id }})_]({{ commit.link }}){% if include_author %} ({{ commit.author_name }}){% endif %}
 {% if commit.body -%}
 > {{ commit.body }}
 {% endif -%}
@@ -436,7 +446,7 @@ body = """# [{{ version  }}]({{ link }}) - {{ timestamp | date(format="%Y-%m-%d"
 > {{ commit.breaking_description }}
 {% endif -%}
 {% else -%}
-- {% if commit.scope %}_({{ commit.scope }})_ {% endif %}{{ commit.message }} [_({{ commit.id | truncate(length=8, end="") }})_]({{ commit.link }})
+- {% if commit.scope %}_({{ commit.scope }})_ {% endif %}{{ commit.title }} [_({{ commit.short_id }})_]({{ commit.link }}){% if include_author %} ({{ commit.author_name }}){% endif %}
 {% endif -%}
 {% endfor %}
 {% endfor %}"""

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -37,6 +37,10 @@ The configuration file uses TOML format with these main sections:
     changelog (optional, default: false)
   - `skip_miscellaneous` - (optional, default: false) Exclude non-conventional
     commits from changelog (optional, default: false)
+  - `skip_merge_commits` - (optional, default: true) Exclude merge commits from
+    changelog
+  - `skip_release_commits` - (optional, default: true) Exclude release commits
+    from changelog
   - `include_author` - (optional, default: false) Include commit author names in
     changelog
 - **`[[package]]`** - Defines packages within the repository with their
@@ -290,6 +294,40 @@ skip_miscellaneous = true  # Exclude commits without a type prefix
 **Example use case**: Use this option to keep your changelog focused on
 conventional commits only, filtering out commits that don't follow the
 `type: description` format.
+
+#### `skip_merge_commits` (Optional)
+
+Excludes merge commits from the changelog. When set to `true`, commits that are
+identified as merge commits will not appear in generated changelogs.
+
+```toml
+[changelog]
+skip_merge_commits = true  # Exclude merge commits like "Merge pull request #123"
+```
+
+**Default**: `true`
+
+**Example use case**: Merge commits often don't provide meaningful information
+in changelogs since the individual commits being merged are typically more
+relevant. However, you may want to set this to `false` if your workflow relies
+on merge commits for tracking feature integration.
+
+#### `skip_release_commits` (Optional)
+
+Excludes release commits from the changelog. When set to `true`, commits that
+match the release commit pattern (e.g., `chore(<default_branch>): release <package-name>`)
+will not appear in generated changelogs.
+
+```toml
+[changelog]
+skip_release_commits = true  # Exclude commits like "chore(main): release my-package v1.2.0"
+```
+
+**Default**: `true`
+
+**Example use case**: Release commits are typically automated commits created by
+Releasaurus itself and don't represent actual changes to your codebase. Keeping
+them out of the changelog reduces noise and focuses on meaningful changes.
 
 #### `include_author` (Optional)
 
@@ -633,9 +671,10 @@ changelog for a release are as follows:
 - **include_author** - Boolean flag indicating if author names should be included
 - **commits**: `List<Commit>` - Array of commit objects with the following fields:
   - **id** - Commit SHA
+  - **short_id** - Short version of commit SHA
   - **group** - Commit category (e.g., "Features", "Bug Fixes", "Chore", "CI/CD")
   - **scope** - Optional scope from conventional commit (e.g., "api", "ui")
-  - **message** - Commit description
+  - **title** - Commit message title without conventional commit type or scope
   - **body** - Optional extended commit body
   - **link** - URL link to the commit
   - **breaking** - Boolean indicating if this is a breaking change
@@ -644,7 +683,8 @@ changelog for a release are as follows:
   - **timestamp** - Unix timestamp of the commit
   - **author_name** - Name of the commit author
   - **author_email** - Email of the commit author
-  - **raw_message** - Original unprocessed commit message
+  - **raw_title** - Original unprocessed commit title
+  - **raw_message** - Original unprocessed full commit message
 
 ### Using the `include_author` Flag in Templates
 

--- a/book/src/quick-start.md
+++ b/book/src/quick-start.md
@@ -170,10 +170,12 @@ options to the `[changelog]` section:
 
 ```toml
 [changelog]
-skip_ci = true              # Exclude CI/CD commits
-skip_chore = true           # Exclude chore/maintenance commits
-skip_miscellaneous = true   # Exclude non-conventional commits
-include_author = true       # Show commit author names
+skip_ci = true                # Exclude CI/CD commits
+skip_chore = true             # Exclude chore/maintenance commits
+skip_miscellaneous = true     # Exclude non-conventional commits
+skip_merge_commits = true     # Exclude merge commits (default: true)
+skip_release_commits = true   # Exclude release commits (default: true)
+include_author = true         # Show commit author names
 
 [[package]]
 path = "."
@@ -185,6 +187,8 @@ These options help you:
 - **`skip_ci`** - Remove CI/CD related commits (e.g., "ci: update workflow")
 - **`skip_chore`** - Remove maintenance commits (e.g., "chore: update deps")
 - **`skip_miscellaneous`** - Remove commits without conventional type prefixes
+- **`skip_merge_commits`** - Remove merge commits (default: true)
+- **`skip_release_commits`** - Remove automated release commits (default: true)
 - **`include_author`** - Add author attribution to each changelog entry
 
 This keeps your changelog focused on user-facing changes. See the

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -74,6 +74,7 @@ impl Analyzer {
             sha: release.sha.clone(),
             name: tag_name,
             semver,
+            timestamp: 0,
         };
 
         release.link =
@@ -136,6 +137,7 @@ impl Analyzer {
             sha: release.sha.clone(),
             name: next_tag_name.clone(),
             semver: next,
+            timestamp: 0,
         };
 
         release.link =
@@ -220,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_new() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config.clone());
 
         assert!(analyzer.is_ok());
@@ -230,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_analyzer_new_with_tag_prefix() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.tag_prefix = Some("v".to_string());
 
         let analyzer = Analyzer::new(config);
@@ -239,7 +241,7 @@ mod tests {
 
     #[test]
     fn test_analyze_empty_commits() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let result = analyzer.analyze(vec![], None).unwrap();
@@ -248,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_analyze_first_release_no_tag() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let commits = vec![
@@ -270,13 +272,14 @@ mod tests {
 
     #[test]
     fn test_analyze_with_current_tag_patch_bump() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let current_tag = release::Tag {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![create_test_forge_commit(
@@ -298,13 +301,14 @@ mod tests {
 
     #[test]
     fn test_analyze_with_current_tag_minor_bump() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let current_tag = release::Tag {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![create_test_forge_commit(
@@ -326,13 +330,14 @@ mod tests {
 
     #[test]
     fn test_analyze_with_current_tag_major_bump() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let current_tag = release::Tag {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![create_test_forge_commit(
@@ -354,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_analyze_with_tag_prefix() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.tag_prefix = Some("v".to_string());
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -374,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_analyze_generates_release_link() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let commits = vec![create_test_forge_commit(
@@ -396,13 +401,14 @@ mod tests {
 
     #[test]
     fn test_analyze_multiple_commits() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let current_tag = release::Tag {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![
@@ -425,7 +431,7 @@ mod tests {
 
     #[test]
     fn test_skip_ci_filters_ci_commits() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_ci = true;
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -433,6 +439,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![
@@ -453,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_skip_ci_false_includes_ci_commits() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_ci = false; // Explicitly set to false
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -472,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_skip_chore_filters_chore_commits() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_chore = true;
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -480,6 +487,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![
@@ -509,7 +517,7 @@ mod tests {
 
     #[test]
     fn test_skip_chore_false_includes_chore_commits() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_chore = false; // Explicitly set to false
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -532,7 +540,7 @@ mod tests {
 
     #[test]
     fn test_skip_miscellaneous_filters_non_conventional_commits() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_miscellaneous = true;
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -540,6 +548,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![
@@ -569,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_skip_miscellaneous_false_includes_non_conventional_commits() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_miscellaneous = false; // Explicitly set to false
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -588,7 +597,7 @@ mod tests {
 
     #[test]
     fn test_skip_multiple_types_combined() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_ci = true;
         config.skip_chore = true;
         config.skip_miscellaneous = true;
@@ -598,6 +607,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![
@@ -632,7 +642,7 @@ mod tests {
 
     #[test]
     fn test_include_author_sets_release_flag() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.include_author = true;
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -652,7 +662,7 @@ mod tests {
 
     #[test]
     fn test_include_author_false_by_default() {
-        let config = create_test_analyzer_config();
+        let config = create_test_analyzer_config(None);
         let analyzer = Analyzer::new(config).unwrap();
 
         let commits = vec![create_test_forge_commit(
@@ -671,7 +681,7 @@ mod tests {
 
     #[test]
     fn test_skip_ci_with_no_ci_commits() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_ci = true;
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -690,7 +700,7 @@ mod tests {
 
     #[test]
     fn test_skip_all_types_results_in_no_release() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_ci = true;
         config.skip_chore = true;
         config.skip_miscellaneous = true;
@@ -711,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_include_author_with_skip_options() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.skip_ci = true;
         config.include_author = true;
         let analyzer = Analyzer::new(config).unwrap();
@@ -733,7 +743,7 @@ mod tests {
 
     #[test]
     fn test_prerelease_start_from_stable() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.prerelease = Some("alpha".to_string());
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -741,6 +751,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![create_test_forge_commit(
@@ -761,7 +772,7 @@ mod tests {
 
     #[test]
     fn test_prerelease_continue_same_identifier() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.prerelease = Some("alpha".to_string());
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -769,6 +780,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.1.0-alpha.1".to_string(),
             semver: SemVer::parse("1.1.0-alpha.1").unwrap(),
+            timestamp: 0,
         };
 
         let commits =
@@ -786,7 +798,7 @@ mod tests {
 
     #[test]
     fn test_prerelease_graduate_to_stable() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.prerelease = None; // No prerelease = graduate
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -794,6 +806,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0-alpha.5".to_string(),
             semver: SemVer::parse("1.0.0-alpha.5").unwrap(),
+            timestamp: 0,
         };
 
         let commits =
@@ -811,7 +824,7 @@ mod tests {
 
     #[test]
     fn test_prerelease_switch_identifier() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.prerelease = Some("beta".to_string());
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -819,6 +832,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0-alpha.3".to_string(),
             semver: SemVer::parse("1.0.0-alpha.3").unwrap(),
+            timestamp: 0,
         };
 
         let commits =
@@ -837,7 +851,7 @@ mod tests {
 
     #[test]
     fn test_prerelease_first_release() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.prerelease = Some("alpha".to_string());
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -856,7 +870,7 @@ mod tests {
 
     #[test]
     fn test_prerelease_breaking_change() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.prerelease = Some("alpha".to_string());
         let analyzer = Analyzer::new(config).unwrap();
 
@@ -864,6 +878,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![create_test_forge_commit(
@@ -885,7 +900,7 @@ mod tests {
 
     #[test]
     fn test_prerelease_with_tag_prefix() {
-        let mut config = create_test_analyzer_config();
+        let mut config = create_test_analyzer_config(None);
         config.prerelease = Some("rc".to_string());
         config.tag_prefix = Some("v".to_string());
         let analyzer = Analyzer::new(config).unwrap();
@@ -894,6 +909,7 @@ mod tests {
             sha: "old123".to_string(),
             name: "v1.0.0".to_string(),
             semver: SemVer::parse("1.0.0").unwrap(),
+            timestamp: 0,
         };
 
         let commits = vec![create_test_forge_commit(

--- a/src/analyzer/group.rs
+++ b/src/analyzer/group.rs
@@ -212,15 +212,17 @@ mod tests {
     fn create_test_commit(raw_message: &str, breaking: bool) -> Commit {
         Commit {
             id: "abc123".to_string(),
+            short_id: "abc".to_string(),
             group: Group::default(),
             scope: None,
-            message: "test message".to_string(),
+            title: "test message".to_string(),
             body: None,
             link: "https://example.com".to_string(),
             breaking,
             breaking_description: None,
             merge_commit: false,
             timestamp: 1640995200,
+            raw_title: "test message".to_string(),
             raw_message: raw_message.to_string(),
             author_name: "".into(),
             author_email: "".into(),

--- a/src/analyzer/helpers.rs
+++ b/src/analyzer/helpers.rs
@@ -28,24 +28,13 @@ pub fn update_release_with_commit(
     if let Some(commit) =
         Commit::parse_forge_commit(group_parser, forge_commit, config)
     {
-        // omit merge commits from release
-        if commit.merge_commit {
-            return;
-        }
-
         let commit_id = commit.id.to_string();
-        let lines = commit
-            .message
-            .split("\n")
-            .map(|l| l.to_string())
-            .collect::<Vec<String>>();
-        let title = lines.first();
 
-        if let Some(t) = title {
-            let short_sha =
-                commit_id.split("").take(8).collect::<Vec<&str>>().join("");
-            info!("processing commit: {} : {}", short_sha, t);
-        }
+        info!(
+            "processing commit: {} : {}",
+            commit.short_id, commit.raw_title
+        );
+
         // add commit to release
         release.commits.push(commit);
         // set release commit - this will keep getting updated until we
@@ -92,12 +81,13 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit() {
-        let analyzer_config = test_helpers::create_test_analyzer_config();
+        let analyzer_config = test_helpers::create_test_analyzer_config(None);
         let group_parser = GroupParser::new();
         let mut release = Release::default();
 
         let forge_commit1 = ForgeCommit {
             id: "commit1".to_string(),
+            short_id: "comm1".to_string(),
             link: "https://example.com/commit/commit1".to_string(),
             author_name: "Author 1".to_string(),
             author_email: "author1@example.com".to_string(),
@@ -109,6 +99,7 @@ mod tests {
 
         let forge_commit2 = ForgeCommit {
             id: "commit2".to_string(),
+            short_id: "comm2".to_string(),
             link: "https://example.com/commit/commit2".to_string(),
             author_name: "Author 2".to_string(),
             author_email: "author2@example.com".to_string(),
@@ -242,13 +233,15 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit_skip_ci() {
-        let mut analyzer_config = test_helpers::create_test_analyzer_config();
+        let mut analyzer_config =
+            test_helpers::create_test_analyzer_config(None);
         analyzer_config.skip_ci = true;
         let group_parser = GroupParser::new();
         let mut release = Release::default();
 
         let ci_commit = ForgeCommit {
             id: "ci123".to_string(),
+            short_id: "ci1".to_string(),
             link: "https://example.com/commit/ci123".to_string(),
             author_name: "CI Bot".to_string(),
             author_email: "ci@example.com".to_string(),
@@ -260,6 +253,7 @@ mod tests {
 
         let feat_commit = ForgeCommit {
             id: "feat123".to_string(),
+            short_id: "feat1".to_string(),
             link: "https://example.com/commit/feat123".to_string(),
             author_name: "Developer".to_string(),
             author_email: "dev@example.com".to_string(),
@@ -289,13 +283,15 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit_skip_chore() {
-        let mut analyzer_config = test_helpers::create_test_analyzer_config();
+        let mut analyzer_config =
+            test_helpers::create_test_analyzer_config(None);
         analyzer_config.skip_chore = true;
         let group_parser = GroupParser::new();
         let mut release = Release::default();
 
         let chore_commit = ForgeCommit {
             id: "chore123".to_string(),
+            short_id: "cho1".to_string(),
             link: "https://example.com/commit/chore123".to_string(),
             author_name: "Maintainer".to_string(),
             author_email: "maint@example.com".to_string(),
@@ -307,6 +303,7 @@ mod tests {
 
         let fix_commit = ForgeCommit {
             id: "fix123".to_string(),
+            short_id: "fi1".to_string(),
             link: "https://example.com/commit/fix123".to_string(),
             author_name: "Developer".to_string(),
             author_email: "dev@example.com".to_string(),
@@ -336,13 +333,15 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit_skip_miscellaneous() {
-        let mut analyzer_config = test_helpers::create_test_analyzer_config();
+        let mut analyzer_config =
+            test_helpers::create_test_analyzer_config(None);
         analyzer_config.skip_miscellaneous = true;
         let group_parser = GroupParser::new();
         let mut release = Release::default();
 
         let misc_commit = ForgeCommit {
             id: "misc123".to_string(),
+            short_id: "mi1".to_string(),
             link: "https://example.com/commit/misc123".to_string(),
             author_name: "Random User".to_string(),
             author_email: "random@example.com".to_string(),
@@ -354,6 +353,7 @@ mod tests {
 
         let feat_commit = ForgeCommit {
             id: "feat123".to_string(),
+            short_id: "fe1".to_string(),
             link: "https://example.com/commit/feat123".to_string(),
             author_name: "Developer".to_string(),
             author_email: "dev@example.com".to_string(),
@@ -383,7 +383,8 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit_skip_multiple_types() {
-        let mut analyzer_config = test_helpers::create_test_analyzer_config();
+        let mut analyzer_config =
+            test_helpers::create_test_analyzer_config(None);
         analyzer_config.skip_ci = true;
         analyzer_config.skip_chore = true;
         analyzer_config.skip_miscellaneous = true;
@@ -393,6 +394,7 @@ mod tests {
         let commits = vec![
             ForgeCommit {
                 id: "ci123".to_string(),
+                short_id: "ci1".to_string(),
                 link: "https://example.com/commit/ci123".to_string(),
                 author_name: "CI Bot".to_string(),
                 author_email: "ci@example.com".to_string(),
@@ -403,6 +405,7 @@ mod tests {
             },
             ForgeCommit {
                 id: "chore123".to_string(),
+                short_id: "ch1".to_string(),
                 link: "https://example.com/commit/chore123".to_string(),
                 author_name: "Maintainer".to_string(),
                 author_email: "maint@example.com".to_string(),
@@ -413,6 +416,7 @@ mod tests {
             },
             ForgeCommit {
                 id: "misc123".to_string(),
+                short_id: "mi1".to_string(),
                 link: "https://example.com/commit/misc123".to_string(),
                 author_name: "Random".to_string(),
                 author_email: "random@example.com".to_string(),
@@ -423,6 +427,7 @@ mod tests {
             },
             ForgeCommit {
                 id: "feat123".to_string(),
+                short_id: "fe1".to_string(),
                 link: "https://example.com/commit/feat123".to_string(),
                 author_name: "Developer".to_string(),
                 author_email: "dev@example.com".to_string(),
@@ -433,6 +438,7 @@ mod tests {
             },
             ForgeCommit {
                 id: "fix123".to_string(),
+                short_id: "fi1".to_string(),
                 link: "https://example.com/commit/fix123".to_string(),
                 author_name: "Developer 2".to_string(),
                 author_email: "dev2@example.com".to_string(),
@@ -460,12 +466,13 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit_preserves_author_info() {
-        let analyzer_config = test_helpers::create_test_analyzer_config();
+        let analyzer_config = test_helpers::create_test_analyzer_config(None);
         let group_parser = GroupParser::new();
         let mut release = Release::default();
 
         let commit_with_author = ForgeCommit {
             id: "author123".to_string(),
+            short_id: "au1".to_string(),
             link: "https://example.com/commit/author123".to_string(),
             author_name: "Jane Smith".to_string(),
             author_email: "jane.smith@example.com".to_string(),
@@ -489,13 +496,15 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit_author_info_with_skip_options() {
-        let mut analyzer_config = test_helpers::create_test_analyzer_config();
+        let mut analyzer_config =
+            test_helpers::create_test_analyzer_config(None);
         analyzer_config.skip_ci = true;
         let group_parser = GroupParser::new();
         let mut release = Release::default();
 
         let ci_commit = ForgeCommit {
             id: "ci123".to_string(),
+            short_id: "ci1".to_string(),
             link: "https://example.com/commit/ci123".to_string(),
             author_name: "CI Bot".to_string(),
             author_email: "ci@example.com".to_string(),
@@ -507,6 +516,7 @@ mod tests {
 
         let feat_commit = ForgeCommit {
             id: "feat123".to_string(),
+            short_id: "fe1".to_string(),
             link: "https://example.com/commit/feat123".to_string(),
             author_name: "John Doe".to_string(),
             author_email: "john.doe@example.com".to_string(),
@@ -537,13 +547,14 @@ mod tests {
 
     #[test]
     fn test_update_release_with_commit_no_skip_includes_all() {
-        let analyzer_config = test_helpers::create_test_analyzer_config();
+        let analyzer_config = test_helpers::create_test_analyzer_config(None);
         let group_parser = GroupParser::new();
         let mut release = Release::default();
 
         let commits = vec![
             ForgeCommit {
                 id: "ci123".to_string(),
+                short_id: "ci1".to_string(),
                 link: "https://example.com/commit/ci123".to_string(),
                 author_name: "CI Bot".to_string(),
                 author_email: "ci@example.com".to_string(),
@@ -554,6 +565,7 @@ mod tests {
             },
             ForgeCommit {
                 id: "chore123".to_string(),
+                short_id: "ch1".to_string(),
                 link: "https://example.com/commit/chore123".to_string(),
                 author_name: "Maintainer".to_string(),
                 author_email: "maint@example.com".to_string(),
@@ -564,6 +576,7 @@ mod tests {
             },
             ForgeCommit {
                 id: "misc123".to_string(),
+                short_id: "mi1".to_string(),
                 link: "https://example.com/commit/misc123".to_string(),
                 author_name: "Random".to_string(),
                 author_email: "random@example.com".to_string(),
@@ -574,6 +587,7 @@ mod tests {
             },
             ForgeCommit {
                 id: "feat123".to_string(),
+                short_id: "fe1".to_string(),
                 link: "https://example.com/commit/feat123".to_string(),
                 author_name: "Developer".to_string(),
                 author_email: "dev@example.com".to_string(),

--- a/src/analyzer/release.rs
+++ b/src/analyzer/release.rs
@@ -15,6 +15,8 @@ pub struct Tag {
     pub name: String,
     /// Semantic version parsed from tag name.
     pub semver: semver::Version,
+    /// Timestamp of tag
+    pub timestamp: i64,
 }
 
 impl Default for Tag {
@@ -23,6 +25,7 @@ impl Default for Tag {
             name: "".into(),
             semver: Version::new(0, 0, 0),
             sha: "".into(),
+            timestamp: 0,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,10 @@ pub struct ChangelogConfig {
     pub skip_chore: bool,
     /// Skips including miscellaneous commits in changelog (default: false)
     pub skip_miscellaneous: bool,
+    /// Skips including merge commits in changelog (default: true)
+    pub skip_merge_commits: bool,
+    /// Skips including release commits in changelog (default: true)
+    pub skip_release_commits: bool,
     /// Includes commit author in default body template (default: false)
     pub include_author: bool,
 }
@@ -33,6 +37,8 @@ impl Default for ChangelogConfig {
             skip_ci: false,
             skip_chore: false,
             skip_miscellaneous: false,
+            skip_merge_commits: true,
+            skip_release_commits: true,
             include_author: false,
         }
     }

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -132,6 +132,7 @@ struct GiteaCommitQueryObject {
 
 #[derive(Debug, Deserialize)]
 struct GiteaTagCommit {
+    pub created: String,
     pub sha: String,
 }
 
@@ -347,6 +348,11 @@ impl Forge for Gitea {
                         name: tag.name,
                         semver: sver,
                         sha: tag.commit.sha,
+                        timestamp: DateTime::parse_from_rfc3339(
+                            &tag.commit.created,
+                        )
+                        .unwrap()
+                        .timestamp(),
                     }));
                 }
             }
@@ -401,6 +407,13 @@ impl Forge for Gitea {
                     author_email: result.commit.author.email.clone(),
                     author_name: result.commit.author.name.clone(),
                     id: result.sha.clone(),
+                    short_id: result
+                        .sha
+                        .clone()
+                        .split("")
+                        .take(8)
+                        .collect::<Vec<&str>>()
+                        .join(""),
                     link: format!(
                         "{}/{}",
                         self.config.commit_link_base_url, result.sha

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -302,6 +302,11 @@ impl Forge for Gitlab {
                         name: t.name,
                         semver: sver,
                         sha: t.commit.id,
+                        timestamp: DateTime::parse_from_rfc3339(
+                            &t.commit.created_at,
+                        )
+                        .unwrap()
+                        .timestamp(),
                     }));
                 }
             }
@@ -372,6 +377,13 @@ impl Forge for Gitlab {
                 author_email: commit.author_email.clone(),
                 author_name: commit.author_name.clone(),
                 id: commit.id.clone(),
+                short_id: commit
+                    .id
+                    .clone()
+                    .split("")
+                    .take(8)
+                    .collect::<Vec<&str>>()
+                    .join(""),
                 link: format!(
                     "{}/{}",
                     self.config.commit_link_base_url, commit.id

--- a/src/forge/request.rs
+++ b/src/forge/request.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use serde::{Deserialize, Serialize};
 
 /// Release pull request information with PR number and merge commit SHA.
@@ -41,9 +43,10 @@ pub struct PrLabelsRequest {
 
 /// Normalized commit data returned from any forge platform with metadata
 /// and links.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq)]
 pub struct ForgeCommit {
     pub id: String,
+    pub short_id: String,
     pub link: String,
     pub author_name: String,
     pub author_email: String,
@@ -51,6 +54,18 @@ pub struct ForgeCommit {
     pub message: String,
     pub timestamp: i64,
     pub files: Vec<String>,
+}
+
+impl PartialEq for ForgeCommit {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Hash for ForgeCommit {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
 }
 
 /// How to apply file content changes during branch creation.

--- a/src/updater/framework.rs
+++ b/src/updater/framework.rs
@@ -454,6 +454,7 @@ mod tests {
                     sha: "test-sha".to_string(),
                     name: "v1.0.0".to_string(),
                     semver: SemVer::parse("1.0.0").unwrap(),
+                    timestamp: 100,
                 }),
                 link: String::new(),
                 sha: "test-sha".to_string(),


### PR DESCRIPTION
## Description

    feat: adds new options to changelog config

    Allows users to configure whether or not merge commits and release
    commits will be included in changelog and version bump logic.

    refactor: refactors how commits are gathered

    When possible we find the package with the oldest tag in time and pull
    all commits from that point. This way we don't need to pull individually
    for each package as we know all other package commits will also be
    included in that set. However, if we encounter a package that hasn't
    been tagged yet, we won't be able to reliably determine a starting point
    (sha), so in this case we fall back to pulling commits individually
    for each package.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Chore

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)

