### PR TITLE
chore: cleans up manifest workspace logic

### DIFF
--- a/src/updater/generic/updater.rs
+++ b/src/updater/generic/updater.rs
@@ -82,7 +82,6 @@ mod tests {
 
     fn create_manifest(content: &str) -> ManifestFile {
         ManifestFile {
-            is_workspace: false,
             path: "test.txt".to_string(),
             basename: "test.txt".to_string(),
             content: content.to_string(),

--- a/src/updater/java/gradle.rs
+++ b/src/updater/java/gradle.rs
@@ -66,7 +66,6 @@ mod tests {
         let gradle = Gradle::new();
         let content = r#"version = "1.0.0""#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: content.to_string(),
@@ -95,7 +94,6 @@ mod tests {
         let gradle = Gradle::new();
         let content = "version = '1.0.0'";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: content.to_string(),
@@ -124,7 +122,6 @@ mod tests {
         let gradle = Gradle::new();
         let content = r#"version = "1.0.0""#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle.kts".to_string(),
             basename: "build.gradle.kts".to_string(),
             content: content.to_string(),
@@ -153,7 +150,6 @@ mod tests {
         let gradle = Gradle::new();
         let content = r#"project.version = "1.0.0""#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: content.to_string(),
@@ -182,7 +178,6 @@ mod tests {
         let gradle = Gradle::new();
         let content = "dependencies { implementation 'com.example:lib:1.0.0' }";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: content.to_string(),
@@ -208,13 +203,11 @@ mod tests {
     fn update_handles_multiple_manifests() {
         let gradle = Gradle::new();
         let groovy_manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: r#"version = "1.0.0""#.to_string(),
         };
         let kotlin_manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle.kts".to_string(),
             basename: "build.gradle.kts".to_string(),
             content: r#"version = "1.0.0""#.to_string(),
@@ -242,7 +235,6 @@ mod tests {
     fn update_returns_none_when_no_changes() {
         let gradle = Gradle::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: "<version>1.0.0</version>".to_string(),
@@ -269,7 +261,6 @@ mod tests {
         let gradle = Gradle::new();
         let content = "version   =   \"1.0.0\"";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: content.to_string(),

--- a/src/updater/java/gradle_properties.rs
+++ b/src/updater/java/gradle_properties.rs
@@ -66,7 +66,6 @@ mod tests {
         let properties = GradleProperties::new();
         let content = "version=1.0.0";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: content.to_string(),
@@ -95,7 +94,6 @@ mod tests {
         let properties = GradleProperties::new();
         let content = "version  =  1.0.0";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: content.to_string(),
@@ -124,7 +122,6 @@ mod tests {
         let properties = GradleProperties::new();
         let content = "  version=1.0.0";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: content.to_string(),
@@ -154,7 +151,6 @@ mod tests {
         let content =
             "org.gradle.jvmargs=-Xmx2048m\nversion=1.0.0\ngroup=com.example";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: content.to_string(),
@@ -187,7 +183,6 @@ mod tests {
         let properties = GradleProperties::new();
         let content = "org.gradle.jvmargs=-Xmx2048m\ngroup=com.example";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: content.to_string(),
@@ -213,13 +208,11 @@ mod tests {
     fn process_package_handles_multiple_properties_files() {
         let properties = GradleProperties::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "module1/gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: "version=1.0.0".to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "module2/gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: "version=1.0.0".to_string(),
@@ -247,7 +240,6 @@ mod tests {
     fn process_package_returns_none_when_no_gradle_properties() {
         let properties = GradleProperties::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: "version = \"1.0.0\"".to_string(),
@@ -274,7 +266,6 @@ mod tests {
         let properties = GradleProperties::new();
         let content = "# version=0.0.1\nversion=1.0.0";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "gradle.properties".to_string(),
             basename: "gradle.properties".to_string(),
             content: content.to_string(),

--- a/src/updater/java/manifests.rs
+++ b/src/updater/java/manifests.rs
@@ -10,32 +10,26 @@ impl ManifestTargets for JavaManifests {
     fn manifest_targets(pkg: &PackageConfig) -> Vec<ManifestTarget> {
         vec![
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("build.gradle")),
                 basename: "build.gradle".into(),
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("lib/build.gradle")),
                 basename: "build.gradle".into(),
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("build.gradle.kts")),
                 basename: "build.gradle.kts".into(),
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("lib/build.gradle.kts")),
                 basename: "build.gradle.kts".into(),
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("gradle.properties")),
                 basename: "gradle.properties".into(),
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("pom.xml")),
                 basename: "pom.xml".into(),
             },
@@ -64,7 +58,6 @@ mod tests {
         let targets = JavaManifests::manifest_targets(&pkg);
 
         assert_eq!(targets.len(), 6);
-        assert!(targets.iter().all(|t| !t.is_workspace));
 
         let basenames: Vec<_> = targets.iter().map(|t| &t.basename).collect();
         assert_eq!(

--- a/src/updater/java/maven.rs
+++ b/src/updater/java/maven.rs
@@ -132,7 +132,6 @@ mod tests {
     <version>1.0.0</version>
 </project>"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: content.to_string(),
@@ -172,7 +171,6 @@ mod tests {
     </dependencies>
 </project>"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: content.to_string(),
@@ -212,7 +210,6 @@ mod tests {
     </dependencies>
 </project>"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: content.to_string(),
@@ -250,7 +247,6 @@ mod tests {
     <packaging>jar</packaging>
 </project>"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: content.to_string(),
@@ -279,14 +275,12 @@ mod tests {
     fn process_package_handles_multiple_pom_files() {
         let maven = Maven::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "module1/pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: r#"<?xml version="1.0"?><project><version>1.0.0</version></project>"#
                 .to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "module2/pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: r#"<?xml version="1.0"?><project><version>1.0.0</version></project>"#
@@ -315,7 +309,6 @@ mod tests {
     fn process_package_returns_none_when_no_pom_files() {
         let maven = Maven::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "build.gradle".to_string(),
             basename: "build.gradle".to_string(),
             content: "version = \"1.0.0\"".to_string(),
@@ -350,7 +343,6 @@ mod tests {
     <version>1.0.0</version>
 </project>"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: content.to_string(),

--- a/src/updater/java/updater.rs
+++ b/src/updater/java/updater.rs
@@ -61,7 +61,6 @@ mod tests {
     <version>1.0.0</version>
 </project>"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pom.xml".to_string(),
             basename: "pom.xml".to_string(),
             content: content.to_string(),
@@ -87,7 +86,6 @@ mod tests {
     fn returns_none_when_no_java_files() {
         let updater = JavaUpdater::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"version":"1.0.0"}"#.to_string(),

--- a/src/updater/manager.rs
+++ b/src/updater/manager.rs
@@ -57,8 +57,6 @@ impl std::fmt::Debug for AdditionalManifestFile {
 
 #[derive(Debug)]
 pub struct ManifestTarget {
-    /// Whether or not to treat this as a workspace manifest
-    pub is_workspace: bool,
     /// The file path relative to the package path
     pub path: String,
     /// The base name of the file path
@@ -67,8 +65,6 @@ pub struct ManifestTarget {
 
 #[derive(Default, Clone)]
 pub struct ManifestFile {
-    /// Whether or not to treat this as a workspace manifest
-    pub is_workspace: bool,
     /// The file path relative to the package path
     pub path: String,
     /// The base name of the file path
@@ -80,7 +76,6 @@ pub struct ManifestFile {
 impl std::fmt::Debug for ManifestFile {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ManifestFile")
-            .field("is_workspace", &self.is_workspace)
             .field("path", &self.path)
             .field("basename", &self.basename)
             .finish()
@@ -93,7 +88,6 @@ impl From<AdditionalManifestFile> for ManifestFile {
             path: value.path,
             basename: value.basename,
             content: value.content,
-            is_workspace: false,
         }
     }
 }
@@ -104,7 +98,6 @@ impl From<&AdditionalManifestFile> for ManifestFile {
             path: value.path.clone(),
             basename: value.basename.clone(),
             content: value.content.clone(),
-            is_workspace: false,
         }
     }
 }
@@ -141,7 +134,6 @@ impl UpdateManager {
             {
                 info!("Loaded manifest: {}", target.path);
                 manifests.push(ManifestFile {
-                    is_workspace: target.is_workspace,
                     path: target.path,
                     basename: target.basename,
                     content,

--- a/src/updater/node/manifests.rs
+++ b/src/updater/node/manifests.rs
@@ -26,7 +26,6 @@ impl ManifestTargets for NodeManifests {
         for file in package_files {
             let full_path = package_path(pkg, Some(file));
             targets.push(ManifestTarget {
-                is_workspace: false,
                 path: full_path,
                 basename: file.to_string(),
             })
@@ -37,7 +36,6 @@ impl ManifestTargets for NodeManifests {
                 let full_path = workspace_path(pkg, Some(file));
 
                 targets.push(ManifestTarget {
-                    is_workspace: true,
                     path: full_path,
                     basename: file.to_string(),
                 })
@@ -69,7 +67,6 @@ mod tests {
         let targets = NodeManifests::manifest_targets(&pkg);
 
         assert_eq!(targets.len(), 3);
-        assert!(targets.iter().all(|t| !t.is_workspace));
 
         let basenames: Vec<_> = targets.iter().map(|t| &t.basename).collect();
         assert!(basenames.contains(&&"package.json".to_string()));
@@ -81,19 +78,7 @@ mod tests {
     fn workspace_package_includes_workspace_lock_files() {
         let pkg = create_test_package("packages/my-app");
         let targets = NodeManifests::manifest_targets(&pkg);
-
         assert_eq!(targets.len(), 5);
-
-        let workspace_targets: Vec<_> =
-            targets.iter().filter(|t| t.is_workspace).collect();
-        assert_eq!(workspace_targets.len(), 2);
-
-        let workspace_basenames: Vec<_> =
-            workspace_targets.iter().map(|t| &t.basename).collect();
-        assert!(
-            workspace_basenames.contains(&&"package-lock.json".to_string())
-        );
-        assert!(workspace_basenames.contains(&&"yarn.lock".to_string()));
     }
 
     #[test]

--- a/src/updater/node/package_json.rs
+++ b/src/updater/node/package_json.rs
@@ -124,7 +124,6 @@ mod tests {
         let package_json = PackageJson::new();
         let content = r#"{"name":"my-package","version":"1.0.0"}"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),
@@ -158,7 +157,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),
@@ -205,7 +203,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),
@@ -252,7 +249,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),
@@ -299,7 +295,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),
@@ -347,7 +342,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),
@@ -387,13 +381,11 @@ mod tests {
     fn process_package_handles_multiple_package_json_files() {
         let package_json = PackageJson::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"name":"package-a","version":"1.0.0"}"#.to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/subdir/package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"name":"package-a-sub","version":"1.0.0"}"#
@@ -422,7 +414,6 @@ mod tests {
     fn process_package_returns_none_when_no_package_json_files() {
         let package_json = PackageJson::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: "[package]\nversion = \"1.0.0\"".to_string(),
@@ -457,7 +448,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),

--- a/src/updater/node/package_lock.rs
+++ b/src/updater/node/package_lock.rs
@@ -118,16 +118,8 @@ impl PackageUpdater for PackageLock {
                 continue;
             }
 
-            if manifest.is_workspace
-                && let Some(change) = self.update_lock_file(
-                    manifest,
-                    package,
-                    workspace_packages,
-                )?
-            {
-                file_changes.push(change);
-            } else if let Some(change) =
-                self.update_lock_file(manifest, package, &[])?
+            if let Some(change) =
+                self.update_lock_file(manifest, package, workspace_packages)?
             {
                 file_changes.push(change);
             }
@@ -158,7 +150,6 @@ mod tests {
         let content =
             r#"{"name":"my-package","version":"1.0.0","packages":{}}"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: content.to_string(),
@@ -195,7 +186,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: content.to_string(),
@@ -237,7 +227,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: true,
             path: "package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: content.to_string(),
@@ -290,7 +279,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: true,
             path: "package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: content.to_string(),
@@ -343,7 +331,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: true,
             path: "package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: content.to_string(),
@@ -397,7 +384,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: content.to_string(),
@@ -424,14 +410,12 @@ mod tests {
     fn process_package_handles_multiple_lock_files() {
         let package_lock = PackageLock::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: r#"{"name":"package-a","version":"1.0.0","packages":{}}"#
                 .to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/b/package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: r#"{"name":"package-b","version":"1.0.0","packages":{}}"#
@@ -460,7 +444,6 @@ mod tests {
     fn process_package_returns_none_when_no_lock_files() {
         let package_lock = PackageLock::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"name":"my-package","version":"1.0.0"}"#.to_string(),
@@ -498,7 +481,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package-lock.json".to_string(),
             basename: "package-lock.json".to_string(),
             content: content.to_string(),

--- a/src/updater/node/updater.rs
+++ b/src/updater/node/updater.rs
@@ -59,7 +59,6 @@ mod tests {
         let updater = NodeUpdater::new();
         let content = r#"{"name":"my-package","version":"1.0.0"}"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: content.to_string(),
@@ -85,7 +84,6 @@ mod tests {
     fn returns_none_when_no_node_files() {
         let updater = NodeUpdater::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: "[package]\nversion = \"1.0.0\"\n".to_string(),

--- a/src/updater/node/yarn_lock.rs
+++ b/src/updater/node/yarn_lock.rs
@@ -120,7 +120,6 @@ mod tests {
   resolved "https://registry.yarnpkg.com/package-a/-/package-a-1.0.0.tgz"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: content.to_string(),
@@ -159,7 +158,6 @@ mod tests {
   resolved "https://registry.yarnpkg.com/package-b/-/package-b-1.0.0.tgz"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: content.to_string(),
@@ -210,7 +208,6 @@ mod tests {
   resolved "https://registry.yarnpkg.com/external-lib/-/external-lib-5.0.0.tgz"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: content.to_string(),
@@ -246,7 +243,6 @@ package-a@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-a/-/package-a-1.0.0.tgz"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: content.to_string(),
@@ -282,7 +278,6 @@ package-a@^1.0.0:
   integrity sha512-abc123
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: content.to_string(),
@@ -313,13 +308,11 @@ package-a@^1.0.0:
     fn process_package_handles_multiple_yarn_lock_files() {
         let yarn_lock = YarnLock::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: "\"package-a@^1.0.0\":\n  version \"1.0.0\"".to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/b/yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: "\"package-a@^1.0.0\":\n  version \"1.0.0\"".to_string(),
@@ -349,7 +342,6 @@ package-a@^1.0.0:
     fn process_package_returns_none_when_no_yarn_lock_files() {
         let yarn_lock = YarnLock::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"name":"my-package","version":"1.0.0"}"#.to_string(),
@@ -381,7 +373,6 @@ package-a@^1.0.0:
   resolved "https://registry.yarnpkg.com/external-lib/-/external-lib-5.0.0.tgz"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: content.to_string(),
@@ -419,7 +410,6 @@ package-a@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-a/-/package-a-1.5.0.tgz"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "yarn.lock".to_string(),
             basename: "yarn.lock".to_string(),
             content: content.to_string(),

--- a/src/updater/php/composer_json.rs
+++ b/src/updater/php/composer_json.rs
@@ -95,7 +95,6 @@ mod tests {
         let composer_json = ComposerJson::new();
         let content = r#"{"name":"vendor/package","version":"1.0.0"}"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "composer.json".to_string(),
             basename: "composer.json".to_string(),
             content: content.to_string(),
@@ -124,7 +123,6 @@ mod tests {
         let content =
             r#"{"name":"vendor/package","description":"A test package"}"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "composer.json".to_string(),
             basename: "composer.json".to_string(),
             content: content.to_string(),
@@ -161,7 +159,6 @@ mod tests {
   }
 }"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "composer.json".to_string(),
             basename: "composer.json".to_string(),
             content: content.to_string(),
@@ -192,14 +189,12 @@ mod tests {
     fn process_package_handles_multiple_composer_files() {
         let composer_json = ComposerJson::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/composer.json".to_string(),
             basename: "composer.json".to_string(),
             content: r#"{"name":"vendor/package-a","version":"1.0.0"}"#
                 .to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/b/composer.json".to_string(),
             basename: "composer.json".to_string(),
             content: r#"{"name":"vendor/package-b","version":"1.0.0"}"#
@@ -248,7 +243,6 @@ mod tests {
     fn process_package_returns_none_when_no_composer_json_files() {
         let composer_json = ComposerJson::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"name":"my-package","version":"1.0.0"}"#.to_string(),

--- a/src/updater/php/manifests.rs
+++ b/src/updater/php/manifests.rs
@@ -9,7 +9,6 @@ pub struct PhpManifests {}
 impl ManifestTargets for PhpManifests {
     fn manifest_targets(pkg: &PackageConfig) -> Vec<ManifestTarget> {
         vec![ManifestTarget {
-            is_workspace: false,
             path: package_path(pkg, Some("composer.json")),
             basename: "composer.json".into(),
         }]
@@ -37,7 +36,6 @@ mod tests {
         let targets = PhpManifests::manifest_targets(&pkg);
 
         assert_eq!(targets.len(), 1);
-        assert!(!targets[0].is_workspace);
         assert_eq!(targets[0].basename, "composer.json");
         assert_eq!(targets[0].path, "composer.json");
     }

--- a/src/updater/php/updater.rs
+++ b/src/updater/php/updater.rs
@@ -50,7 +50,6 @@ mod tests {
         let updater = PhpUpdater::new();
         let content = r#"{"name":"vendor/package","version":"1.0.0"}"#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "composer.json".to_string(),
             basename: "composer.json".to_string(),
             content: content.to_string(),
@@ -76,7 +75,6 @@ mod tests {
     fn returns_none_when_no_php_files() {
         let updater = PhpUpdater::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"version":"1.0.0"}"#.to_string(),

--- a/src/updater/python/manifests.rs
+++ b/src/updater/python/manifests.rs
@@ -14,7 +14,6 @@ impl ManifestTargets for PythonManifests {
 
         for file in files {
             targets.push(ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some(file)),
                 basename: file.into(),
             })
@@ -45,7 +44,6 @@ mod tests {
         let targets = PythonManifests::manifest_targets(&pkg);
 
         assert_eq!(targets.len(), 3);
-        assert!(targets.iter().all(|t| !t.is_workspace));
 
         let basenames: Vec<_> = targets.iter().map(|t| &t.basename).collect();
         assert!(basenames.contains(&&"pyproject.toml".to_string()));

--- a/src/updater/python/pyproject.rs
+++ b/src/updater/python/pyproject.rs
@@ -116,7 +116,6 @@ name = "my-package"
 version = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: content.to_string(),
@@ -147,7 +146,6 @@ name = "my-package"
 version = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: content.to_string(),
@@ -179,7 +177,6 @@ version = "1.0.0"
 dynamic = ["version"]
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: content.to_string(),
@@ -210,7 +207,6 @@ version = "1.0.0"
 dynamic = ["version"]
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: content.to_string(),
@@ -245,7 +241,6 @@ requires-python = ">=3.8"
 requests = "^2.28.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: content.to_string(),
@@ -278,7 +273,6 @@ requests = "^2.28.0"
 requires = ["setuptools", "wheel"]
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: content.to_string(),
@@ -304,14 +298,12 @@ requires = ["setuptools", "wheel"]
     fn process_package_handles_multiple_pyproject_files() {
         let pyproject = PyProject::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: "[project]\nname = \"package-a\"\nversion = \"1.0.0\"\n"
                 .to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/b/pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: "[project]\nname = \"package-b\"\nversion = \"1.0.0\"\n"
@@ -340,7 +332,6 @@ requires = ["setuptools", "wheel"]
     fn process_package_returns_none_when_no_pyproject_files() {
         let pyproject = PyProject::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: "setup(name='my-package', version='1.0.0')".to_string(),

--- a/src/updater/python/setupcfg.rs
+++ b/src/updater/python/setupcfg.rs
@@ -65,7 +65,6 @@ mod tests {
         let setupcfg = SetupCfg::new();
         let content = "[metadata]\nname = my-package\nversion = 1.0.0\n";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: content.to_string(),
@@ -93,7 +92,6 @@ mod tests {
         let setupcfg = SetupCfg::new();
         let content = "[metadata]\nname = my-package\nversion = \"1.0.0\"\n";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: content.to_string(),
@@ -121,7 +119,6 @@ mod tests {
         let setupcfg = SetupCfg::new();
         let content = "[metadata]\nname = my-package\nversion = '1.0.0'\n";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: content.to_string(),
@@ -149,7 +146,6 @@ mod tests {
         let setupcfg = SetupCfg::new();
         let content = "[metadata]\nname = my-package\nversion   =   1.0.0\n";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: content.to_string(),
@@ -187,7 +183,6 @@ install_requires =
     requests>=2.28.0
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: content.to_string(),
@@ -219,13 +214,11 @@ install_requires =
     fn process_package_handles_multiple_setup_cfg_files() {
         let setupcfg = SetupCfg::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: "[metadata]\nversion = 1.0.0\n".to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/b/setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: "[metadata]\nversion = 1.0.0\n".to_string(),
@@ -253,7 +246,6 @@ install_requires =
     fn process_package_returns_none_when_no_setup_cfg_files() {
         let setupcfg = SetupCfg::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: "setup(name='my-package', version='1.0.0')".to_string(),

--- a/src/updater/python/setuppy.rs
+++ b/src/updater/python/setuppy.rs
@@ -66,7 +66,6 @@ mod tests {
         let content =
             "setup(\n    name='my-package',\n    version=\"1.0.0\",\n)\n";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: content.to_string(),
@@ -95,7 +94,6 @@ mod tests {
         let content =
             "setup(\n    name='my-package',\n    version='1.0.0',\n)\n";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: content.to_string(),
@@ -124,7 +122,6 @@ mod tests {
         let content =
             "setup(\n    name='my-package',\n    version   =   \"1.0.0\",\n)\n";
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: content.to_string(),
@@ -164,7 +161,6 @@ setup(
 )
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: content.to_string(),
@@ -196,14 +192,12 @@ setup(
     fn process_package_handles_multiple_setup_py_files() {
         let setuppy = SetupPy::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: "setup(\n    name='package-a',\n    version='1.0.0'\n)"
                 .to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/b/setup.py".to_string(),
             basename: "setup.py".to_string(),
             content: "setup(\n    name='package-b',\n    version='1.0.0'\n)"
@@ -232,7 +226,6 @@ setup(
     fn process_package_returns_none_when_no_setup_py_files() {
         let setuppy = SetupPy::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "setup.cfg".to_string(),
             basename: "setup.cfg".to_string(),
             content: "[metadata]\nversion = 1.0.0\n".to_string(),

--- a/src/updater/python/updater.rs
+++ b/src/updater/python/updater.rs
@@ -62,7 +62,6 @@ name = "my-package"
 version = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "pyproject.toml".to_string(),
             basename: "pyproject.toml".to_string(),
             content: content.to_string(),
@@ -88,7 +87,6 @@ version = "1.0.0"
     fn returns_none_when_no_python_files() {
         let updater = PythonUpdater::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"version":"1.0.0"}"#.to_string(),

--- a/src/updater/ruby/gemspec.rs
+++ b/src/updater/ruby/gemspec.rs
@@ -81,7 +81,6 @@ mod tests {
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "my-gem.gemspec".to_string(),
             basename: "my-gem.gemspec".to_string(),
             content: content.to_string(),
@@ -113,7 +112,6 @@ end
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "my-gem.gemspec".to_string(),
             basename: "my-gem.gemspec".to_string(),
             content: content.to_string(),
@@ -145,7 +143,6 @@ end
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "my-gem.gemspec".to_string(),
             basename: "my-gem.gemspec".to_string(),
             content: content.to_string(),
@@ -176,7 +173,6 @@ end
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "my-gem.gemspec".to_string(),
             basename: "my-gem.gemspec".to_string(),
             content: content.to_string(),
@@ -213,7 +209,6 @@ end
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "my-gem.gemspec".to_string(),
             basename: "my-gem.gemspec".to_string(),
             content: content.to_string(),
@@ -244,13 +239,11 @@ end
     fn process_packages_handles_multiple_gemspec_files() {
         let gemspec = Gemspec::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "gems/a/gem-a.gemspec".to_string(),
             basename: "gem-a.gemspec".to_string(),
             content: "Gem::Specification.new do |spec|\n  spec.version = \"1.0.0\"\nend\n".to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "gems/b/gem-b.gemspec".to_string(),
             basename: "gem-b.gemspec".to_string(),
             content: "Gem::Specification.new do |spec|\n  spec.version = \"1.0.0\"\nend\n".to_string(),
@@ -278,7 +271,6 @@ end
     fn process_packages_returns_none_when_no_gemspec_files() {
         let gemspec = Gemspec::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Gemfile".to_string(),
             basename: "Gemfile".to_string(),
             content: "source 'https://rubygems.org'\ngem 'rails'".to_string(),

--- a/src/updater/ruby/manifests.rs
+++ b/src/updater/ruby/manifests.rs
@@ -13,22 +13,18 @@ impl ManifestTargets for RubyManifests {
 
         vec![
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some(&pkg_gemspec)),
                 basename: pkg_gemspec,
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some(&lib_pkg_version)),
                 basename: "version.rb".into(),
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("lib/version.rb")),
                 basename: "version.rb".into(),
             },
             ManifestTarget {
-                is_workspace: false,
                 path: package_path(pkg, Some("version.rb")),
                 basename: "version.rb".into(),
             },
@@ -57,7 +53,6 @@ mod tests {
         let targets = RubyManifests::manifest_targets(&pkg);
 
         assert_eq!(targets.len(), 4);
-        assert!(targets.iter().all(|t| !t.is_workspace));
 
         let basenames: Vec<_> = targets.iter().map(|t| &t.basename).collect();
         assert!(basenames.contains(&&"my-gem.gemspec".to_string()));

--- a/src/updater/ruby/updater.rs
+++ b/src/updater/ruby/updater.rs
@@ -59,7 +59,6 @@ mod tests {
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "my-gem.gemspec".to_string(),
             basename: "my-gem.gemspec".to_string(),
             content: content.to_string(),
@@ -85,7 +84,6 @@ end
     fn returns_none_when_no_ruby_files() {
         let updater = RubyUpdater::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"version":"1.0.0"}"#.to_string(),

--- a/src/updater/ruby/version_rb.rs
+++ b/src/updater/ruby/version_rb.rs
@@ -71,7 +71,6 @@ mod tests {
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "lib/my_gem/version.rb".to_string(),
             basename: "version.rb".to_string(),
             content: content.to_string(),
@@ -102,7 +101,6 @@ end
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "lib/my_gem/version.rb".to_string(),
             basename: "version.rb".to_string(),
             content: content.to_string(),
@@ -133,7 +131,6 @@ end
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "lib/my_gem/version.rb".to_string(),
             basename: "version.rb".to_string(),
             content: content.to_string(),
@@ -164,7 +161,6 @@ end
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "lib/my_gem/version.rb".to_string(),
             basename: "version.rb".to_string(),
             content: content.to_string(),
@@ -201,7 +197,6 @@ module MyGem
 end
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "lib/my_gem/version.rb".to_string(),
             basename: "version.rb".to_string(),
             content: content.to_string(),
@@ -232,13 +227,11 @@ end
     fn process_package_handles_multiple_version_rb_files() {
         let version_rb = VersionRb::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "gems/a/lib/gem_a/version.rb".to_string(),
             basename: "version.rb".to_string(),
             content: "module GemA\n  VERSION = \"1.0.0\"\nend\n".to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "gems/b/lib/gem_b/version.rb".to_string(),
             basename: "version.rb".to_string(),
             content: "module GemB\n  VERSION = \"1.0.0\"\nend\n".to_string(),
@@ -266,7 +259,6 @@ end
     fn process_package_returns_none_when_no_version_rb_files() {
         let version_rb = VersionRb::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "lib/my_gem.rb".to_string(),
             basename: "my_gem.rb".to_string(),
             content: "module MyGem\n  # Main module\nend\n".to_string(),

--- a/src/updater/rust/cargo_lock.rs
+++ b/src/updater/rust/cargo_lock.rs
@@ -105,7 +105,6 @@ name = "my-package"
 version = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: content.to_string(),
@@ -144,7 +143,6 @@ name = "package-b"
 version = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: content.to_string(),
@@ -195,7 +193,6 @@ name = "external-crate"
 version = "5.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: content.to_string(),
@@ -240,7 +237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abc123"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: content.to_string(),
@@ -276,7 +272,6 @@ checksum = "abc123"
         let content = r#"version = 3
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: content.to_string(),
@@ -304,13 +299,11 @@ checksum = "abc123"
     fn process_package_handles_multiple_cargo_lock_files() {
         let cargo_lock = CargoLock::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "workspace/a/Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: "version = 3\n\n[[package]]\nname = \"package-a\"\nversion = \"1.0.0\"\n".to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "workspace/b/Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: "version = 3\n\n[[package]]\nname = \"package-a\"\nversion = \"1.0.0\"\n".to_string(),
@@ -340,7 +333,6 @@ checksum = "abc123"
     fn process_package_returns_none_when_no_cargo_lock_files() {
         let cargo_lock = CargoLock::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: "[package]\nname = \"my-package\"\nversion = \"1.0.0\"\n"
@@ -381,7 +373,6 @@ name = "external-crate"
 version = "5.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: content.to_string(),

--- a/src/updater/rust/cargo_toml.rs
+++ b/src/updater/rust/cargo_toml.rs
@@ -159,7 +159,6 @@ name = "my-package"
 version = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -193,7 +192,6 @@ version = "1.0.0"
 package-b = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -240,7 +238,6 @@ version = "1.0.0"
 package-b = { version = "1.0.0", features = ["serde"] }
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -288,7 +285,6 @@ version = "1.0.0"
 package-b = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -335,7 +331,6 @@ version = "1.0.0"
 package-b = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "packages/a/Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -378,7 +373,6 @@ package-b = "1.0.0"
 members = ["packages/*"]
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -413,7 +407,6 @@ authors = ["Test Author"]
 serde = "1.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -443,14 +436,12 @@ serde = "1.0"
     fn process_package_handles_multiple_cargo_toml_files() {
         let cargo_toml = CargoToml::new();
         let manifest1 = ManifestFile {
-            is_workspace: false,
             path: "packages/a/Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: "[package]\nname = \"package-a\"\nversion = \"1.0.0\"\n"
                 .to_string(),
         };
         let manifest2 = ManifestFile {
-            is_workspace: false,
             path: "packages/b/Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: "[package]\nname = \"package-b\"\nversion = \"1.0.0\"\n"
@@ -479,7 +470,6 @@ serde = "1.0"
     fn process_package_returns_none_when_no_cargo_toml_files() {
         let cargo_toml = CargoToml::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.lock".to_string(),
             basename: "Cargo.lock".to_string(),
             content: "version = 3\n".to_string(),

--- a/src/updater/rust/manifests.rs
+++ b/src/updater/rust/manifests.rs
@@ -23,7 +23,6 @@ impl ManifestTargets for RustManifests {
         for file in package_files {
             let full_path = package_path(pkg, Some(file));
             targets.push(ManifestTarget {
-                is_workspace: false,
                 path: full_path,
                 basename: file.to_string(),
             })
@@ -34,7 +33,6 @@ impl ManifestTargets for RustManifests {
                 let full_path = workspace_path(pkg, Some(file));
 
                 targets.push(ManifestTarget {
-                    is_workspace: true,
                     path: full_path,
                     basename: file.to_string(),
                 })
@@ -66,7 +64,6 @@ mod tests {
         let targets = RustManifests::manifest_targets(&pkg);
 
         assert_eq!(targets.len(), 2);
-        assert!(targets.iter().all(|t| !t.is_workspace));
 
         let basenames: Vec<_> = targets.iter().map(|t| &t.basename).collect();
         assert!(basenames.contains(&&"Cargo.toml".to_string()));
@@ -77,13 +74,7 @@ mod tests {
     fn workspace_package_includes_workspace_lock_file() {
         let pkg = create_test_package("crates/my-crate");
         let targets = RustManifests::manifest_targets(&pkg);
-
         assert_eq!(targets.len(), 3);
-
-        let workspace_targets: Vec<_> =
-            targets.iter().filter(|t| t.is_workspace).collect();
-        assert_eq!(workspace_targets.len(), 1);
-        assert_eq!(workspace_targets[0].basename, "Cargo.lock");
     }
 
     #[test]

--- a/src/updater/rust/updater.rs
+++ b/src/updater/rust/updater.rs
@@ -60,7 +60,6 @@ name = "my-package"
 version = "1.0.0"
 "#;
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "Cargo.toml".to_string(),
             basename: "Cargo.toml".to_string(),
             content: content.to_string(),
@@ -86,7 +85,6 @@ version = "1.0.0"
     fn returns_none_when_no_rust_files() {
         let updater = RustUpdater::new();
         let manifest = ManifestFile {
-            is_workspace: false,
             path: "package.json".to_string(),
             basename: "package.json".to_string(),
             content: r#"{"version":"1.0.0"}"#.to_string(),


### PR DESCRIPTION
## Description

Removes "is_workspace" from ManifestTarget and ManifestFile. This was left over from a previous implementation and isn't really needed anymore.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Chore: refactor

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)
