### PR TITLE
feat: implements sub-package feature

### DIFF
--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -379,6 +379,33 @@ release_type = "rust"
 tag_prefix = "v"
 ```
 
+#### `sub_packages`
+
+**Type**: Array of objects (optional)
+
+**Default**: None
+
+Groups multiple packages under a single release that shares one changelog, tag,
+and release. Each sub-package gets independent manifest updates based on its
+`release_type`.
+
+**Use when:** Multiple packages should always be released together with the same
+version and share the same changelog
+
+```toml
+[[package]]
+name = "platform"
+workspace_root = "."
+path = "."
+sub_packages = [
+    { name = "web", path = "packages/web", release_type = "node" },
+    { name = "cli", path = "packages/cli", release_type = "rust" }
+]
+```
+
+See [Grouped Releases](./configuration-monorepo.md#grouped-releases-sub-packages)
+for details.
+
 #### `auto_start_next`
 
 **Type**: Boolean (optional)

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -94,6 +94,7 @@
           "path": ".",
           "release_type": null,
           "tag_prefix": null,
+          "sub_packages": null,
           "prerelease": null,
           "auto_start_next": null,
           "additional_paths": null,
@@ -227,7 +228,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "Name for this package (default derived from path if not provided)",
+          "description": "Name for this package (default derived from path if not provided). For\nproper manifest version file updates this should match the\ncanonical name field in the release_type manifest file.\ni.e. name = \"...\" in Cargo.toml or \"name\": \"...\" in package.json",
           "type": "string",
           "default": ""
         },
@@ -259,6 +260,17 @@
             "string",
             "null"
           ],
+          "default": null
+        },
+        "sub_packages": {
+          "description": "Groups sub-packages under a single release. Each will share changelog,\ntag, and release, but will receive independent manifest version updates\naccording to their type",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/SubPackage"
+          },
           "default": null
         },
         "prerelease": {
@@ -348,6 +360,35 @@
         "php",
         "ruby",
         "java"
+      ]
+    },
+    "SubPackage": {
+      "description": "Sub-package definition allowing grouping of packages under a parent package\nconfiguration. Sub-packages share changelog, tag, and release with the\nparent package definition but receive independent manifest version file\nupdates according to their defined release type",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name for this sub-package (default derived from path if not provided).\nFor proper manifest version file updates this should match the\ncanonical name field in the release_type manifest file.\ni.e. name = \"...\" in Cargo.toml or \"name\": \"...\" in package.json",
+          "type": "string"
+        },
+        "path": {
+          "description": "Path to the subpackage directory relative to the workspace_root of\nthe parent package",
+          "type": "string"
+        },
+        "release_type": {
+          "description": "[`ReleaseType`] type for determining which version files to update",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ReleaseType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "path"
       ]
     },
     "AdditionalManifestSpec": {

--- a/src/cli/command/show.rs
+++ b/src/cli/command/show.rs
@@ -175,6 +175,7 @@ mod tests {
         },
     };
     use semver::Version as SemVer;
+    use std::rc::Rc;
 
     /// Creates a minimal releasable package for testing
     fn create_releasable_package(
@@ -185,7 +186,7 @@ mod tests {
             name: name.to_string(),
             workspace_root: ".".into(),
             path: ".".into(),
-            release: Release {
+            release: Rc::new(Release {
                 tag: Tag {
                     sha: "test-sha".to_string(),
                     name: format!("v{}", version),
@@ -196,7 +197,7 @@ mod tests {
                 notes: format!("## Changes\n\nRelease {}", version),
                 timestamp: 1234567890,
                 ..Release::default()
-            },
+            }),
             ..ReleasablePackage::default()
         }
     }

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use serde::{Serialize, ser::SerializeStruct};
 
 use crate::{
@@ -6,8 +8,38 @@ use crate::{
     updater::manager::{AdditionalManifestFile, ManifestFile},
 };
 
+#[derive(Debug, Default, Clone)]
+pub struct ReleasableSubPackage {
+    /// The name of this sub-package
+    pub name: String,
+    /// Path to package directory relative to workspace_root path of the
+    /// parent package
+    pub path: String,
+    /// The [`ReleaseType`] for this package
+    pub release_type: ReleaseType,
+    /// Manifest version files specific to this package's release-type
+    pub manifest_files: Option<Vec<ManifestFile>>,
+}
+
+impl ReleasableSubPackage {
+    pub fn to_releasable(
+        &self,
+        parent: &ReleasablePackage,
+    ) -> ReleasablePackage {
+        ReleasablePackage {
+            name: self.name.clone(),
+            path: self.path.clone(),
+            release_type: self.release_type,
+            manifest_files: self.manifest_files.clone(),
+            workspace_root: parent.workspace_root.clone(),
+            release: Rc::clone(&parent.release),
+            ..Default::default()
+        }
+    }
+}
+
 /// Represents a release-able package in manifest
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ReleasablePackage {
     /// The name of this package
     pub name: String,
@@ -16,10 +48,14 @@ pub struct ReleasablePackage {
     /// Path to the workspace root directory for this package relative to the
     /// repository root
     pub workspace_root: String,
+    /// Groups sub-packages under a single release. Each will share changelog,
+    /// tag, and release, but will receive independent manifest version updates
+    /// according to their type
+    pub sub_packages: Vec<ReleasableSubPackage>,
     /// The [`ReleaseType`] for this package
     pub release_type: ReleaseType,
-    /// The computed Release for this package
-    pub release: Release,
+    /// The computed Release for this package (shared via Rc to avoid cloning)
+    pub release: Rc<Release>,
     /// Manifest version files specific to this package's release-type
     pub manifest_files: Option<Vec<ManifestFile>>,
     /// Additional generic version manifest files to update
@@ -39,7 +75,7 @@ impl Serialize for ReleasablePackage {
         s.serialize_field("path", &self.path)?;
         s.serialize_field("workspace_root", &self.workspace_root)?;
         s.serialize_field("release_type", &self.release_type)?;
-        s.serialize_field("release", &self.release)?;
+        s.serialize_field("release", self.release.as_ref())?;
         s.end()
     }
 }

--- a/src/updater/manager.rs
+++ b/src/updater/manager.rs
@@ -200,7 +200,7 @@ impl UpdateManager {
 
     pub fn get_package_manifest_file_changes(
         package: &ReleasablePackage,
-        all_packages: &[ReleasablePackage],
+        all_packages: &[&ReleasablePackage],
     ) -> Result<Vec<FileChange>> {
         let mut file_changes = vec![];
 
@@ -208,18 +208,19 @@ impl UpdateManager {
         // same workspace
         let workspace_packages: Vec<_> = all_packages
             .iter()
-            .filter(|p| {
+            .filter(|&&p| {
                 p.name != package.name
                     && p.workspace_root == package.workspace_root
                     && p.release_type == package.release_type
             })
+            .copied()
             .collect();
 
         let updater_package = UpdaterPackage::from_releasable_package(package);
 
         let workspace_updater_packages = workspace_packages
-            .into_iter()
-            .map(UpdaterPackage::from_releasable_package)
+            .iter()
+            .map(|&p| UpdaterPackage::from_releasable_package(p))
             .collect::<Vec<UpdaterPackage>>();
 
         info!(

--- a/src/updater/rust/cargo_toml.rs
+++ b/src/updater/rust/cargo_toml.rs
@@ -96,7 +96,7 @@ impl PackageUpdater for CargoToml {
                 .cloned()
                 .collect::<Vec<UpdaterPackage>>();
 
-            // loop other packages to check if they current manifest deps
+            // loop other packages to check if they are current manifest deps
             for wkspc_pkg in other_pkgs.iter() {
                 let next_version = wkspc_pkg.next_version.semver.to_string();
 


### PR DESCRIPTION
## Description

Allows users to specifiy sub-packages to group packages under a parent package definition. This means each sub-package definition with share changelog, tag, and release with the parent package but receive independent manifest version file updates according to their defined release_type.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)
