### PR TITLE
chore: refactors Release struct to make tag required

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -109,7 +109,7 @@ impl<'a> Analyzer<'a> {
         release.link =
             format!("{}/{}", self.config.release_link_base_url, next_tag.name);
 
-        release.tag = Some(next_tag);
+        release.tag = next_tag;
 
         let context = tera::Context::from_serialize(&release)?;
         let notes = tera::Tera::one_off(&self.config.body, &context, false)?;
@@ -145,6 +145,7 @@ impl<'a> Analyzer<'a> {
                 );
                 continue;
             }
+
             let forge_commit = if let Some(reworded) = self
                 .config
                 .commit_modifiers

--- a/src/analyzer/release.rs
+++ b/src/analyzer/release.rs
@@ -54,7 +54,7 @@ impl Serialize for Tag {
 #[derive(Clone, Default)]
 pub struct Release {
     /// Associated version tag.
-    pub tag: Option<Tag>,
+    pub tag: Tag,
     /// Release URL link.
     pub link: String,
     /// Git commit SHA for the release.
@@ -87,10 +87,8 @@ impl Serialize for Release {
         S: serde::Serializer,
     {
         let mut s = serializer.serialize_struct("Release", 7)?;
-        let default_tag = Tag::default();
-        let tag = self.tag.as_ref().unwrap_or(&default_tag);
         s.serialize_field("link", &self.link)?;
-        s.serialize_field("version", &tag.semver.to_string())?;
+        s.serialize_field("version", &self.tag.semver.to_string())?;
         s.serialize_field("sha", &self.sha)?;
         s.serialize_field("include_author", &self.include_author)?;
         s.serialize_field("commits", &self.commits)?;

--- a/src/analyzer/tests/filtering.rs
+++ b/src/analyzer/tests/filtering.rs
@@ -729,7 +729,7 @@ fn test_reword_changes_version_calculation() {
         .unwrap();
 
     // Should be minor bump (1.1.0) because reworded to feat, not patch (1.0.1)
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("1.1.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("1.1.0").unwrap());
 }
 
 #[test]

--- a/src/analyzer/tests/prerelease.rs
+++ b/src/analyzer/tests/prerelease.rs
@@ -45,10 +45,7 @@ fn test_prerelease_start_from_stable() {
     let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
     let release = result.unwrap();
-    assert_eq!(
-        release.tag.unwrap().semver,
-        SemVer::parse("1.1.0-alpha.1").unwrap()
-    );
+    assert_eq!(release.tag.semver, SemVer::parse("1.1.0-alpha.1").unwrap());
 }
 
 #[test]
@@ -79,10 +76,7 @@ fn test_prerelease_continue_same_identifier() {
     let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
     let release = result.unwrap();
-    assert_eq!(
-        release.tag.unwrap().semver,
-        SemVer::parse("1.1.0-alpha.2").unwrap()
-    );
+    assert_eq!(release.tag.semver, SemVer::parse("1.1.0-alpha.2").unwrap());
 }
 
 #[test]
@@ -110,7 +104,7 @@ fn test_prerelease_graduate_to_stable() {
     let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
     let release = result.unwrap();
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("1.0.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("1.0.0").unwrap());
 }
 
 #[test]
@@ -142,10 +136,7 @@ fn test_prerelease_switch_identifier() {
 
     let release = result.unwrap();
     // Should switch to beta and calculate next version
-    assert_eq!(
-        release.tag.unwrap().semver,
-        SemVer::parse("1.1.0-beta.1").unwrap()
-    );
+    assert_eq!(release.tag.semver, SemVer::parse("1.1.0-beta.1").unwrap());
 }
 
 #[test]
@@ -169,10 +160,7 @@ fn test_prerelease_first_release() {
     let result = analyzer.analyze(commits, None).unwrap();
 
     let release = result.unwrap();
-    assert_eq!(
-        release.tag.unwrap().semver,
-        SemVer::parse("0.1.0-alpha.1").unwrap()
-    );
+    assert_eq!(release.tag.semver, SemVer::parse("0.1.0-alpha.1").unwrap());
 }
 
 #[test]
@@ -204,10 +192,7 @@ fn test_prerelease_breaking_change() {
 
     let release = result.unwrap();
     // Breaking change should bump major version
-    assert_eq!(
-        release.tag.unwrap().semver,
-        SemVer::parse("2.0.0-alpha.1").unwrap()
-    );
+    assert_eq!(release.tag.semver, SemVer::parse("2.0.0-alpha.1").unwrap());
 }
 
 #[test]
@@ -239,10 +224,7 @@ fn test_new_prerelease_with_static_strategy() {
 
     let release = result.unwrap();
     // Static strategy should produce version without numeric suffix
-    assert_eq!(
-        release.tag.unwrap().semver,
-        SemVer::parse("1.1.0-dev").unwrap()
-    );
+    assert_eq!(release.tag.semver, SemVer::parse("1.1.0-dev").unwrap());
 }
 
 #[test]
@@ -274,10 +256,7 @@ fn test_continuing_prerelease_with_static_strategy() {
 
     let release = result.unwrap();
     // Static strategy increments base version, keeps static suffix
-    assert_eq!(
-        release.tag.unwrap().semver,
-        SemVer::parse("1.1.1-dev").unwrap()
-    );
+    assert_eq!(release.tag.semver, SemVer::parse("1.1.1-dev").unwrap());
 }
 
 #[test]
@@ -309,7 +288,6 @@ fn test_prerelease_with_tag_prefix() {
     let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
 
     let release = result.unwrap();
-    let tag = release.tag.unwrap();
-    assert_eq!(tag.semver, SemVer::parse("1.1.0-rc.1").unwrap());
-    assert_eq!(tag.name, "v1.1.0-rc.1");
+    assert_eq!(release.tag.semver, SemVer::parse("1.1.0-rc.1").unwrap());
+    assert_eq!(release.tag.name, "v1.1.0-rc.1");
 }

--- a/src/analyzer/tests/version_rules.rs
+++ b/src/analyzer/tests/version_rules.rs
@@ -42,7 +42,7 @@ fn test_breaking_always_increment_major_disabled() {
 
     // In 0.x versions with breaking_always_increment_major=false,
     // breaking changes bump minor instead of major
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("0.2.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("0.2.0").unwrap());
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn test_custom_major_regex_works_with_breaking_syntax() {
     let release = result.unwrap();
 
     // Breaking syntax still triggers major bump (custom regex is additive)
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("1.0.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("1.0.0").unwrap());
 }
 
 #[test]
@@ -103,7 +103,7 @@ fn test_custom_major_increment_regex() {
     let release = result.unwrap();
 
     // Custom regex matches "doc" in commit message, bumps major
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("1.0.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("1.0.0").unwrap());
 }
 
 #[test]
@@ -133,7 +133,7 @@ fn test_features_always_increment_minor_disabled() {
 
     // In 0.x versions with features_always_increment_minor=false,
     // features bump patch instead of minor
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("0.1.1").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("0.1.1").unwrap());
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn test_custom_minor_increment_regex() {
     let release = result.unwrap();
 
     // Custom regex matches "ci" in commit message, bumps minor
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("0.2.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("0.2.0").unwrap());
 }
 
 #[test]
@@ -191,7 +191,7 @@ fn test_custom_minor_regex_works_with_feat_syntax() {
     let release = result.unwrap();
 
     // Feat syntax still triggers minor bump (custom regex is additive)
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("0.2.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("0.2.0").unwrap());
 }
 
 #[test]
@@ -236,7 +236,7 @@ fn test_both_boolean_flags_disabled_minor_bump() {
     let release = result.unwrap();
 
     // With both flags disabled, only minor bump
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("0.2.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("0.2.0").unwrap());
 }
 
 #[test]
@@ -275,7 +275,7 @@ fn test_both_boolean_flags_disabled_patch_bump() {
     let release = result.unwrap();
 
     // With both flags disabled, only patch bump
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("0.1.1").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("0.1.1").unwrap());
 }
 
 #[test]
@@ -305,5 +305,5 @@ fn test_custom_regex_matches_non_conventional_commit() {
     let release = result.unwrap();
 
     // Custom regex matches "wow" and triggers major bump
-    assert_eq!(release.tag.unwrap().semver, SemVer::parse("1.0.0").unwrap());
+    assert_eq!(release.tag.semver, SemVer::parse("1.0.0").unwrap());
 }

--- a/src/cli/command/show.rs
+++ b/src/cli/command/show.rs
@@ -186,12 +186,12 @@ mod tests {
             workspace_root: ".".into(),
             path: ".".into(),
             release: Release {
-                tag: Some(Tag {
+                tag: Tag {
                     sha: "test-sha".to_string(),
                     name: format!("v{}", version),
                     semver: SemVer::parse(version).unwrap(),
                     ..Tag::default()
-                }),
+                },
                 sha: "test-sha".to_string(),
                 notes: format!("## Changes\n\nRelease {}", version),
                 timestamp: 1234567890,
@@ -333,17 +333,7 @@ mod tests {
 
         assert_eq!(next_releases.len(), 1);
         assert_eq!(next_releases[0].name, "pkg-a");
-        assert!(next_releases[0].release.tag.is_some());
-        assert_eq!(
-            next_releases[0]
-                .release
-                .tag
-                .as_ref()
-                .unwrap()
-                .semver
-                .to_string(),
-            "0.1.0"
-        );
+        assert_eq!(next_releases[0].release.tag.semver.to_string(), "0.1.0");
         assert!(next_releases[0].release.notes.contains("test feature"));
     }
 

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -69,9 +69,7 @@ pub async fn start_next_release(
             file_changes,
             message: format!(
                 "chore({}): bump patch version {} - {}",
-                base_branch,
-                pkg.name,
-                pkg.release.tag.as_ref().unwrap_or(&Tag::default()).semver
+                base_branch, pkg.name, pkg.release.tag.semver
             ),
         };
 

--- a/src/updater/manager.rs
+++ b/src/updater/manager.rs
@@ -294,7 +294,6 @@ pub struct UpdaterPackage {
 
 impl UpdaterPackage {
     fn from_releasable_package(pkg: &ReleasablePackage) -> Self {
-        let tag = pkg.release.tag.as_ref().cloned().unwrap_or_default();
         let release_type = pkg.release_type;
         let updater = Rc::new(Updater::new(release_type));
 
@@ -306,7 +305,7 @@ impl UpdaterPackage {
                 .as_ref()
                 .cloned()
                 .unwrap_or_default(),
-            next_version: tag,
+            next_version: pkg.release.tag.clone(),
             updater,
         }
     }


### PR DESCRIPTION
## Description

Since we return None when there are no releasable commits, it is guaranteed that a release always has a valid tag

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Chore: refactor

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)

