### PR TITLE
feat(gitea): force push release branch

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -10,25 +10,6 @@ Actions and Gitea Actions workflows.
 | `command`      | Yes      | The releasaurus command to run   |
 | `command_args` | No       | Arguments to pass to the command |
 
-## Known Limitations
-
-### Gitea: Closed Release PRs on Repeated Runs (Gitea < 1.26)
-
-Gitea versions prior to **1.26** do not support force-pushing a branch via
-the API. As a workaround, releasaurus deletes the release branch and
-re-creates it on each run. Gitea automatically closes any open pull request
-targeting a deleted branch, so each run produces a new PR and leaves a
-closed one behind.
-
-**Workaround**: Use `--local-path` (hybrid mode) to perform git operations
-locally. This bypasses the branch-deletion workaround and avoids accumulating
-closed PRs. See the [Using `--local-path`](#using---local-path-hybrid-mode)
-example below, substituting `--forge gitea` and your Gitea repository URL.
-
-This limitation will be resolved once Gitea 1.26 is released and a
-corresponding releasaurus update ships. See
-[PR #200](https://github.com/robgonnella/releasaurus/pull/200).
-
 ## Examples
 
 ### Basic Release Workflow

--- a/crates/releasaurus-core/src/forge/gitea.rs
+++ b/crates/releasaurus-core/src/forge/gitea.rs
@@ -9,8 +9,8 @@ use reqwest::{
     header::{HeaderMap, HeaderValue},
 };
 use secrecy::{ExposeSecret, SecretString};
-use std::{cmp, sync::Arc, time::Duration};
-use tokio::{sync::Mutex, time::sleep};
+use std::{cmp, sync::Arc};
+use tokio::sync::Mutex;
 use url::Url;
 
 use crate::{
@@ -118,17 +118,6 @@ impl Gitea {
             compare_link_base_url,
             default_branch: default_branch.into(),
         })
-    }
-
-    // TODO: Right now gitea does not support force updating a branch
-    // Once the below issue is resolved we can remove this method and use the
-    // "force" option
-    // https://github.com/go-gitea/gitea/issues/35538
-    async fn delete_branch_if_exists(&self, branch: &str) -> Result<()> {
-        let url = self.base_url.join(&format!("branches/{branch}"))?;
-        let request = self.client.delete(url).build()?;
-        self.client.execute(request).await?;
-        Ok(())
     }
 
     async fn get_file_sha(&self, path: &str) -> Result<String> {
@@ -455,13 +444,6 @@ impl Forge for Gitea {
         &self,
         req: CreateReleaseBranchRequest,
     ) -> Result<Commit> {
-        // TODO: Once below issue is resolved we can delete this call
-        // https://github.com/go-gitea/gitea/issues/35538
-        self.delete_branch_if_exists(&req.release_branch).await?;
-        // pause execution to wait for any PRs that might have been closed as
-        // a result to fully register as closed
-        sleep(Duration::from_millis(3000)).await;
-
         let mut file_changes: Vec<GiteaFileChange> = vec![];
 
         for change in req.file_changes.iter() {
@@ -490,15 +472,12 @@ impl Forge for Gitea {
             })
         }
 
-        // TODO: Currently gitea does not support the force option
-        // Update once below issue is resolved
-        // https://github.com/go-gitea/gitea/issues/35538
         let body = GiteaModifyFiles {
             old_ref_name: req.base_branch,
             new_branch: Some(req.release_branch),
             message: req.message,
             files: file_changes,
-            // force: true,
+            force_push: true,
         };
 
         let contents_url = self.base_url.join("contents")?;
@@ -562,6 +541,7 @@ impl Forge for Gitea {
             old_ref_name: req.target_branch,
             message: req.message,
             files: file_changes,
+            force_push: false,
         };
 
         let contents_url = self.base_url.join("contents")?;

--- a/crates/releasaurus-core/src/forge/gitea/types.rs
+++ b/crates/releasaurus-core/src/forge/gitea/types.rs
@@ -138,15 +138,12 @@ pub struct GiteaFileChange {
 }
 
 #[derive(Debug, Serialize)]
-// TODO: Currently gitea does not support the force option
-// Update once below issue is resolved
-// https://github.com/go-gitea/gitea/issues/35538
 pub struct GiteaModifyFiles {
     pub old_ref_name: String,
     pub new_branch: Option<String>,
     pub message: String,
     pub files: Vec<GiteaFileChange>,
-    // pub force: bool,
+    pub force_push: bool,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Description

Now that gitea 1.26 is released we can use the feature to force push the release branch instead of deleting and recreating the branch each time.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)

## Related Issues

Relates to:
[Gitea-Issue-35538](https://github.com/go-gitea/gitea/issues/35538)
[Gitea-PR-35592](https://github.com/go-gitea/gitea/pull/35592)

