### PR TITLE
fix: addresses issue in gitlab forge `get_merged_release_pr`

### DIFF
--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -109,7 +109,10 @@ struct CommitAuthor {
 }
 
 #[derive(Debug, Deserialize)]
-struct GiteaCommitParent {}
+#[allow(unused)]
+struct GiteaCommitParent {
+    pub sha: String,
+}
 
 #[derive(Debug, Deserialize)]
 struct GiteaCommit {
@@ -400,7 +403,8 @@ impl Forge for Gitea {
         let mut since = None;
 
         if let Some(sha) = sha.clone() {
-            let commit_url = self.base_url.join(&format!("commits/{sha}"))?;
+            let commit_url =
+                self.base_url.join(&format!("git/commits/{sha}"))?;
             let request = self.client.get(commit_url).build()?;
             let response = self.client.execute(request).await?;
             let result = response.error_for_status()?;

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -128,6 +128,7 @@ struct FileInfo {
 #[derive(Debug, Deserialize)]
 struct MergeRequestInfo {
     iid: u64,
+    merge_commit_sha: Option<String>,
     sha: String,
     merged_at: Option<String>,
     description: String,
@@ -655,9 +656,14 @@ impl Forge for Gitlab {
             ));
         }
 
+        let sha = merge_request
+            .merge_commit_sha
+            .clone()
+            .unwrap_or(merge_request.sha.clone());
+
         Ok(Some(PullRequest {
             number: merge_request.iid,
-            sha: merge_request.sha.clone(),
+            sha,
             body: merge_request.description.clone(),
         }))
     }


### PR DESCRIPTION
## Description

Previously the gitlab forge implementation for `get_merged_release_pr` was only using `merge_request.sha` which does not represent the actual commit generated upon merge if "merge commit" is used as the merging strategy. This update aligns the gitlab implementation with github and gitea implementations and returns the `merge_request.merge_commit_sha` if present and otherwise using `merge_request.sha` for linear merge strategies. This aligns with release-please implementation and ensures the correct commit is tagged in gitlab.

Additionally a bug was discovered and fixed in the `get_commits` method in the gitea forge implementation.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)
