### PR TITLE
feat: implements "show release" command

### DIFF
--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -82,26 +82,30 @@ releasaurus show next-release --forge local --repo "."
 **Output:** JSON array of releasable packages with version, commits, and
 notes.
 
-#### `show release-notes`
+#### `show release`
 
-Retrieves release notes for an existing tag:
+Retrieves release data for an existing tag, including the tag name, commit SHA, and release notes:
 
 ```bash
 # Display release notes
-releasaurus show release-notes \
+releasaurus show release \
   --tag v1.0.0 \
   --forge github \
   --repo "https://github.com/owner/repo"
 
 # Save to file
-releasaurus show release-notes \
+releasaurus show release \
   --tag v1.0.0 \
-  --out-file notes.txt \
+  --out-file release.json \
   --forge github \
   --repo "https://github.com/owner/repo"
 ```
 
-**Output:** Release notes text for the specified tag.
+**Output:** JSON object containing release data with fields:
+
+- `tag` - The release tag name
+- `sha` - The commit SHA the tag points to
+- `notes` - The release notes content
 
 **Custom Notifications:** Use these commands to build notification scripts
 that announce upcoming releases (pre-release) or published releases

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -338,7 +338,7 @@ mod tests {
             token: Some(token),
             base_branch: None,
             command: Command::Show {
-                command: ShowCommand::ReleaseNotes {
+                command: ShowCommand::Release {
                     out_file: None,
                     tag: "v1.0.0".into(),
                 },

--- a/src/cli/command/show.rs
+++ b/src/cli/command/show.rs
@@ -21,14 +21,14 @@ pub enum ShowCommand {
         #[arg(short, long)]
         package: Option<String>,
     },
-    /// Outputs the release notes associated with a given tag
-    ReleaseNotes {
+    /// Outputs the release data associated with a given tag
+    Release {
         /// Output release notes directly to file
         #[arg(short, long)]
         out_file: Option<String>,
 
         /// Gets release notes associated with specific tag
-        #[arg(short, long, required = true)]
+        #[arg(long, required = true)]
         tag: String,
     },
 }
@@ -49,28 +49,38 @@ pub async fn execute(
             )
             .await
         }
-        ShowCommand::ReleaseNotes { out_file, tag } => {
-            show_release_notes(forge_manager, out_file, tag).await
+        ShowCommand::Release { out_file, tag } => {
+            show_release(forge_manager, out_file, tag).await
         }
     }
 }
 
-async fn show_release_notes(
+async fn show_release(
     forge_manager: &ForgeManager,
     out_file: Option<String>,
     tag: String,
 ) -> Result<()> {
-    info!("retrieving release notes for tag: {tag}");
-    let notes = forge_manager.get_release_notes(&tag).await?;
+    info!("retrieving release data for tag: {tag}");
+    let data = forge_manager.get_release_by_tag(&tag).await?;
+    let json = serde_json::json!(&data);
+
     if let Some(out_file) = out_file {
         let file_path = Path::new(&out_file);
         info!(
-            "writing release notes for tag {tag} to: {}",
+            "writing release data for tag {tag} to: {}",
             file_path.display()
         );
-        fs::write(file_path, &notes).await?;
+
+        if let Some(parent) = file_path.parent()
+            && !parent.exists()
+        {
+            fs::create_dir_all(parent).await?;
+        }
+
+        let content = serde_json::to_string_pretty(&json)?;
+        fs::write(file_path, &content).await?;
     } else {
-        println!("{notes}");
+        println!("{json}");
     }
     Ok(())
 }
@@ -125,7 +135,10 @@ mod tests {
     use crate::{
         analyzer::release::{Release, Tag},
         config::{Config, package::PackageConfig, release_type::ReleaseType},
-        forge::{config::RemoteConfig, traits::MockForge},
+        forge::{
+            config::RemoteConfig, request::ReleaseByTagResponse,
+            traits::MockForge,
+        },
     };
     use semver::Version as SemVer;
 
@@ -136,28 +149,21 @@ mod tests {
     ) -> ReleasablePackage {
         ReleasablePackage {
             name: name.to_string(),
-            path: ".".to_string(),
-            workspace_root: ".".to_string(),
-            manifest_files: None,
-            additional_manifest_files: None,
-            release_type: ReleaseType::Node,
+            workspace_root: ".".into(),
+            path: ".".into(),
             release: Release {
                 tag: Some(Tag {
                     sha: "test-sha".to_string(),
                     name: format!("v{}", version),
                     semver: SemVer::parse(version).unwrap(),
-                    timestamp: None,
+                    ..Tag::default()
                 }),
-                link: format!(
-                    "https://github.com/test/repo/releases/tag/v{}",
-                    version
-                ),
                 sha: "test-sha".to_string(),
-                commits: vec![],
-                include_author: false,
                 notes: format!("## Changes\n\nRelease {}", version),
                 timestamp: 1234567890,
+                ..Release::default()
             },
+            ..ReleasablePackage::default()
         }
     }
 
@@ -188,12 +194,21 @@ mod tests {
         ForgeManager::new(Box::new(mock))
     }
 
-    /// Creates a mock forge manager that returns release notes
-    fn mock_forge_with_release_notes(notes: String) -> ForgeManager {
+    /// Creates a mock forge manager that returns release data
+    fn mock_forge_with_release_data(
+        tag: String,
+        sha: String,
+        notes: String,
+    ) -> ForgeManager {
         let mut mock = MockForge::new();
 
-        mock.expect_get_release_notes()
-            .returning(move |_| Ok(notes.clone()));
+        mock.expect_get_release_by_tag().returning(move |_| {
+            Ok(ReleaseByTagResponse {
+                tag: tag.clone(),
+                sha: sha.clone(),
+                notes: notes.clone(),
+            })
+        });
 
         mock.expect_remote_config().returning(RemoteConfig::default);
 
@@ -321,14 +336,18 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // ===== ReleaseNotes SubCommand Tests =====
+    // ===== Release SubCommand Tests =====
 
     #[tokio::test]
-    async fn release_notes_retrieves_notes_to_stdout() {
+    async fn release_retrieves_data_to_stdout() {
         let notes = "## Release v1.0.0\n\n- Feature added".to_string();
-        let manager = mock_forge_with_release_notes(notes);
+        let manager = mock_forge_with_release_data(
+            "v1.0.0".to_string(),
+            "abc123".to_string(),
+            notes,
+        );
 
-        let cmd = ShowCommand::ReleaseNotes {
+        let cmd = ShowCommand::Release {
             out_file: None,
             tag: "v1.0.0".to_string(),
         };
@@ -338,15 +357,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn release_notes_writes_to_file() {
+    async fn release_writes_to_file() {
         let notes = "## Release v1.0.0\n\n- Feature added".to_string();
-        let manager = mock_forge_with_release_notes(notes.clone());
+        let manager = mock_forge_with_release_data(
+            "v1.0.0".to_string(),
+            "abc123".to_string(),
+            notes.clone(),
+        );
 
         let temp_dir = tempfile::tempdir().unwrap();
-        let out_file = temp_dir.path().join("notes.txt");
+        let out_file = temp_dir.path().join("release.json");
         let out_file_str = out_file.to_str().unwrap().to_string();
 
-        let cmd = ShowCommand::ReleaseNotes {
+        let cmd = ShowCommand::Release {
             out_file: Some(out_file_str),
             tag: "v1.0.0".to_string(),
         };
@@ -357,17 +380,26 @@ mod tests {
         // Verify file was created
         assert!(out_file.exists(), "Output file should be created");
 
-        // Verify file contains the release notes
+        // Verify file contains valid JSON with the release data
         let content = tokio::fs::read_to_string(&out_file).await.unwrap();
-        assert_eq!(content, notes);
+        let json: serde_json::Value = serde_json::from_str(&content)
+            .expect("File should contain valid JSON");
+
+        assert_eq!(json["tag"], "v1.0.0");
+        assert_eq!(json["sha"], "abc123");
+        assert_eq!(json["notes"], notes);
     }
 
     #[tokio::test]
-    async fn release_notes_handles_different_tags() {
+    async fn release_handles_different_tags() {
         let notes = "## Release v2.1.3\n\n- Bug fix".to_string();
-        let manager = mock_forge_with_release_notes(notes);
+        let manager = mock_forge_with_release_data(
+            "v2.1.3".to_string(),
+            "def456".to_string(),
+            notes,
+        );
 
-        let cmd = ShowCommand::ReleaseNotes {
+        let cmd = ShowCommand::Release {
             out_file: None,
             tag: "v2.1.3".to_string(),
         };
@@ -387,7 +419,7 @@ mod tests {
         assert_eq!(json["name"], "test-pkg");
         assert_eq!(json["path"], ".");
         assert_eq!(json["workspace_root"], ".");
-        assert_eq!(json["release_type"], "node");
+        assert_eq!(json["release_type"], "generic");
         assert_eq!(json["release"]["version"], "1.2.3");
         assert_eq!(json["release"]["sha"], "test-sha");
         assert!(

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -10,7 +10,7 @@ use crate::{
 pub type Result<T> = EyreResult<T>;
 
 /// Represents a release-able package in manifest
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ReleasablePackage {
     /// The name of this package
     pub name: String,

--- a/src/forge/local.rs
+++ b/src/forge/local.rs
@@ -19,7 +19,8 @@ use crate::{
         config::RemoteConfig,
         request::{
             Commit, CreateBranchRequest, CreatePrRequest, ForgeCommit,
-            GetPrRequest, PrLabelsRequest, PullRequest, UpdatePrRequest,
+            GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -106,7 +107,10 @@ impl Forge for LocalRepo {
         }
     }
 
-    async fn get_release_notes(&self, _tag: &str) -> Result<String> {
+    async fn get_release_by_tag(
+        &self,
+        _tag: &str,
+    ) -> Result<ReleaseByTagResponse> {
         Err(eyre!("not implemented for local forge"))
     }
 

--- a/src/forge/manager.rs
+++ b/src/forge/manager.rs
@@ -9,7 +9,8 @@ use crate::{
         config::RemoteConfig,
         request::{
             Commit, CreateBranchRequest, CreatePrRequest, ForgeCommit,
-            GetPrRequest, PrLabelsRequest, PullRequest, UpdatePrRequest,
+            GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -52,8 +53,11 @@ impl ForgeManager {
         self.forge.load_config().await
     }
 
-    pub async fn get_release_notes(&self, tag: &str) -> Result<String> {
-        self.forge.get_release_notes(tag).await
+    pub async fn get_release_by_tag(
+        &self,
+        tag: &str,
+    ) -> Result<ReleaseByTagResponse> {
+        self.forge.get_release_by_tag(tag).await
     }
 
     pub async fn load_manifest_targets(

--- a/src/forge/request.rs
+++ b/src/forge/request.rs
@@ -35,6 +35,14 @@ pub struct UpdatePrRequest {
     pub body: String,
 }
 
+/// Response data for retrieving release by tag.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ReleaseByTagResponse {
+    pub tag: String,
+    pub sha: String,
+    pub notes: String,
+}
+
 /// Request to replace all labels on a pull request.
 #[derive(Debug, Clone)]
 pub struct PrLabelsRequest {

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -13,7 +13,8 @@ use crate::{
         config::RemoteConfig,
         request::{
             Commit, CreateBranchRequest, CreatePrRequest, ForgeCommit,
-            GetPrRequest, PrLabelsRequest, PullRequest, UpdatePrRequest,
+            GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            UpdatePrRequest,
         },
     },
 };
@@ -35,7 +36,10 @@ pub trait Forge: Any {
     /// doesn't exist.
     async fn get_file_content(&self, path: &str) -> Result<Option<String>>;
     /// Retrieves the release notes for a specified tag
-    async fn get_release_notes(&self, tag: &str) -> Result<String>;
+    async fn get_release_by_tag(
+        &self,
+        tag: &str,
+    ) -> Result<ReleaseByTagResponse>;
     /// Create a new branch with file changes and return the commit SHA.
     async fn create_release_branch(
         &self,

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
                     silence_logs = true;
                 }
             }
-            ShowCommand::ReleaseNotes { out_file, .. } => {
+            ShowCommand::Release { out_file, .. } => {
                 if out_file.is_none() {
                     silence_logs = true;
                 }


### PR DESCRIPTION
## Description

This replaces the still unreleased "show release-notes" command with a command that returns json data for the targeted release

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)