### PR TITLE
refactor: introduces FileLoader trait

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -124,23 +124,18 @@ pub async fn get_releasable_packages_for_commits(
             let release_type =
                 package.release_type.unwrap_or(ReleaseType::Generic);
 
-            let release_manifest_targets =
-                UpdateManager::release_type_manifest_targets(package);
+            let manifest_files = UpdateManager::load_manifests_for_package(
+                package,
+                forge_manager,
+                Some(base_branch.into()),
+            )
+            .await?;
 
-            let additional_manifest_targets =
-                UpdateManager::additional_manifest_targets(package);
-
-            let manifest_files = forge_manager
-                .load_manifest_targets(
+            let additional_manifest_files =
+                UpdateManager::load_additional_manifests_for_package(
+                    package,
+                    forge_manager,
                     Some(base_branch.into()),
-                    release_manifest_targets,
-                )
-                .await?;
-
-            let additional_manifest_files = forge_manager
-                .load_manifest_targets(
-                    Some(base_branch.into()),
-                    additional_manifest_targets,
                 )
                 .await?;
 

--- a/src/file_loader.rs
+++ b/src/file_loader.rs
@@ -1,0 +1,35 @@
+//! File loading abstraction for manifest content retrieval.
+//!
+//! Provides a trait for loading file content from various sources (forge APIs,
+//! local filesystem, test mocks, etc.) without coupling updaters to specific
+//! implementations.
+
+use async_trait::async_trait;
+
+use crate::Result;
+
+/// Abstraction for loading file content from a source.
+///
+/// This trait allows updaters to load manifest files without depending on
+/// specific forge implementations. It can be implemented by ForgeManager,
+/// local filesystem adapters, test mocks, or any other file source.
+#[async_trait]
+pub trait FileLoader: Send + Sync {
+    /// Load the content of a file from the source.
+    ///
+    /// # Arguments
+    ///
+    /// * `branch` - Optional branch name to load the file from
+    /// * `path` - Path to the file relative to the repository root
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(String))` - File was found and content loaded successfully
+    /// * `Ok(None)` - File does not exist at the specified path
+    /// * `Err(_)` - An error occurred while attempting to load the file
+    async fn load_file(
+        &self,
+        branch: Option<String>,
+        path: String,
+    ) -> Result<Option<String>>;
+}

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -21,7 +21,7 @@ use crate::{
 /// access, PR management, tagging, and release publishing.
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait Forge: Any {
+pub trait Forge: Any + Send + Sync {
     /// whether or not the forge is in dry_run mode
     fn dry_run(&self) -> bool;
     /// Get repository name from configuration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod analyzer;
 mod cli;
 pub mod config;
 mod error;
+mod file_loader;
 mod forge;
 mod path_helpers;
 mod updater;


### PR DESCRIPTION
## Description

This improves separation of concerns around loading manifest targets for version updates. Previously we had to go back and forth between the UpdateManager and the ForgeManager. Now, by introducting a FileLoader trait, we can keep all manifest loading and updating logic confined to the UpdateManager

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Refactor

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)
