### PR TITLE
chore: improve unit tests

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -310,28 +310,14 @@ mod tests {
     #[test]
     fn test_analyzer_new() {
         let config = AnalyzerConfig::default();
-        let analyzer = Analyzer::new(config.clone());
-
-        assert!(analyzer.is_ok());
-        let analyzer = analyzer.unwrap();
+        let analyzer = Analyzer::new(config.clone()).unwrap();
         assert_eq!(analyzer.config.tag_prefix, config.tag_prefix);
-    }
-
-    #[test]
-    fn test_analyzer_new_with_tag_prefix() {
-        let config = AnalyzerConfig {
-            tag_prefix: Some("v".to_string()),
-            ..AnalyzerConfig::default()
-        };
-        let analyzer = Analyzer::new(config);
-        assert!(analyzer.is_ok());
     }
 
     #[test]
     fn test_analyze_empty_commits() {
         let config = AnalyzerConfig::default();
         let analyzer = Analyzer::new(config).unwrap();
-
         let result = analyzer.analyze(vec![], None).unwrap();
         assert!(result.is_none());
     }
@@ -358,7 +344,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert!(release.tag.is_some());
         assert_eq!(
@@ -389,7 +374,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert!(release.tag.is_some());
         assert_eq!(
@@ -419,7 +403,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert!(release.tag.is_some());
         assert_eq!(
@@ -449,7 +432,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert!(release.tag.is_some());
         assert_eq!(
@@ -475,9 +457,7 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
-        assert!(release.tag.is_some());
         assert_eq!(release.tag.as_ref().unwrap().name, "v0.1.0");
     }
 
@@ -495,7 +475,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert_eq!(release.commits.len(), 1);
     }
@@ -535,7 +514,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert_eq!(release.commits.len(), 3);
         // Should bump minor due to features
@@ -589,7 +567,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should only have 2 commits (feat and fix), ci commits filtered out
         assert_eq!(release.commits.len(), 2);
@@ -621,7 +598,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should have both commits
         assert_eq!(release.commits.len(), 2);
@@ -671,7 +647,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should only have 2 commits (feat and fix), chore commits filtered out
         assert_eq!(release.commits.len(), 2);
@@ -708,7 +683,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should have both commits
         assert_eq!(release.commits.len(), 2);
@@ -758,7 +732,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should only have 2 commits (feat and fix), miscellaneous filtered out
         assert_eq!(release.commits.len(), 2);
@@ -795,7 +768,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should have both commits
         assert_eq!(release.commits.len(), 2);
@@ -861,7 +833,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should only have 3 commits (feat, fix, docs)
         assert_eq!(release.commits.len(), 3);
@@ -897,7 +868,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should have include_author set to true
         assert!(release.include_author);
@@ -917,7 +887,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should have include_author set to false by default
         assert!(!release.include_author);
@@ -948,7 +917,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should have all commits since none are ci
         assert_eq!(release.commits.len(), 2);
@@ -1019,7 +987,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert_eq!(
             release.tag.unwrap().semver,
@@ -1054,7 +1021,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert_eq!(
             release.tag.unwrap().semver,
@@ -1086,7 +1052,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert_eq!(
             release.tag.unwrap().semver,
@@ -1121,7 +1086,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Should switch to beta and calculate next version
         assert_eq!(
@@ -1150,7 +1114,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, None).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         assert_eq!(
             release.tag.unwrap().semver,
@@ -1185,7 +1148,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         // Breaking change should bump major version
         assert_eq!(
@@ -1221,7 +1183,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         let tag = release.tag.unwrap();
         assert_eq!(tag.semver, SemVer::parse("1.1.0-snapshot").unwrap());
@@ -1255,7 +1216,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         let tag = release.tag.unwrap();
         assert_eq!(tag.semver, SemVer::parse("1.1.0-SNAPSHOT").unwrap());
@@ -1290,7 +1250,6 @@ mod tests {
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
-        assert!(result.is_some());
         let release = result.unwrap();
         let tag = release.tag.unwrap();
         assert_eq!(tag.semver, SemVer::parse("1.1.0-rc.1").unwrap());
@@ -1321,8 +1280,6 @@ mod tests {
         }];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // In 0.x versions with breaking_always_increment_major=false,
@@ -1358,7 +1315,6 @@ mod tests {
         }];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
         let release = result.unwrap();
 
         // Breaking syntax still triggers major bump (custom regex is additive)
@@ -1392,8 +1348,6 @@ mod tests {
         }];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // Custom regex matches "doc" in commit message, bumps major
@@ -1426,8 +1380,6 @@ mod tests {
         }];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // In 0.x versions with features_always_increment_minor=false,
@@ -1461,8 +1413,6 @@ mod tests {
         }];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // Custom regex matches "ci" in commit message, bumps minor
@@ -1495,8 +1445,6 @@ mod tests {
         }];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // Feat syntax still triggers minor bump (custom regex is additive)
@@ -1545,8 +1493,6 @@ mod tests {
         ];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // With both flags disabled, only minor bump
@@ -1589,8 +1535,6 @@ mod tests {
         ];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // With both flags disabled, only patch bump
@@ -1624,8 +1568,6 @@ mod tests {
         }];
 
         let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
-        assert!(result.is_some());
-
         let release = result.unwrap();
 
         // Custom regex matches "wow" and triggers major bump

--- a/src/analyzer/commit.rs
+++ b/src/analyzer/commit.rs
@@ -935,7 +935,6 @@ mod tests {
         );
 
         // Should return Some when skip_ci is false
-        assert!(result.is_some());
         let commit = result.unwrap();
         assert_eq!(commit.group, Group::Ci);
         assert_eq!(commit.title, "update github actions workflow");
@@ -990,7 +989,6 @@ mod tests {
         );
 
         // Should return Some when skip_chore is false
-        assert!(result.is_some());
         let commit = result.unwrap();
         assert_eq!(commit.group, Group::Chore);
         assert_eq!(commit.title, "update dependencies");
@@ -1045,7 +1043,6 @@ mod tests {
         );
 
         // Should return Some when skip_miscellaneous is false
-        assert!(result.is_some());
         let commit = result.unwrap();
         assert_eq!(commit.group, Group::Miscellaneous);
         assert_eq!(commit.title, "random commit message without type");
@@ -1121,7 +1118,6 @@ mod tests {
             &analyzer_config,
         );
 
-        assert!(result.is_some());
         let commit = result.unwrap();
         assert_eq!(commit.author_name, "John Doe");
         assert_eq!(commit.author_email, "john.doe@example.com");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -254,10 +254,7 @@ mod tests {
             command: Command::ReleasePR,
         };
 
-        let result = cli_config.get_remote();
-        assert!(result.is_ok());
-
-        let remote = result.unwrap();
+        let remote = cli_config.get_remote().unwrap();
 
         assert!(matches!(remote, Remote::Github(_)));
     }
@@ -277,10 +274,7 @@ mod tests {
             command: Command::Release,
         };
 
-        let result = cli_config.get_remote();
-        assert!(result.is_ok());
-
-        let remote = result.unwrap();
+        let remote = cli_config.get_remote().unwrap();
 
         assert!(matches!(remote, Remote::Gitlab(_)));
     }
@@ -305,10 +299,7 @@ mod tests {
             },
         };
 
-        let result = cli_config.get_remote();
-        assert!(result.is_ok());
-
-        let remote = result.unwrap();
+        let remote = cli_config.get_remote().unwrap();
 
         assert!(matches!(remote, Remote::Gitea(_)));
     }
@@ -327,10 +318,7 @@ mod tests {
             command: Command::ReleasePR,
         };
 
-        let result = cli_config.get_remote();
-        assert!(result.is_ok());
-
-        let remote = result.unwrap();
+        let remote = cli_config.get_remote().unwrap();
 
         assert!(matches!(remote, Remote::Local(_)));
     }

--- a/src/cli/command/release.rs
+++ b/src/cli/command/release.rs
@@ -221,8 +221,7 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -280,8 +279,7 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -321,8 +319,7 @@ mod tests {
 
         // Should not call tag_commit, create_release, or replace_pr_labels
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -398,8 +395,7 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -440,8 +436,9 @@ mod tests {
             body: "<!--{\"metadata\":{\"name\":\"pkg-a\",\"tag\":\"pkg-a-v1.0.0\",\"notes\":\"Release notes for pkg-a\"}}-->\n<details>\n<!--{\"metadata\":{\"name\":\"pkg-b\",\"tag\":\"pkg-b-v2.0.0\",\"notes\":\"Release notes for pkg-b\"}}-->\n<details>".to_string(),
         };
 
-        let result = create_package_release(&forge_manger, &package, &pr).await;
-        assert!(result.is_ok());
+        create_package_release(&forge_manger, &package, &pr)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -474,8 +471,9 @@ mod tests {
             body: "<!--{\"metadata\":{\"name\":\"my-package\",\"tag\":\"v1.0.0\",\"notes\":\"  Trimmed notes  \\n  \"}}-->\n<details>".to_string(),
         };
 
-        let result = create_package_release(&manager, &package, &pr).await;
-        assert!(result.is_ok());
+        create_package_release(&manager, &package, &pr)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -502,7 +500,6 @@ mod tests {
         };
 
         let result = create_package_release(&manager, &package, &pr).await;
-        assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
@@ -562,7 +559,6 @@ mod tests {
         };
 
         let result = create_package_release(&manager, &package, &pr).await;
-        assert!(result.is_err());
         assert!(
             result
                 .unwrap_err()
@@ -654,8 +650,7 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -766,8 +761,9 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, Some("develop".to_string())).await;
-        assert!(result.is_ok());
+        execute(&manager, Some("develop".to_string()))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -834,8 +830,7 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -909,8 +904,7 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -961,7 +955,6 @@ mod tests {
 
         let manager = ForgeManager::new(Box::new(mock_forge));
 
-        let result = execute(&manager, None).await;
-        assert!(result.is_ok());
+        execute(&manager, None).await.unwrap();
     }
 }

--- a/src/cli/command/release_pr.rs
+++ b/src/cli/command/release_pr.rs
@@ -432,7 +432,6 @@ mod tests {
             .iter()
             .find(|fc| fc.path.contains("CHANGELOG.md"));
 
-        assert!(changelog.is_some());
         assert_eq!(changelog.unwrap().update_type, FileUpdateType::Prepend);
     }
 
@@ -464,7 +463,6 @@ mod tests {
             .iter()
             .find(|fc| fc.path == "VERSION");
 
-        assert!(version_change.is_some());
         assert!(version_change.unwrap().content.contains("2.0.0"));
     }
 
@@ -534,13 +532,13 @@ mod tests {
         mock.expect_replace_pr_labels().returning(|_| Ok(()));
         mock.expect_remote_config().returning(RemoteConfig::default);
 
-        let result = create_branch_release_prs(
+        create_branch_release_prs(
             prs,
             &ForgeManager::new(Box::new(mock)),
             base_branch,
         )
-        .await;
-        assert!(result.is_ok());
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -578,13 +576,13 @@ mod tests {
         mock.expect_replace_pr_labels().returning(|_| Ok(()));
         mock.expect_remote_config().returning(RemoteConfig::default);
 
-        let result = create_branch_release_prs(
+        create_branch_release_prs(
             prs,
             &ForgeManager::new(Box::new(mock)),
             base_branch,
         )
-        .await;
-        assert!(result.is_ok());
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -621,7 +619,6 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_err());
         let err = format!("{}", result.unwrap_err());
         assert!(err.contains("pending release"));
     }
@@ -672,13 +669,13 @@ mod tests {
         mock.expect_replace_pr_labels().returning(|_| Ok(()));
         mock.expect_remote_config().returning(RemoteConfig::default);
 
-        let result = create_branch_release_prs(
+        create_branch_release_prs(
             prs,
             &ForgeManager::new(Box::new(mock)),
             base_branch,
         )
-        .await;
-        assert!(result.is_ok());
+        .await
+        .unwrap();
     }
 
     // ===== get_releasable_packages Tests =====
@@ -859,8 +856,9 @@ mod tests {
             }))
         });
 
-        let result = execute(&ForgeManager::new(Box::new(mock)), None).await;
-        assert!(result.is_ok());
+        execute(&ForgeManager::new(Box::new(mock)), None)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -908,11 +906,11 @@ mod tests {
             });
         mock.expect_replace_pr_labels().returning(|_| Ok(()));
 
-        let result = execute(
+        execute(
             &ForgeManager::new(Box::new(mock)),
             Some("develop".to_string()),
         )
-        .await;
-        assert!(result.is_ok());
+        .await
+        .unwrap();
     }
 }

--- a/src/cli/command/show.rs
+++ b/src/cli/command/show.rs
@@ -241,8 +241,7 @@ mod tests {
             package: None,
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -267,8 +266,7 @@ mod tests {
             package: Some("pkg-a".to_string()),
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -280,8 +278,7 @@ mod tests {
             package: None,
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -297,8 +294,7 @@ mod tests {
             package: None,
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
 
         // Verify file was created
         assert!(out_file.exists(), "Output file should be created");
@@ -334,8 +330,7 @@ mod tests {
             package: Some("pkg-a".to_string()),
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
     }
 
     // ===== Release SubCommand Tests =====
@@ -354,8 +349,7 @@ mod tests {
             tag: "v1.0.0".to_string(),
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -376,8 +370,7 @@ mod tests {
             tag: "v1.0.0".to_string(),
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
 
         // Verify file was created
         assert!(out_file.exists(), "Output file should be created");
@@ -406,8 +399,7 @@ mod tests {
             tag: "v2.1.3".to_string(),
         };
 
-        let result = execute(&manager, cmd, None).await;
-        assert!(result.is_ok());
+        execute(&manager, cmd, None).await.unwrap();
     }
 
     // ===== JSON Serialization Tests =====

--- a/src/cli/command/start_next.rs
+++ b/src/cli/command/start_next.rs
@@ -101,9 +101,7 @@ mod tests {
 
         let forge_manager = ForgeManager::new(Box::new(mock));
 
-        let result = execute(&forge_manager, None, None).await;
-
-        assert!(result.is_ok());
+        execute(&forge_manager, None, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -198,9 +196,7 @@ mod tests {
 
         let forge_manager = ForgeManager::new(Box::new(mock));
 
-        let result = execute(&forge_manager, None, None).await;
-
-        assert!(result.is_ok());
+        execute(&forge_manager, None, None).await.unwrap();
     }
 
     #[tokio::test]
@@ -226,10 +222,9 @@ mod tests {
 
         let forge_manager = ForgeManager::new(Box::new(mock));
 
-        let result =
-            execute(&forge_manager, None, Some("develop".into())).await;
-
-        assert!(result.is_ok());
+        execute(&forge_manager, None, Some("develop".into()))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -253,9 +248,7 @@ mod tests {
 
         let forge_manager = ForgeManager::new(Box::new(mock));
 
-        let result = execute(&forge_manager, None, None).await;
-
-        assert!(result.is_ok());
+        execute(&forge_manager, None, None).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/forge/manager.rs
+++ b/src/forge/manager.rs
@@ -290,7 +290,6 @@ mod tests {
         let result =
             manager.load_manifest_targets(None, targets).await.unwrap();
 
-        assert!(result.is_some());
         let manifests = result.unwrap();
         assert_eq!(manifests.len(), 1);
         assert_eq!(manifests[0].basename, "package.json");
@@ -331,9 +330,7 @@ mod tests {
             });
 
         let manager = ForgeManager::new(Box::new(mock_forge));
-        let result = manager.tag_commit("v1.0.0", "abc123").await;
-
-        assert!(result.is_ok());
+        manager.tag_commit("v1.0.0", "abc123").await.unwrap();
     }
 
     #[tokio::test]
@@ -375,9 +372,7 @@ mod tests {
             title: "Updated title".to_string(),
             body: "Updated body".to_string(),
         };
-        let result = manager.update_pr(req).await;
-
-        assert!(result.is_ok());
+        manager.update_pr(req).await.unwrap();
     }
 
     #[tokio::test]
@@ -395,9 +390,7 @@ mod tests {
             pr_number: 42,
             labels: vec!["release".to_string()],
         };
-        let result = manager.replace_pr_labels(req).await;
-
-        assert!(result.is_ok());
+        manager.replace_pr_labels(req).await.unwrap();
     }
 
     #[tokio::test]
@@ -411,10 +404,9 @@ mod tests {
             });
 
         let manager = ForgeManager::new(Box::new(mock_forge));
-        let result = manager
+        manager
             .create_release("v1.0.0", "abc123", "Release notes")
-            .await;
-
-        assert!(result.is_ok());
+            .await
+            .unwrap();
     }
 }

--- a/src/updater/generic/updater.rs
+++ b/src/updater/generic/updater.rs
@@ -86,7 +86,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         let change = result.unwrap();
         assert_eq!(change.content, r#"version = "2.0.0""#);
         assert_eq!(change.path, "test.txt");
@@ -99,7 +98,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         assert!(result.unwrap().content.contains("'2.0.0'"));
     }
 
@@ -110,7 +108,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         assert_eq!(result.unwrap().content, r#""version": "2.0.0""#);
     }
 
@@ -121,7 +118,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         assert_eq!(result.unwrap().content, "version   =   \"2.0.0\"");
     }
 
@@ -132,7 +128,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         assert!(result.unwrap().content.contains("2.0.0-beta.2"));
     }
 
@@ -145,7 +140,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         let content = result.unwrap().content;
         assert!(content.contains("version = \"2.0.0\""));
         assert!(content.contains("name = \"my-package\""));
@@ -179,7 +173,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         assert!(result.unwrap().content.contains("2.0.0"));
     }
 
@@ -192,7 +185,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         let content = result.unwrap().content;
         assert!(content.contains("version: \"2.5.3\""));
         assert!(content.contains("metadata:"));
@@ -208,7 +200,6 @@ mod tests {
 
         let result = GenericUpdater::update_manifest(&manifest, &next_version);
 
-        assert!(result.is_some());
         let content = result.unwrap().content;
         assert!(content.contains("const Version = \"3.2.1\""));
         assert!(content.contains("package main"));

--- a/src/updater/java/gradle.rs
+++ b/src/updater/java/gradle.rs
@@ -73,7 +73,6 @@ mod tests {
 
         let result = gradle.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let change = result.unwrap();
         assert_eq!(change.len(), 1);
         assert_eq!(change[0].content, r#"version = "2.0.0""#);
@@ -103,7 +102,6 @@ mod tests {
 
         let result = gradle.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let change = result.unwrap();
         assert_eq!(change.len(), 1);
         assert_eq!(change[0].content, "version = '2.0.0'");
@@ -133,7 +131,6 @@ mod tests {
 
         let result = gradle.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let change = result.unwrap();
         assert_eq!(change.len(), 1);
         assert_eq!(change[0].content, r#"version = "3.5.0""#);
@@ -163,7 +160,6 @@ mod tests {
 
         let result = gradle.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let change = result.unwrap();
         assert_eq!(change.len(), 1);
         assert_eq!(change[0].content, r#"project.version = "4.0.0""#);
@@ -225,7 +221,6 @@ mod tests {
 
         let result = gradle.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));
@@ -281,7 +276,6 @@ mod tests {
 
         let result = gradle.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let change = result.unwrap();
         assert_eq!(change.len(), 1);
         assert_eq!(change[0].content, "version   =   \"2.0.0\"");

--- a/src/updater/java/gradle_properties.rs
+++ b/src/updater/java/gradle_properties.rs
@@ -72,7 +72,6 @@ mod tests {
 
         let result = properties.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].content, "version=2.0.0");
@@ -102,7 +101,6 @@ mod tests {
 
         let result = properties.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].content, "version  =  3.0.0");
@@ -132,7 +130,6 @@ mod tests {
 
         let result = properties.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].content, "  version=2.5.0");
@@ -163,7 +160,6 @@ mod tests {
 
         let result = properties.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 1);
         let updated = changes[0].content.clone();
@@ -229,7 +225,6 @@ mod tests {
 
         let result = properties.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));
@@ -285,7 +280,6 @@ mod tests {
 
         let result = properties.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 1);
 

--- a/src/updater/java/maven.rs
+++ b/src/updater/java/maven.rs
@@ -144,7 +144,6 @@ mod tests {
 
         let result = maven.update_pom_file(&manifest, &package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap().content;
         assert!(updated.contains("<version>2.0.0</version>"));
     }
@@ -185,7 +184,6 @@ mod tests {
 
         let result = maven.update_pom_file(&manifest, &package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap().content;
         assert!(updated.contains("<groupId>com.example</groupId>"));
         assert!(updated.contains("<artifactId>my-app</artifactId>"));
@@ -226,7 +224,6 @@ mod tests {
 
         let result = maven.update_pom_file(&manifest, &package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap().content;
         assert!(updated.contains("<version>3.0.0</version>"));
         assert!(updated.contains("<version>4.12</version>"));
@@ -265,7 +262,6 @@ mod tests {
 
         let result = maven.update_pom_file(&manifest, &package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap().content;
         assert!(updated.contains("<version>2.5.0</version>"));
         assert!(updated.contains("<modelVersion>4.0.0</modelVersion>"));
@@ -303,7 +299,6 @@ mod tests {
 
         let result = maven.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));
@@ -367,7 +362,6 @@ mod tests {
 
         let result = maven.update_pom_file(&manifest, &package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap().content;
         assert!(updated.contains("<version>3.0.0</version>"));
         assert!(updated.contains("<version>5.0.0</version>"));

--- a/src/updater/java/updater.rs
+++ b/src/updater/java/updater.rs
@@ -98,7 +98,6 @@ mod tests {
 
         let result = updater.update(&package, vec![]).unwrap();
 
-        assert!(result.is_some());
         assert!(result.unwrap()[0].content.contains("2.0.0"));
     }
 

--- a/src/updater/node/package_json.rs
+++ b/src/updater/node/package_json.rs
@@ -136,7 +136,6 @@ mod tests {
 
         let result = package_json.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
     }
@@ -184,7 +183,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"package-b\": \"^3.0.0\""));
     }
@@ -232,7 +230,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"package-b\": \"^3.0.0\""));
     }
@@ -280,7 +277,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"package-b\": \"workspace:^1.0.0\""));
     }
@@ -328,7 +324,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"package-b\": \"repo:^1.0.0\""));
     }
@@ -377,7 +372,6 @@ mod tests {
             .process_package(&package_root, &[package_root.clone(), package_a])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"package-a\": \"^1.0.0\""));
     }
@@ -412,7 +406,6 @@ mod tests {
 
         let result = package_json.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));
@@ -476,7 +469,6 @@ mod tests {
 
         let result = package_json.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
         assert!(updated.contains("\"description\": \"A test package\""));

--- a/src/updater/node/package_lock.rs
+++ b/src/updater/node/package_lock.rs
@@ -169,7 +169,6 @@ mod tests {
 
         let result = package_lock.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
     }
@@ -207,7 +206,6 @@ mod tests {
 
         let result = package_lock.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
         // Should appear twice: once at root, once in packages[""]
@@ -263,7 +261,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"package-b\": \"3.0.0\""));
     }
@@ -317,7 +314,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"package-b\": \"3.0.0\""));
     }
@@ -371,7 +367,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         let parsed: Value = serde_json::from_str(&updated).unwrap();
         assert_eq!(
@@ -413,7 +408,6 @@ mod tests {
 
         let result = package_lock.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
     }
@@ -449,7 +443,6 @@ mod tests {
 
         let result = package_lock.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));
@@ -516,7 +509,6 @@ mod tests {
 
         let result = package_lock.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
         assert!(updated.contains("\"lockfileVersion\": 2"));

--- a/src/updater/node/updater.rs
+++ b/src/updater/node/updater.rs
@@ -99,7 +99,6 @@ mod tests {
 
         let result = updater.update(&package, vec![]).unwrap();
 
-        assert!(result.is_some());
         assert!(result.unwrap()[0].content.contains("2.0.0"));
     }
 

--- a/src/updater/node/yarn_lock.rs
+++ b/src/updater/node/yarn_lock.rs
@@ -137,7 +137,6 @@ mod tests {
             .process_package(&package_a, slice::from_ref(&package_a))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version \"2.0.0\""));
     }
@@ -188,7 +187,6 @@ mod tests {
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version \"2.0.0\""));
         assert!(updated.contains("version \"3.0.0\""));
@@ -229,7 +227,6 @@ mod tests {
             .process_package(&package_a, slice::from_ref(&package_a))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version \"2.0.0\""));
         assert!(updated.contains("version \"5.0.0\""));
@@ -266,7 +263,6 @@ package-a@^1.0.0:
             .process_package(&package_a, slice::from_ref(&package_a))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version \"2.0.0\""));
     }
@@ -303,7 +299,6 @@ package-a@^1.0.0:
             .process_package(&package_a, slice::from_ref(&package_a))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("  version \"2.0.0\""));
         assert!(updated.contains("  resolved"));
@@ -341,7 +336,6 @@ package-a@^1.0.0:
             .process_package(&package, slice::from_ref(&package))
             .unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));
@@ -442,7 +436,6 @@ package-a@^1.0.0:
             .process_package(&package_a, slice::from_ref(&package_a))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         // Both entries should be updated to 2.0.0
         assert_eq!(updated.matches("version \"2.0.0\"").count(), 2);

--- a/src/updater/php/composer_json.rs
+++ b/src/updater/php/composer_json.rs
@@ -106,7 +106,6 @@ mod tests {
 
         let result = composer_json.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
     }
@@ -136,7 +135,6 @@ mod tests {
 
         let result = composer_json.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
         assert!(updated.contains("\"description\": \"A test package\""));
@@ -174,7 +172,6 @@ mod tests {
 
         let result = composer_json.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("\"version\": \"2.0.0\""));
         assert!(updated.contains("\"name\": \"vendor/package\""));
@@ -214,7 +211,6 @@ mod tests {
 
         let result = composer_json.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));

--- a/src/updater/php/updater.rs
+++ b/src/updater/php/updater.rs
@@ -65,7 +65,6 @@ mod tests {
 
         let result = updater.update(&package, vec![]).unwrap();
 
-        assert!(result.is_some());
         assert!(result.unwrap()[0].content.contains("2.0.0"));
     }
 

--- a/src/updater/python/pyproject.rs
+++ b/src/updater/python/pyproject.rs
@@ -128,7 +128,6 @@ version = "1.0.0"
 
         let result = pyproject.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
     }
@@ -160,7 +159,6 @@ version = "1.0.0"
 
         let result = pyproject.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
     }
@@ -259,7 +257,6 @@ requests = "^2.28.0"
 
         let result = pyproject.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
         assert!(updated.contains("description = \"A test package\""));
@@ -327,7 +324,6 @@ requires = ["setuptools", "wheel"]
 
         let result = pyproject.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));

--- a/src/updater/python/setupcfg.rs
+++ b/src/updater/python/setupcfg.rs
@@ -71,7 +71,6 @@ mod tests {
 
         let result = setupcfg.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = 2.0.0"));
     }
@@ -100,7 +99,6 @@ mod tests {
 
         let result = setupcfg.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
     }
@@ -129,7 +127,6 @@ mod tests {
 
         let result = setupcfg.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = '2.0.0'"));
     }
@@ -158,7 +155,6 @@ mod tests {
 
         let result = setupcfg.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version   =   2.0.0"));
     }
@@ -197,7 +193,6 @@ install_requires =
 
         let result = setupcfg.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = 2.0.0"));
         assert!(updated.contains("name = my-package"));
@@ -236,7 +231,6 @@ install_requires =
 
         let result = setupcfg.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));

--- a/src/updater/python/setuppy.rs
+++ b/src/updater/python/setuppy.rs
@@ -72,7 +72,6 @@ mod tests {
 
         let result = setuppy.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version=\"2.0.0\""));
     }
@@ -102,7 +101,6 @@ mod tests {
 
         let result = setuppy.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version='2.0.0'"));
     }
@@ -132,7 +130,6 @@ mod tests {
 
         let result = setuppy.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version   =   \"2.0.0\""));
     }
@@ -173,7 +170,6 @@ setup(
 
         let result = setuppy.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version=\"2.0.0\""));
         assert!(updated.contains("name='my-package'"));
@@ -214,7 +210,6 @@ setup(
 
         let result = setuppy.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));

--- a/src/updater/python/updater.rs
+++ b/src/updater/python/updater.rs
@@ -90,7 +90,6 @@ version = "1.0.0"
 
         let result = updater.update(&package, vec![]).unwrap();
 
-        assert!(result.is_some());
         assert!(result.unwrap()[0].content.contains("2.0.0"));
     }
 

--- a/src/updater/ruby/gemspec.rs
+++ b/src/updater/ruby/gemspec.rs
@@ -87,7 +87,6 @@ end
 
         let result = gemspec.process_packages(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("spec.version = \"2.0.0\""));
     }
@@ -120,7 +119,6 @@ end
 
         let result = gemspec.process_packages(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("s.version = \"2.0.0\""));
     }
@@ -153,7 +151,6 @@ end
 
         let result = gemspec.process_packages(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("spec.version = '2.0.0'"));
     }
@@ -185,7 +182,6 @@ end
 
         let result = gemspec.process_packages(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("spec.version   =   \"2.0.0\""));
     }
@@ -223,7 +219,6 @@ end
 
         let result = gemspec.process_packages(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("spec.version = \"2.0.0\""));
         assert!(updated.contains("spec.name = \"my-gem\""));
@@ -261,7 +256,6 @@ end
 
         let result = gemspec.process_packages(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));

--- a/src/updater/ruby/updater.rs
+++ b/src/updater/ruby/updater.rs
@@ -88,7 +88,6 @@ end
 
         let result = updater.update(&package, vec![]).unwrap();
 
-        assert!(result.is_some());
         assert!(result.unwrap()[0].content.contains("2.0.0"));
     }
 

--- a/src/updater/ruby/version_rb.rs
+++ b/src/updater/ruby/version_rb.rs
@@ -77,7 +77,6 @@ end
 
         let result = version_rb.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("VERSION = \"2.0.0\""));
     }
@@ -109,7 +108,6 @@ end
 
         let result = version_rb.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("VERSION = '2.0.0'"));
     }
@@ -141,7 +139,6 @@ end
 
         let result = version_rb.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("VERSION   =   \"2.0.0\""));
     }
@@ -210,7 +207,6 @@ end
 
         let result = version_rb.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("VERSION = \"2.0.0\""));
         assert!(updated.contains("# frozen_string_literal: true"));
@@ -248,7 +244,6 @@ end
 
         let result = version_rb.process_package(&package).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));

--- a/src/updater/rust/cargo_lock.rs
+++ b/src/updater/rust/cargo_lock.rs
@@ -121,7 +121,6 @@ version = "1.0.0"
             .process_package(&package, slice::from_ref(&package))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
     }
@@ -172,7 +171,6 @@ version = "1.0.0"
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
         assert!(updated.contains("version = \"3.0.0\""));
@@ -213,7 +211,6 @@ version = "5.0.0"
             .process_package(&package, slice::from_ref(&package))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
         assert!(updated.contains("version = \"5.0.0\""));
@@ -259,7 +256,6 @@ checksum = "abc123"
             .process_package(&package, slice::from_ref(&package))
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
         assert!(updated.contains("dependencies = ["));
@@ -330,7 +326,6 @@ checksum = "abc123"
             .process_package(&package, slice::from_ref(&package))
             .unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));
@@ -416,7 +411,6 @@ version = "5.0.0"
             )
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         // Main package should be updated to 3.0.0
         assert!(updated.contains("name = \"main-package\""));

--- a/src/updater/rust/cargo_toml.rs
+++ b/src/updater/rust/cargo_toml.rs
@@ -171,7 +171,6 @@ version = "1.0.0"
 
         let result = cargo_toml.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
     }
@@ -219,7 +218,6 @@ package-b = "1.0.0"
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("package-b = \"3.0.0\""));
     }
@@ -267,7 +265,6 @@ package-b = { version = "1.0.0", features = ["serde"] }
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"3.0.0\""));
         assert!(updated.contains("features = [\"serde\"]"));
@@ -316,7 +313,6 @@ package-b = "1.0.0"
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("package-b = \"3.0.0\""));
     }
@@ -364,7 +360,6 @@ package-b = "1.0.0"
             .process_package(&package_a, &[package_a.clone(), package_b])
             .unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("package-b = \"3.0.0\""));
     }
@@ -430,7 +425,6 @@ serde = "1.0"
 
         let result = cargo_toml.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let updated = result.unwrap()[0].content.clone();
         assert!(updated.contains("version = \"2.0.0\""));
         assert!(updated.contains("edition = \"2021\""));
@@ -469,7 +463,6 @@ serde = "1.0"
 
         let result = cargo_toml.process_package(&package, &[]).unwrap();
 
-        assert!(result.is_some());
         let changes = result.unwrap();
         assert_eq!(changes.len(), 2);
         assert!(changes.iter().all(|c| c.content.contains("2.0.0")));

--- a/src/updater/rust/updater.rs
+++ b/src/updater/rust/updater.rs
@@ -92,7 +92,6 @@ version = "1.0.0"
 
         let result = updater.update(&package, vec![]).unwrap();
 
-        assert!(result.is_some());
         assert!(result.unwrap()[0].content.contains("2.0.0"));
     }
 


### PR DESCRIPTION
## Description

Removes assertions that check "is_ok()" or "is_some()" and instead calls "unwrap()" directly in the test. This makes it easier to debug tests as the full error will now be displayed when a test fails

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Chore: test updates

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)

