### PR TITLE
feat: implements start-next feature

### DIFF
--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -39,6 +39,59 @@ This command finalizes the release:
 - Supports prerelease versions (alpha, beta, rc, etc.)
 - Supports dry-run mode for testing
 
+### `start-next`
+
+**Purpose**: Prepare for the next development cycle by bumping patch versions
+
+This command helps maintain a continuous development workflow by automatically
+incrementing patch versions immediately after a release:
+
+- Bumps patch version in manifest files for each package
+- Creates "chore" commits directly on the base branch
+- Does NOT create pull requests or tags
+- Skips packages that haven't been tagged yet
+- Supports filtering to specific packages with `--packages` flag
+- Ensures version numbers are always ahead of the last release
+
+**Usage:**
+
+```bash
+# Start next release cycle for all packages
+releasaurus start-next \
+  --forge github \
+  --repo "https://github.com/owner/repo"
+
+# Target specific packages only
+releasaurus start-next \
+  --forge github \
+  --repo "https://github.com/owner/repo" \
+  --packages pkg-a,pkg-b
+
+# With custom base branch
+releasaurus start-next \
+  --forge github \
+  --repo "https://github.com/owner/repo" \
+  --base-branch develop
+```
+
+**When to use:**
+
+- After merging a release PR and publishing a release
+- To immediately bump versions for the next development cycle
+- To keep manifest versions ahead of released versions
+
+**How it works:**
+
+1. Identifies all packages that have been previously tagged
+2. Analyzes each package's current version from its latest tag
+3. Bumps the patch version (e.g., `1.2.3` → `1.2.4`)
+4. Updates manifest files (package.json, Cargo.toml, etc.)
+5. Creates a chore commit directly on the base branch
+
+**Note:** This command commits directly to your base branch without creating
+a pull request. Make sure you have the appropriate permissions and that your
+branch protection rules allow this operation.
+
 ### `show`
 
 **Purpose**: Query release information without making changes
@@ -129,6 +182,11 @@ releasaurus release-pr \
 
 # Step 3: Publish the release (run from anywhere)
 releasaurus release \
+  --forge github \
+  --repo "https://github.com/owner/repo"
+
+# Step 4 (Optional): Start next development cycle
+releasaurus start-next \
   --forge github \
   --repo "https://github.com/owner/repo"
 ```
@@ -457,8 +515,7 @@ Get help for any command:
 releasaurus --help
 
 # Command-specific help
-releasaurus release-pr --help
-releasaurus release --help
+releasaurus <cmd> --help
 
 # Version information
 releasaurus --version

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -128,6 +128,7 @@ The configuration file uses TOML format with these main sections:
   history depth for initial release analysis
 - **`separate_pull_requests`** - (optional, default: false) Create separate PRs
   for each package in monorepos
+- **`auto_start_next`** - (optional, default: false) Automatically bump patch versions after release
 - **`[prerelease]`** - (optional) Global prerelease configuration
   - `suffix` - (optional) Identifier to append (e.g., `"alpha"`, `"beta"`,
     `"SNAPSHOT"`). Omit or set to `null` to disable prereleases.
@@ -156,6 +157,7 @@ The configuration file uses TOML format with these main sections:
   - `release_type`: (required) The release type for this package, see below for
     options
   - `tag_prefix`: (optional) The tag prefix to use for this package
+  - `auto_start_next`: (optional) Override global auto_start_next setting
   - `prerelease`: (optional) Inline table that overrides global prerelease
     config for this package, e.g. `prerelease = { suffix = "beta",
 strategy = "static" }`
@@ -392,6 +394,30 @@ With this configuration:
 - Teams can merge and release packages independently
 - No need to coordinate releases across all packages
 - Each package maintains its own version history
+
+## Auto Start Next Release
+
+Automatically bumps patch versions after publishing a release. After
+`releasaurus release` completes, manifest files are updated and chore commits
+are pushed for each targeted package directly to the base branch to start the
+next release cycle. No PRs are created and no tagging occurs at this time, only
+manifest version file updates.
+
+```toml
+# Enable globally for all packages
+auto_start_next = true
+
+# Or override per package
+[[package]]
+path = "./packages/core"
+release_type = "rust"
+auto_start_next = false  # Disable for this package
+```
+
+**Default**: `false`
+
+Package-level settings override the global configuration. See
+[`start-next` command](./commands.md#start-next) for more details.
 
 ## Changelog Configuration
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -13,7 +13,7 @@
       "default": null
     },
     "first_release_search_depth": {
-      "description": "Maximum number of commits to search for the first release when no\ntags exist.",
+      "description": "Maximum number of commits to search for the first release when no\ntags exist",
       "type": "integer",
       "format": "uint64",
       "minimum": 0,
@@ -25,12 +25,20 @@
       "default": false
     },
     "prerelease": {
-      "description": "Global prerelease configuration (suffix + strategy). Packages can\noverride this configuration.",
+      "description": "Global prerelease configuration (suffix + strategy). Packages can\noverride this configuration",
       "$ref": "#/$defs/PrereleaseConfig",
       "default": {
         "suffix": null,
         "strategy": "versioned"
       }
+    },
+    "auto_start_next": {
+      "description": "Global config to auto start next release for all packages. Packages\ncan override this configuration",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "default": null
     },
     "breaking_always_increment_major": {
       "description": "Always increments major version on breaking commits",
@@ -85,6 +93,7 @@
           "release_type": null,
           "tag_prefix": null,
           "prerelease": null,
+          "auto_start_next": null,
           "additional_paths": null,
           "additional_manifest_files": null,
           "breaking_always_increment_major": null,
@@ -219,6 +228,14 @@
             {
               "type": "null"
             }
+          ],
+          "default": null
+        },
+        "auto_start_next": {
+          "description": "Auto starts next release for this package by performing a patch version\nupdate to version files and pushing a \"chore\" commit to the base_branch",
+          "type": [
+            "boolean",
+            "null"
           ],
           "default": null
         },

--- a/src/analyzer/commit.rs
+++ b/src/analyzer/commit.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Structured commit with parsed conventional commit fields, author
 /// metadata, and changelog categorization.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct Commit {
     pub id: String,
     pub short_id: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,6 +75,16 @@ pub enum Command {
         #[command(subcommand)]
         command: ShowCommand,
     },
+
+    /// Performs patch version update in manifest version files to start next
+    /// release. This does not create any PRs or perform any tagging. It updates
+    /// the version files and commits the changes to the targeted base branch
+    /// as a "chore" commit
+    StartNext {
+        /// Optional comma separated list of package names to target
+        #[arg(long, value_delimiter(','))]
+        packages: Option<Vec<String>>,
+    },
 }
 
 impl Cli {

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -3,3 +3,4 @@
 pub mod release;
 pub mod release_pr;
 pub mod show;
+pub mod start_next;

--- a/src/cli/command/release_pr.rs
+++ b/src/cli/command/release_pr.rs
@@ -690,7 +690,7 @@ mod tests {
             .returning(|| "main".to_string());
         mock.expect_repo_name().returning(|| "repo".to_string());
         mock.expect_remote_config().returning(RemoteConfig::default);
-        mock.expect_get_file_content().returning(|_, _| Ok(None));
+        mock.expect_get_file_content().returning(|_| Ok(None));
         mock.expect_get_commits().returning(|_, _| {
             let commit = ForgeCommit {
                 id: "abc".into(),
@@ -775,7 +775,7 @@ mod tests {
             .returning(|| "main".to_string());
         mock.expect_repo_name().returning(|| "repo".to_string());
         mock.expect_remote_config().returning(RemoteConfig::default);
-        mock.expect_get_file_content().returning(|_, _| Ok(None));
+        mock.expect_get_file_content().returning(|_| Ok(None));
         mock.expect_get_commits().returning(|_, _| {
             let commit = ForgeCommit {
                 id: "abc".into(),

--- a/src/cli/command/show.rs
+++ b/src/cli/command/show.rs
@@ -1,4 +1,4 @@
-//! Projected release command implementation.
+//! Shows information about prior and upcoming releases
 use clap::Subcommand;
 use log::*;
 use std::path::Path;

--- a/src/cli/command/start_next.rs
+++ b/src/cli/command/start_next.rs
@@ -1,0 +1,331 @@
+//! Starts next release by creating chore commits to bump patch versions in
+//! manifest files for each package
+use log::*;
+
+use crate::{Result, cli::common, forge::manager::ForgeManager};
+
+/// Perform patch version update on manifest files and commit as "chore" to
+/// start the next release cycle
+pub async fn execute(
+    forge_manager: &ForgeManager,
+    targets: Option<Vec<String>>,
+    base_branch_override: Option<String>,
+) -> Result<()> {
+    let repo_name = forge_manager.repo_name();
+
+    let mut config = forge_manager
+        .load_config(base_branch_override.clone())
+        .await?;
+
+    config = common::process_config(&repo_name, &mut config);
+
+    if let Some(targets) = targets {
+        config.packages.retain(|p| targets.contains(&p.name));
+    }
+
+    let mut tagged_packages = vec![];
+
+    for p in config.packages.iter() {
+        let tag_prefix = common::get_tag_prefix(p, &repo_name);
+        let current =
+            forge_manager.get_latest_tag_for_prefix(&tag_prefix).await?;
+        if current.is_none() {
+            warn!(
+                "package {} has not been tagged yet: cannot start-next: skipping",
+                p.name
+            );
+            continue;
+        }
+
+        tagged_packages.push(p.clone());
+    }
+
+    config.packages = tagged_packages;
+
+    let base_branch =
+        common::base_branch(&config, forge_manager, base_branch_override);
+
+    common::start_next_release(&config, forge_manager, &base_branch).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        analyzer::release::Tag,
+        config::{Config, package::PackageConfig, release_type::ReleaseType},
+        forge::{config::RemoteConfig, request::Commit, traits::MockForge},
+    };
+    use semver::Version as SemVer;
+
+    #[tokio::test]
+    async fn succeeds_when_package_has_tag() {
+        let mut mock = MockForge::new();
+
+        mock.expect_load_config().returning(|_| {
+            Ok(Config {
+                packages: vec![PackageConfig {
+                    name: "test-pkg".into(),
+                    path: ".".into(),
+                    release_type: Some(ReleaseType::Node),
+                    ..PackageConfig::default()
+                }],
+                ..Config::default()
+            })
+        });
+
+        mock.expect_repo_name()
+            .returning(|| "test-repo".to_string());
+
+        mock.expect_remote_config().returning(RemoteConfig::default);
+
+        mock.expect_default_branch()
+            .returning(|| "main".to_string());
+
+        mock.expect_get_latest_tag_for_prefix().returning(|_| {
+            Ok(Some(Tag {
+                name: "v1.0.0".into(),
+                semver: SemVer::parse("1.0.0").unwrap(),
+                sha: "abc123".into(),
+                ..Tag::default()
+            }))
+        });
+
+        mock.expect_get_file_content().returning(|_req| Ok(None));
+
+        mock.expect_create_commit().returning(|_req| {
+            Ok(Commit {
+                sha: "new-commit-sha".into(),
+            })
+        });
+
+        let forge_manager = ForgeManager::new(Box::new(mock));
+
+        let result = execute(&forge_manager, None, None).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn skips_packages_without_tags() {
+        let mut mock = MockForge::new();
+
+        mock.expect_load_config().returning(|_| {
+            Ok(Config {
+                packages: vec![PackageConfig {
+                    name: "untagged-pkg".into(),
+                    path: ".".into(),
+                    release_type: Some(ReleaseType::Node),
+                    ..PackageConfig::default()
+                }],
+                ..Config::default()
+            })
+        });
+
+        mock.expect_repo_name()
+            .returning(|| "test-repo".to_string());
+
+        mock.expect_remote_config().returning(RemoteConfig::default);
+
+        mock.expect_default_branch()
+            .returning(|| "main".to_string());
+
+        mock.expect_get_latest_tag_for_prefix()
+            .returning(|_| Ok(None));
+
+        let forge_manager = ForgeManager::new(Box::new(mock));
+
+        execute(&forge_manager, None, None).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn handles_multiple_packages() {
+        let mut mock = MockForge::new();
+
+        mock.expect_load_config().returning(|_| {
+            Ok(Config {
+                packages: vec![
+                    PackageConfig {
+                        name: "pkg-a".into(),
+                        path: "./packages/a".into(),
+                        release_type: Some(ReleaseType::Node),
+                        ..PackageConfig::default()
+                    },
+                    PackageConfig {
+                        name: "pkg-b".into(),
+                        path: "./packages/b".into(),
+                        release_type: Some(ReleaseType::Rust),
+                        ..PackageConfig::default()
+                    },
+                ],
+                ..Config::default()
+            })
+        });
+
+        mock.expect_repo_name()
+            .returning(|| "test-repo".to_string());
+
+        mock.expect_remote_config().returning(RemoteConfig::default);
+
+        mock.expect_default_branch()
+            .returning(|| "main".to_string());
+
+        mock.expect_get_latest_tag_for_prefix().returning(|prefix| {
+            if prefix.contains("pkg-a") {
+                Ok(Some(Tag {
+                    name: "pkg-a-v1.0.0".into(),
+                    semver: SemVer::parse("1.0.0").unwrap(),
+                    sha: "abc123".into(),
+                    ..Tag::default()
+                }))
+            } else {
+                Ok(Some(Tag {
+                    name: "pkg-b-v2.0.0".into(),
+                    semver: SemVer::parse("2.0.0").unwrap(),
+                    sha: "def456".into(),
+                    ..Tag::default()
+                }))
+            }
+        });
+
+        mock.expect_get_file_content().returning(|_req| Ok(None));
+
+        mock.expect_create_commit().returning(|_req| {
+            Ok(Commit {
+                sha: "new-commit-sha".into(),
+            })
+        });
+
+        let forge_manager = ForgeManager::new(Box::new(mock));
+
+        let result = execute(&forge_manager, None, None).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn uses_base_branch_override() {
+        let mut mock = MockForge::new();
+
+        mock.expect_load_config().returning(|branch| {
+            assert_eq!(branch, Some("develop".to_string()));
+            Ok(Config {
+                packages: vec![],
+                ..Config::default()
+            })
+        });
+
+        mock.expect_repo_name()
+            .returning(|| "test-repo".to_string());
+
+        mock.expect_remote_config().returning(RemoteConfig::default);
+
+        mock.expect_default_branch()
+            .times(0)
+            .returning(|| "main".to_string());
+
+        let forge_manager = ForgeManager::new(Box::new(mock));
+
+        let result =
+            execute(&forge_manager, None, Some("develop".into())).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn succeeds_with_empty_package_list() {
+        let mut mock = MockForge::new();
+
+        mock.expect_load_config().returning(|_| {
+            Ok(Config {
+                packages: vec![],
+                ..Config::default()
+            })
+        });
+
+        mock.expect_repo_name()
+            .returning(|| "test-repo".to_string());
+
+        mock.expect_remote_config().returning(RemoteConfig::default);
+
+        mock.expect_default_branch()
+            .returning(|| "main".to_string());
+
+        let forge_manager = ForgeManager::new(Box::new(mock));
+
+        let result = execute(&forge_manager, None, None).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn filters_to_specific_packages() {
+        let mut mock = MockForge::new();
+
+        mock.expect_load_config().returning(|_| {
+            Ok(Config {
+                packages: vec![
+                    PackageConfig {
+                        name: "pkg-a".into(),
+                        path: "./packages/a".into(),
+                        release_type: Some(ReleaseType::Node),
+                        ..PackageConfig::default()
+                    },
+                    PackageConfig {
+                        name: "pkg-b".into(),
+                        path: "./packages/b".into(),
+                        release_type: Some(ReleaseType::Rust),
+                        ..PackageConfig::default()
+                    },
+                ],
+                ..Config::default()
+            })
+        });
+
+        mock.expect_repo_name()
+            .returning(|| "test-repo".to_string());
+
+        mock.expect_remote_config().returning(RemoteConfig::default);
+
+        mock.expect_default_branch()
+            .returning(|| "main".to_string());
+
+        // Only expect calls for pkg-a
+        mock.expect_get_latest_tag_for_prefix()
+            .times(2)
+            .returning(|req| {
+                if req.contains("pkg-a") {
+                    Ok(Some(Tag {
+                        name: "pkg-a-v1.0.0".into(),
+                        semver: SemVer::parse("1.0.0").unwrap(),
+                        sha: "abc123".into(),
+                        ..Tag::default()
+                    }))
+                } else {
+                    Ok(Some(Tag {
+                        name: "pkg-b-v1.0.0".into(),
+                        semver: SemVer::parse("1.0.0").unwrap(),
+                        sha: "def456".into(),
+                        ..Tag::default()
+                    }))
+                }
+            });
+
+        mock.expect_get_file_content().returning(|_| Ok(None));
+
+        mock.expect_create_commit()
+            .times(1)
+            .withf(|req| req.message.contains("chore(main): bump"))
+            .returning(|_| {
+                Ok(Commit {
+                    sha: "new-commit-sha".into(),
+                })
+            });
+
+        let forge_manager = ForgeManager::new(Box::new(mock));
+
+        execute(&forge_manager, Some(vec!["pkg-a".into()]), None)
+            .await
+            .unwrap()
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,13 +25,16 @@ pub struct Config {
     /// defaults to default_branch for repository
     pub base_branch: Option<String>,
     /// Maximum number of commits to search for the first release when no
-    /// tags exist.
+    /// tags exist
     pub first_release_search_depth: u64,
     /// Generates different release PRs for each package defined in config
     pub separate_pull_requests: bool,
     /// Global prerelease configuration (suffix + strategy). Packages can
-    /// override this configuration.
+    /// override this configuration
     pub prerelease: PrereleaseConfig,
+    /// Global config to auto start next release for all packages. Packages
+    /// can override this configuration
+    pub auto_start_next: Option<bool>,
     /// Always increments major version on breaking commits
     pub breaking_always_increment_major: bool,
     /// Always increments minor version on feature commits
@@ -54,6 +57,7 @@ impl Default for Config {
             first_release_search_depth: DEFAULT_COMMIT_SEARCH_DEPTH,
             separate_pull_requests: false,
             prerelease: PrereleaseConfig::default(),
+            auto_start_next: None,
             breaking_always_increment_major: true,
             features_always_increment_minor: true,
             custom_major_increment_regex: None,

--- a/src/config/package.rs
+++ b/src/config/package.rs
@@ -20,6 +20,9 @@ pub struct PackageConfig {
     pub tag_prefix: Option<String>,
     /// Optional prerelease configuration that overrides global settings
     pub prerelease: Option<PrereleaseConfig>,
+    /// Auto starts next release for this package by performing a patch version
+    /// update to version files and pushing a "chore" commit to the base_branch
+    pub auto_start_next: Option<bool>,
     /// Additional directory paths to include commits from
     pub additional_paths: Option<Vec<String>>,
     /// Additional paths generic version manifest files to update. Paths must
@@ -44,6 +47,7 @@ impl Default for PackageConfig {
             release_type: None,
             tag_prefix: None,
             prerelease: None,
+            auto_start_next: None,
             additional_paths: None,
             additional_manifest_files: None,
             breaking_always_increment_major: None,

--- a/src/forge/local.rs
+++ b/src/forge/local.rs
@@ -18,7 +18,8 @@ use crate::{
     forge::{
         config::RemoteConfig,
         request::{
-            Commit, CreatePrRequest, CreateReleaseBranchRequest, ForgeCommit,
+            Commit, CreateCommitRequest, CreatePrRequest,
+            CreateReleaseBranchRequest, ForgeCommit, GetFileContentRequest,
             GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
             UpdatePrRequest,
         },
@@ -88,10 +89,9 @@ impl Forge for LocalRepo {
 
     async fn get_file_content(
         &self,
-        _branch: Option<String>,
-        path: &str,
+        req: GetFileContentRequest,
     ) -> Result<Option<String>> {
-        let full_path = Path::new(&self.repo_path).join(path);
+        let full_path = Path::new(&self.repo_path).join(&req.path);
         if !full_path.exists() {
             return Ok(None);
         }
@@ -100,8 +100,12 @@ impl Forge for LocalRepo {
     }
 
     async fn load_config(&self, branch: Option<String>) -> Result<Config> {
-        if let Some(content) =
-            self.get_file_content(branch, DEFAULT_CONFIG_FILE).await?
+        if let Some(content) = self
+            .get_file_content(GetFileContentRequest {
+                branch,
+                path: DEFAULT_CONFIG_FILE.into(),
+            })
+            .await?
         {
             let config: Config = toml::from_str(&content)?;
             Ok(config)
@@ -282,9 +286,12 @@ impl Forge for LocalRepo {
         req: CreateReleaseBranchRequest,
     ) -> Result<Commit> {
         warn!("local_mode: would create branch: req: {:#?}", req);
-        Ok(Commit {
-            sha: "abc123".into(),
-        })
+        Ok(Commit { sha: "None".into() })
+    }
+
+    async fn create_commit(&self, req: CreateCommitRequest) -> Result<Commit> {
+        warn!("local_mode: would create commit: req: {:#?}", req);
+        Ok(Commit { sha: "None".into() })
     }
 
     async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()> {
@@ -315,7 +322,7 @@ impl Forge for LocalRepo {
         warn!("local_mode: would create release pr: req: {:#?}", req);
         Ok(PullRequest {
             number: 0,
-            sha: "fff".into(),
+            sha: "None".into(),
             body: req.body,
         })
     }

--- a/src/forge/request.rs
+++ b/src/forge/request.rs
@@ -11,6 +11,13 @@ pub struct PullRequest {
     pub body: String,
 }
 
+/// Request to get content for a file path in the remote repo
+#[derive(Debug, Clone, PartialEq)]
+pub struct GetFileContentRequest {
+    pub branch: Option<String>,
+    pub path: String,
+}
+
 /// Request to find a pull request by comparing head and base branch names.
 #[derive(Debug, Clone)]
 pub struct GetPrRequest {
@@ -88,19 +95,24 @@ pub enum FileUpdateType {
 /// File modification for branch creation, supporting updates and new files.
 #[derive(Debug, Clone, Serialize)]
 pub struct FileChange {
-    /// Relative path to the file starting from repo root.
     pub path: String,
-    /// File content to write or prepend.
     pub content: String,
-    /// Whether to replace entire file or prepend to existing content.
     pub update_type: FileUpdateType,
 }
 
-/// Request to create a new branch with file changes and commit message.
+/// Request to create a branch using base_branch as starting point
 #[derive(Debug, Clone)]
 pub struct CreateReleaseBranchRequest {
     pub base_branch: String,
     pub release_branch: String,
+    pub message: String,
+    pub file_changes: Vec<FileChange>,
+}
+
+/// Request to create a new commit on a branch with file changes
+#[derive(Debug, Clone)]
+pub struct CreateCommitRequest {
+    pub target_branch: String,
     pub message: String,
     pub file_changes: Vec<FileChange>,
 }

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -12,7 +12,8 @@ use crate::{
     forge::{
         config::RemoteConfig,
         request::{
-            Commit, CreatePrRequest, CreateReleaseBranchRequest, ForgeCommit,
+            Commit, CreateCommitRequest, CreatePrRequest,
+            CreateReleaseBranchRequest, ForgeCommit, GetFileContentRequest,
             GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
             UpdatePrRequest,
         },
@@ -36,8 +37,7 @@ pub trait Forge: Any {
     /// doesn't exist.
     async fn get_file_content(
         &self,
-        branch: Option<String>,
-        path: &str,
+        req: GetFileContentRequest,
     ) -> Result<Option<String>>;
     /// Retrieves the release notes for a specified tag
     async fn get_release_by_tag(
@@ -49,6 +49,8 @@ pub trait Forge: Any {
         &self,
         req: CreateReleaseBranchRequest,
     ) -> Result<Commit>;
+    /// Creates a commit on a target branch
+    async fn create_commit(&self, req: CreateCommitRequest) -> Result<Commit>;
     /// Create a git tag pointing to a specific commit SHA.
     async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()>;
     /// Find the most recent tag matching the given prefix (e.g., "v" or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@ pub use cli::{
     command::release,
     command::release_pr,
     command::show::{self, ShowCommand},
+    command::start_next,
     types::Result,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@
 use clap::Parser;
 
 use releasaurus::{
-    Cli, Command, Result, ShowCommand, release, release_pr, show,
+    Cli, Command, Result, ShowCommand, release, release_pr, show, start_next,
 };
 
 const DEBUG_ENV_VAR: &str = "RELEASAURUS_DEBUG";
@@ -99,6 +99,9 @@ async fn main() -> Result<()> {
         }
         Command::Show { command } => {
             show::execute(&forge_manager, command, cli.base_branch).await
+        }
+        Command::StartNext { packages } => {
+            start_next::execute(&forge_manager, packages, cli.base_branch).await
         }
     }
 }

--- a/src/updater/java/gradle_properties.rs
+++ b/src/updater/java/gradle_properties.rs
@@ -132,8 +132,6 @@ mod tests {
 
         let result = properties.process_package(&package).unwrap();
 
-        println!("result: {:#?}", result);
-
         assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 1);


### PR DESCRIPTION
## Description

Adds a new command "start-next" that allows users to bump package patch versions in manifest files to mark the start of the next release.

- Bumps patch version in manifest files for each package
- Creates "chore" commits directly on the base branch
- Does not create pull requests or tags
- Skips packages that haven't been tagged yet
- Prevents creating empty commits with no changes

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)
