### PR TITLE
feat: adds out-file option to projected release cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2382,6 +2382,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "tempfile",
  "tera",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,4 @@ reqwest = "0.12.24"
 [dev-dependencies]
 mockall = "0.13.1"
 nanoid = "0.4.0"
+tempfile = "3.23.0"

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -49,6 +49,7 @@ This command provides release information without making any changes:
 - Returns version, commits, notes, and metadata for upcoming releases
 - Outputs machine-readable JSON for automation and CI/CD pipelines
 - Supports filtering to a specific package with `--package`
+- Supports writing output to a file with `--out-file`
 - Returns all releasable packages when no filter is specified
 - Useful for debugging configuration and troubleshooting version detection
   issues
@@ -56,14 +57,20 @@ This command provides release information without making any changes:
 **Usage:**
 
 ```bash
-# Get all projected releases
+# Get all projected releases (prints to stdout)
 releasaurus projected-release --github-repo "https://github.com/owner/repo"
 
 # Get specific package release info
 releasaurus projected-release --package my-pkg --github-repo "https://github.com/owner/repo"
+
+# Write output to a file
+releasaurus projected-release --out-file releases.json --github-repo "https://github.com/owner/repo"
+
+# Combine filter and file output
+releasaurus projected-release --package my-pkg --out-file my-pkg-release.json --github-repo "https://github.com/owner/repo"
 ```
 
-**Output:** JSON object (single package) or array (multiple packages) containing:
+**Output:** JSON array containing releasable packages. Prints to stdout by default, or writes to a file when `--out-file` is specified. Each package includes:
 
 - `name` - Package name
 - `path` - Package path

--- a/book/src/troubleshooting.md
+++ b/book/src/troubleshooting.md
@@ -137,6 +137,9 @@ releasaurus projected-release --github-repo "https://github.com/owner/repo"
 # Inspect specific package
 releasaurus projected-release --package my-pkg --github-repo "https://github.com/owner/repo"
 
+# Save output to file for detailed inspection
+releasaurus projected-release --out-file releases.json --github-repo "https://github.com/owner/repo"
+
 # Test locally without authentication
 releasaurus projected-release --local-repo "."
 ```

--- a/src/command/args.rs
+++ b/src/command/args.rs
@@ -65,8 +65,11 @@ pub enum Command {
 
     /// Returns projected next release info as json
     ProjectedRelease {
+        /// Output projected-release json directly to file
         #[arg(long, short)]
+        out_file: Option<String>,
         /// Optionally restrict output to just 1 specific package
+        #[arg(long, short)]
         package: Option<String>,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,26 +11,18 @@
 //! - Creating release pull requests
 //! - Tagging and Publishing releases to various forge platforms (GitHub, GitLab, Gitea)
 //!
-//! ## Supported Languages & Frameworks
-//!
-//! - **Generic**: No Updates
-//! - **Java**: Maven pom.xml, Gradle build files
-//! - **Node.js**: package.json, package-lock.json, yarn.lock
-//! - **PHP**: composer.json
-//! - **Python**: pyproject.toml, setup.py, setup.cfg
-//! - **Ruby**: gemspec files, version.rb files
-//! - **Rust**: Cargo.toml and Cargo.lock version management
-//!
 //! ## Commands
 //!
 //! - `release-pr`: Create a release preparation pull request
 //! - `release`: Execute the final release process
+//! - `projected-release`: Outputs the entire projected next release object as json
 //!
 //! ## Usage
 //!
 //! ```bash
-//! releasaurus release-pr    # Create a release PR
-//! releasaurus release       # Publish the release
+//! releasaurus release-pr        # Create a release PR
+//! releasaurus release           # Publish the release
+//! releasaurus projected-release # Output projected next release as json
 //! ```
 
 use clap::Parser;
@@ -89,7 +81,9 @@ async fn main() -> Result<()> {
         args.debug = true;
     }
 
-    if matches!(args.command, Command::ProjectedRelease { .. }) {
+    if let Command::ProjectedRelease { out_file, .. } = &args.command
+        && out_file.is_none()
+    {
         silence_logs = true
     }
 
@@ -101,8 +95,8 @@ async fn main() -> Result<()> {
     match args.command {
         Command::ReleasePR => release_pr::execute(&forge_manager).await,
         Command::Release => release::execute(&forge_manager).await,
-        Command::ProjectedRelease { package } => {
-            projected_release::execute(&forge_manager, package).await
+        Command::ProjectedRelease { package, out_file } => {
+            projected_release::execute(&forge_manager, package, out_file).await
         }
     }
 }


### PR DESCRIPTION
## Description

Adds an optional flag, --out-file, to projected-release command that allows users to dump the projected release json directly to file.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)
