### PR TITLE
feat: adds skip_shas and reword features

### DIFF
--- a/action/gitea/action.yml
+++ b/action/gitea/action.yml
@@ -13,12 +13,12 @@ outputs: {}
 runs:
   using: "composite"
   steps:
-    - uses: robgonnella/releasaurus/action/gitea/release@v0.8.0
+    - uses: robgonnella/releasaurus/action/gitea/release@v0.9.0
       with:
         repo: ${{ inputs.repo }}
         token: ${{ inputs.token }}
         debug: ${{ inputs.debug }}
-    - uses: robgonnella/releasaurus/action/gitea/release-pr@v0.8.0
+    - uses: robgonnella/releasaurus/action/gitea/release-pr@v0.9.0
       with:
         repo: ${{ inputs.repo }}
         token: ${{ inputs.token }}

--- a/action/gitea/release-pr/action.yml
+++ b/action/gitea/release-pr/action.yml
@@ -12,7 +12,7 @@ inputs:
 outputs: {}
 runs:
   using: docker
-  image: docker://rgonnella/releasaurus:v0.8.0
+  image: docker://rgonnella/releasaurus:v0.9.0
   env:
     RELEASAURUS_DEBUG: ${{ inputs.debug }}
   args:

--- a/action/gitea/release/action.yml
+++ b/action/gitea/release/action.yml
@@ -12,7 +12,7 @@ inputs:
 outputs: {}
 runs:
   using: docker
-  image: docker://rgonnella/releasaurus:v0.8.0
+  image: docker://rgonnella/releasaurus:v0.9.0
   env:
     RELEASAURUS_DEBUG: ${{ inputs.debug }}
   args:

--- a/action/github/action.yml
+++ b/action/github/action.yml
@@ -13,12 +13,12 @@ outputs: {}
 runs:
   using: "composite"
   steps:
-    - uses: robgonnella/releasaurus/action/github/release@v0.8.0
+    - uses: robgonnella/releasaurus/action/github/release@v0.9.0
       with:
         repo: ${{ inputs.repo }}
         token: ${{ inputs.token }}
         debug: ${{ inputs.debug }}
-    - uses: robgonnella/releasaurus/action/github/release-pr@v0.8.0
+    - uses: robgonnella/releasaurus/action/github/release-pr@v0.9.0
       with:
         repo: ${{ inputs.repo }}
         token: ${{ inputs.token }}

--- a/action/github/release-pr/action.yml
+++ b/action/github/release-pr/action.yml
@@ -12,7 +12,7 @@ inputs:
 outputs: {}
 runs:
   using: docker
-  image: docker://rgonnella/releasaurus:v0.8.0
+  image: docker://rgonnella/releasaurus:v0.9.0
   env:
     RELEASAURUS_DEBUG: ${{ inputs.debug }}
   args:

--- a/action/github/release/action.yml
+++ b/action/github/release/action.yml
@@ -12,7 +12,7 @@ inputs:
 outputs: {}
 runs:
   using: docker
-  image: docker://rgonnella/releasaurus:v0.8.0
+  image: docker://rgonnella/releasaurus:v0.9.0
   env:
     RELEASAURUS_DEBUG: ${{ inputs.debug }}
   args:

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -362,6 +362,10 @@ CI/CD pipelines.
   suffix. This is applied to all packages
 - `--prerelease-strategy <strategy>` - Set global prerelease strategy
   (`versioned` or `static`). This is applied to all packages
+- `--skip-sha <sha>` - Skip specific commits by SHA prefix (7+ characters).
+  Can be used multiple times to skip multiple commits
+- `--reword <sha>=<message>` - Rewrite a commit message. Use format
+  `sha=new message`. Can be used multiple times for multiple commits
 - `--set-package <package_name>.<property>=<value>` - Override
   package-specific properties. The takes precedence over all global overrides
   and config. Not all properties are overridable. If you try to set an
@@ -411,6 +415,13 @@ releasaurus release-pr \
   --base-branch staging \
   --prerelease-suffix alpha \ # applies to all packages
   --set-package frontend.prerelease.suffix=beta \ # applies only to frontend
+  --forge github \
+  --repo "https://github.com/owner/repo"
+
+# Skip specific commits and reword others
+releasaurus release-pr \
+  --skip-sha abc123d \
+  --reword "def456e=feat: improved authentication" \
   --forge github \
   --repo "https://github.com/owner/repo"
 ```

--- a/book/src/configuration-changelog.md
+++ b/book/src/configuration-changelog.md
@@ -95,6 +95,57 @@ Include commit author names in changelog entries:
 include_author = true
 ```
 
+### `skip_shas` (default: none)
+
+Skip specific commits by SHA prefix:
+
+```toml
+[changelog]
+skip_shas = ["abc123d", "def456e"]
+
+[[package]]
+path = "."
+release_type = "rust"
+```
+
+Use short SHA prefixes (7+ characters). Useful for excluding commits that
+shouldn't affect versioning or appear in changelogs.
+
+**CLI override:**
+
+```bash
+releasaurus release-pr --skip-sha "abc123d"
+```
+
+### `reword`
+
+Rewrite commit messages in the changelog:
+
+```toml
+[[changelog.reword]]
+sha = "abc123d"
+message = "fix: corrected security vulnerability"
+
+[[changelog.reword]]
+sha = "def456e"
+message = "feat: added user authentication"
+
+[[package]]
+path = "."
+release_type = "node"
+```
+
+Use SHA prefixes to match commits. The reworded message affects both
+changelog content and version calculation (e.g., changing `fix:` to `feat:`
+bumps minor instead of patch).
+
+**CLI override:**
+
+```bash
+releasaurus release-pr --skip-sha "abc123d" \
+  --reword "def456e=feat: improved feature"
+```
+
 ## Template Customization
 
 ### `body` Template

--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -32,6 +32,7 @@ first_release_search_depth = 400
 ```
 
 **When to adjust:**
+
 - Large repos: decrease to 100-200 for faster analysis
 - Need more history: increase to 1000+
 - CI/CD: use smaller values for speed
@@ -145,6 +146,7 @@ suffix = "alpha"
 **Default**: "versioned"
 
 Prerelease versioning strategy:
+
 - `"versioned"` - Adds incremental counter (`.1`, `.2`)
 - `"static"` - Uses suffix as-is
 
@@ -243,6 +245,38 @@ Include commit author names in changelog.
 include_author = true
 ```
 
+#### `skip_shas`
+
+**Type**: Array of strings (optional)
+
+**Default**: None
+
+Skip specific commits by SHA prefix. Use 7+ character prefixes.
+
+```toml
+[changelog]
+skip_shas = ["abc123d", "def456e"]
+```
+
+#### `reword`
+
+**Type**: Array of objects (optional)
+
+**Default**: None
+
+Rewrite commit messages for specific commits. Affects both changelog and
+version calculation.
+
+```toml
+[[changelog.reword]]
+sha = "abc123d"
+message = "fix: corrected description"
+
+[[changelog.reword]]
+sha = "def456e"
+message = "feat: improved feature"
+```
+
 #### `body`
 
 **Type**: String (optional)
@@ -312,6 +346,7 @@ path = "packages/backend"
 **Default**: None
 
 Language/framework for version file updates:
+
 - `"rust"` - Cargo.toml, Cargo.lock
 - `"node"` - package.json, lock files
 - `"python"` - pyproject.toml, setup.py, setup.cfg
@@ -333,6 +368,7 @@ release_type = "node"
 **Default**: Derived from package name
 
 Git tag prefix. Defaults:
+
 - Root packages: `"v"`
 - Nested packages: `"<name>-v"`
 

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -76,6 +76,8 @@
         "skip_miscellaneous": false,
         "skip_merge_commits": true,
         "skip_release_commits": true,
+        "skip_shas": null,
+        "reword": null,
         "include_author": false
       }
     },
@@ -173,12 +175,52 @@
           "type": "boolean",
           "default": true
         },
+        "skip_shas": {
+          "description": "Skips targeted commit shas (or prefixes) when generating next version\nand changelog. Each value matches any commit whose SHA starts with the\nprovided value",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "reword": {
+          "description": "Rewords commit messages for targeted shas when generated changelog.\nEach SHA can be a prefix - matches any commit whose SHA starts with the\nprovided value",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/RewordedCommit"
+          },
+          "default": null
+        },
         "include_author": {
           "description": "Includes commit author name in default body template",
           "type": "boolean",
           "default": false
         }
       }
+    },
+    "RewordedCommit": {
+      "description": "Rewords messages in changelog for targeted commit shas",
+      "type": "object",
+      "properties": {
+        "sha": {
+          "description": "Sha (or prefix) of the commit to reword. Matches any commit whose SHA\nstarts with this value",
+          "type": "string"
+        },
+        "message": {
+          "description": "The new message to display in changelog",
+          "type": "string"
+        }
+      },
+      "required": [
+        "sha",
+        "message"
+      ]
     },
     "PackageConfig": {
       "description": "Package configuration for multi-package repositories and monorepos",

--- a/src/analyzer/config.rs
+++ b/src/analyzer/config.rs
@@ -3,7 +3,7 @@
 use derive_builder::Builder;
 use regex::Regex;
 
-use crate::config::prerelease::PrereleaseConfig;
+use crate::{cli::CommitModifiers, config::prerelease::PrereleaseConfig};
 
 /// Default changelog body template.
 pub const DEFAULT_BODY: &str = r#"# [{{ version  }}]({{ link }}) - {{ timestamp | date(format="%Y-%m-%d") }}
@@ -59,6 +59,9 @@ pub struct AnalyzerConfig {
     pub custom_major_increment_regex: Option<String>,
     /// Custom commit type regex matcher to increment minor version
     pub custom_minor_increment_regex: Option<String>,
+    /// Custom commit modifiers to skip commit shas or reword commit messages
+    /// when generating changelog content
+    pub commit_modifiers: CommitModifiers,
 }
 
 impl Default for AnalyzerConfig {
@@ -79,6 +82,7 @@ impl Default for AnalyzerConfig {
             features_always_increment_minor: true,
             custom_major_increment_regex: None,
             custom_minor_increment_regex: None,
+            commit_modifiers: CommitModifiers::default(),
         }
     }
 }

--- a/src/analyzer/tests/filtering.rs
+++ b/src/analyzer/tests/filtering.rs
@@ -9,6 +9,8 @@
 
 use crate::{
     analyzer::{Analyzer, config::AnalyzerConfig, group, release},
+    cli::CommitModifiers,
+    config::changelog::RewordedCommit,
     forge::request::ForgeCommit,
 };
 use semver::Version as SemVer;
@@ -452,4 +454,353 @@ fn test_skip_all_types_results_in_no_release() {
 
     // Should result in no release since all commits are filtered
     assert!(result.is_none());
+}
+
+#[test]
+fn test_skip_shas_filters_commits_by_sha() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec!["def456".to_string(), "ghi789".to_string()],
+            reword: vec![],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![
+        ForgeCommit {
+            id: "abc123".to_string(),
+            message: "feat: add feature".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "def456".to_string(),
+            message: "fix: bug fix".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "ghi789".to_string(),
+            message: "feat: another feature".to_string(),
+            timestamp: 3000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "jkl012".to_string(),
+            message: "fix: another fix".to_string(),
+            timestamp: 4000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    // Should only have 2 commits (abc123 and jkl012)
+    assert_eq!(release.commits.len(), 2);
+    assert_eq!(release.commits[0].id, "abc123");
+    assert_eq!(release.commits[1].id, "jkl012");
+}
+
+#[test]
+fn test_skip_shas_matches_by_prefix() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec!["abc123".to_string()],
+            reword: vec![],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![
+        ForgeCommit {
+            id: "abc123def456789012345678901234567890abcd".to_string(),
+            message: "feat: should be skipped".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "def456".to_string(),
+            message: "fix: should be included".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    // Should only have 1 commit (def456) - full SHA starting with abc123 was skipped
+    assert_eq!(release.commits.len(), 1);
+    assert_eq!(release.commits[0].id, "def456");
+}
+
+#[test]
+fn test_skip_shas_with_no_matching_commits() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec!["nonexistent".to_string()],
+            reword: vec![],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![
+        ForgeCommit {
+            id: "abc123".to_string(),
+            message: "feat: add feature".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "def456".to_string(),
+            message: "fix: bug fix".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    assert_eq!(release.commits.len(), 2);
+}
+
+#[test]
+fn test_skip_shas_all_commits_results_in_no_release() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec!["abc123".to_string(), "def456".to_string()],
+            reword: vec![],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![
+        ForgeCommit {
+            id: "abc123".to_string(),
+            message: "feat: add feature".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "def456".to_string(),
+            message: "fix: bug fix".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let result = analyzer.analyze(commits, None).unwrap();
+
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_reword_changes_commit_message() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec![],
+            reword: vec![RewordedCommit {
+                sha: "def456".to_string(),
+                message: "fix: corrected bug description".to_string(),
+            }],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![
+        ForgeCommit {
+            id: "abc123".to_string(),
+            message: "feat: add feature".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "def456".to_string(),
+            message: "fix: original message".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    assert_eq!(release.commits.len(), 2);
+    assert_eq!(release.commits[1].id, "def456");
+    assert_eq!(
+        release.commits[1].raw_message,
+        "fix: corrected bug description"
+    );
+    assert_eq!(release.commits[1].title, "corrected bug description");
+}
+
+#[test]
+fn test_reword_matches_by_prefix() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec![],
+            reword: vec![RewordedCommit {
+                sha: "abc123".to_string(),
+                message: "feat: reworded message".to_string(),
+            }],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![ForgeCommit {
+        id: "abc123def456789012345678901234567890abcd".to_string(),
+        message: "fix: original message".to_string(),
+        timestamp: 1000,
+        ..ForgeCommit::default()
+    }];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    // Full SHA starting with abc123 should be reworded
+    assert_eq!(release.commits[0].raw_message, "feat: reworded message");
+    assert_eq!(release.commits[0].title, "reworded message");
+}
+
+#[test]
+fn test_reword_with_multiline_message() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec![],
+            reword: vec![RewordedCommit {
+                sha: "abc123".to_string(),
+                message: "feat: new title\n\nDetailed body content".to_string(),
+            }],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![ForgeCommit {
+        id: "abc123".to_string(),
+        message: "feat: original".to_string(),
+        timestamp: 1000,
+        ..ForgeCommit::default()
+    }];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    assert_eq!(release.commits[0].title, "new title");
+    assert_eq!(
+        release.commits[0].body,
+        Some("Detailed body content".to_string())
+    );
+}
+
+#[test]
+fn test_reword_changes_version_calculation() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec![],
+            reword: vec![RewordedCommit {
+                sha: "abc123".to_string(),
+                message: "feat: upgraded to feature".to_string(),
+            }],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let current_tag = release::Tag {
+        sha: "old123".to_string(),
+        name: "1.0.0".to_string(),
+        semver: SemVer::parse("1.0.0").unwrap(),
+        ..release::Tag::default()
+    };
+
+    let commits = vec![ForgeCommit {
+        id: "abc123".to_string(),
+        message: "fix: original was just a fix".to_string(),
+        timestamp: 1000,
+        ..ForgeCommit::default()
+    }];
+
+    let release = analyzer
+        .analyze(commits, Some(current_tag))
+        .unwrap()
+        .unwrap();
+
+    // Should be minor bump (1.1.0) because reworded to feat, not patch (1.0.1)
+    assert_eq!(release.tag.unwrap().semver, SemVer::parse("1.1.0").unwrap());
+}
+
+#[test]
+fn test_reword_with_no_matching_commits() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec![],
+            reword: vec![RewordedCommit {
+                sha: "nonexistent".to_string(),
+                message: "feat: new message".to_string(),
+            }],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![ForgeCommit {
+        id: "abc123".to_string(),
+        message: "fix: bug fix".to_string(),
+        timestamp: 1000,
+        ..ForgeCommit::default()
+    }];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    // Original message should be preserved
+    assert_eq!(release.commits[0].raw_message, "fix: bug fix");
+    assert_eq!(release.commits[0].title, "bug fix");
+}
+
+#[test]
+fn test_skip_shas_and_reword_combined() {
+    let config = AnalyzerConfig {
+        commit_modifiers: CommitModifiers {
+            skip_shas: vec!["ghi789".to_string()],
+            reword: vec![RewordedCommit {
+                sha: "def456".to_string(),
+                message: "feat: upgraded from fix".to_string(),
+            }],
+        },
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let commits = vec![
+        ForgeCommit {
+            id: "abc123".to_string(),
+            message: "feat: first feature".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "def456".to_string(),
+            message: "fix: original fix".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "ghi789".to_string(),
+            message: "feat: will be skipped".to_string(),
+            timestamp: 3000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let release = analyzer.analyze(commits, None).unwrap().unwrap();
+
+    // Should have 2 commits (ghi789 skipped)
+    assert_eq!(release.commits.len(), 2);
+    assert_eq!(release.commits[0].id, "abc123");
+    assert_eq!(release.commits[1].id, "def456");
+    // Second commit should be reworded
+    assert_eq!(release.commits[1].title, "upgraded from fix");
 }

--- a/src/cli/command/show.rs
+++ b/src/cli/command/show.rs
@@ -104,6 +104,7 @@ mod tests {
     use super::*;
     use crate::{
         analyzer::release::{Release, Tag},
+        cli::CommitModifiers,
         config::{
             Config,
             package::{PackageConfig, PackageConfigBuilder},
@@ -213,6 +214,7 @@ mod tests {
         let cmd = ShowCommand::NextRelease {
             out_file: None,
             package: None,
+            commit_modifiers: CommitModifiers::default(),
             overrides: crate::cli::SharedCommandOverrides {
                 package_overrides: vec![],
                 prerelease_suffix: None,
@@ -251,6 +253,7 @@ mod tests {
         let cmd = ShowCommand::NextRelease {
             out_file: None,
             package: Some("pkg-a".to_string()),
+            commit_modifiers: CommitModifiers::default(),
             overrides: crate::cli::SharedCommandOverrides {
                 package_overrides: vec![],
                 prerelease_suffix: None,
@@ -274,6 +277,7 @@ mod tests {
         let cmd = ShowCommand::NextRelease {
             out_file: None,
             package: None,
+            commit_modifiers: CommitModifiers::default(),
             overrides: crate::cli::SharedCommandOverrides {
                 package_overrides: vec![],
                 prerelease_suffix: None,
@@ -301,6 +305,7 @@ mod tests {
         let cmd = ShowCommand::NextRelease {
             out_file: Some(out_file_str),
             package: None,
+            commit_modifiers: CommitModifiers::default(),
             overrides: crate::cli::SharedCommandOverrides {
                 package_overrides: vec![],
                 prerelease_suffix: None,
@@ -350,6 +355,7 @@ mod tests {
         let cmd = ShowCommand::NextRelease {
             out_file: Some("/tmp/filtered.json".to_string()),
             package: Some("pkg-a".to_string()),
+            commit_modifiers: CommitModifiers::default(),
             overrides: crate::cli::SharedCommandOverrides {
                 package_overrides: vec![],
                 prerelease_suffix: None,
@@ -400,6 +406,7 @@ mod tests {
         let cmd = ShowCommand::NextRelease {
             out_file: Some("/tmp/filtered.json".to_string()),
             package: Some("pkg-a".to_string()),
+            commit_modifiers: CommitModifiers::default(),
             overrides: crate::cli::SharedCommandOverrides {
                 package_overrides: vec![],
                 prerelease_suffix: None,

--- a/src/config/changelog.rs
+++ b/src/config/changelog.rs
@@ -4,6 +4,19 @@ use serde::{Deserialize, Serialize};
 
 use crate::analyzer::config::DEFAULT_BODY;
 
+/// Rewords messages in changelog for targeted commit shas
+#[derive(
+    Debug, Clone, Default, JsonSchema, Serialize, Deserialize, Builder,
+)]
+#[builder(setter(into))]
+pub struct RewordedCommit {
+    /// Sha (or prefix) of the commit to reword. Matches any commit whose SHA
+    /// starts with this value
+    pub sha: String,
+    /// The new message to display in changelog
+    pub message: String,
+}
+
 /// Changelog configuration (applies to all packages)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Builder)]
 #[builder(setter(into, strip_option), default)]
@@ -21,6 +34,14 @@ pub struct ChangelogConfig {
     pub skip_merge_commits: bool,
     /// Skips including release commits in changelog
     pub skip_release_commits: bool,
+    /// Skips targeted commit shas (or prefixes) when generating next version
+    /// and changelog. Each value matches any commit whose SHA starts with the
+    /// provided value
+    pub skip_shas: Option<Vec<String>>,
+    /// Rewords commit messages for targeted shas when generated changelog.
+    /// Each SHA can be a prefix - matches any commit whose SHA starts with the
+    /// provided value
+    pub reword: Option<Vec<RewordedCommit>>,
     /// Includes commit author name in default body template
     pub include_author: bool,
 }
@@ -34,6 +55,8 @@ impl Default for ChangelogConfig {
             skip_miscellaneous: false,
             skip_merge_commits: true,
             skip_release_commits: true,
+            skip_shas: None,
+            reword: None,
             include_author: false,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,9 +93,11 @@ async fn main() -> Result<()> {
 
     let global_overrides = cli.get_global_overrides();
     let package_overrides = cli.get_package_overrides()?;
+    let commit_modifiers = cli.get_commit_modifiers();
 
     log::debug!("global overrides: {:#?}", global_overrides);
     log::debug!("package overrides: {:#?}", package_overrides);
+    log::debug!("commit modifiers: {:#?}", commit_modifiers);
 
     let mut config = forge_manager
         .load_config(global_overrides.base_branch.clone())
@@ -111,7 +113,8 @@ async fn main() -> Result<()> {
         release_link_base_url,
         package_overrides,
         global_overrides,
-    );
+        commit_modifiers,
+    )?;
 
     match cli.command {
         Command::ReleasePR { .. } => {


### PR DESCRIPTION
## Description

Allows users to skip targeted commits by sha when calculating version and changelog content. Also allows users to reword targeted commits by sha before calculating version and changelog content

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

