### PR TITLE
fix: fixes issue in tag searches

### DIFF
--- a/src/forge/config.rs
+++ b/src/forge/config.rs
@@ -4,6 +4,8 @@ use secrecy::SecretString;
 
 /// Default number of commits to search when finding releases.
 pub const DEFAULT_COMMIT_SEARCH_DEPTH: u64 = 400;
+/// Default number of tag to search when looking for starting tags
+pub const DEFAULT_TAG_SEARCH_DEPTH: u8 = 100;
 /// Default page size for paginated commit queries
 pub const DEFAULT_PAGE_SIZE: u8 = 50;
 /// Default branch name prefix for release PRs.

--- a/src/forge/gitea/types.rs
+++ b/src/forge/gitea/types.rs
@@ -1,0 +1,155 @@
+use serde::{Deserialize, Serialize};
+
+use crate::forge::request::Commit;
+
+#[derive(Debug, Default, Serialize)]
+pub struct CreateLabel {
+    pub name: String,
+    pub color: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Label {
+    pub id: u64,
+    pub name: String,
+    pub color: String,
+    pub description: String,
+    pub exclusive: bool,
+    pub is_archived: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PullRequestBranch {
+    pub label: String,
+    pub sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaPullRequest {
+    pub number: u64,
+    pub head: PullRequestBranch,
+    pub merge_commit_sha: Option<String>,
+    pub body: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaIssuePr {
+    pub merged: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaIssue {
+    pub number: u64,
+    pub pull_request: GiteaIssuePr,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreatePull {
+    pub title: String,
+    pub body: String,
+    pub head: String,
+    pub base: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdatePullBody {
+    pub title: String,
+    pub body: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct UpdatePullLabels {
+    pub labels: Vec<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreateRelease {
+    pub tag_name: String,
+    pub target_commitish: String,
+    pub name: String,
+    pub body: String,
+    pub draft: bool,
+    pub prerelease: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitAuthor {
+    pub name: String,
+    pub email: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(unused)]
+pub struct GiteaCommitParent {
+    pub sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaCommit {
+    pub author: CommitAuthor,
+    pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaCommitFile {
+    pub filename: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaCommitQueryObject {
+    pub sha: String,
+    pub created: String,
+    pub commit: GiteaCommit,
+    pub files: Vec<GiteaCommitFile>,
+    pub parents: Vec<GiteaCommitParent>,
+    pub html_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaTagCommit {
+    pub created: String,
+    pub sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaTag {
+    pub name: String,
+    pub commit: GiteaTagCommit,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaRelease {
+    pub body: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GiteaFileChangeOperation {
+    Create,
+    Update,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GiteaFileChange {
+    pub path: String,
+    pub content: String,
+    pub operation: GiteaFileChangeOperation,
+    pub sha: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+// TODO: Currently gitea does not support the force option
+// Update once below issue is resolved
+// https://github.com/go-gitea/gitea/issues/35538
+pub struct GiteaModifyFiles {
+    pub old_ref_name: String,
+    pub new_branch: Option<String>,
+    pub message: String,
+    pub files: Vec<GiteaFileChange>,
+    // pub force: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GiteaCreatedCommit {
+    pub commit: Commit,
+}

--- a/src/forge/github/graphql.rs
+++ b/src/forge/github/graphql.rs
@@ -1,0 +1,149 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct PageInfo {
+    #[serde(rename = "endCursor")]
+    pub end_cursor: Option<String>,
+    #[serde(rename = "hasNextPage")]
+    pub has_next_page: bool,
+}
+
+pub const SHA_DATE_QUERY: &str = r#"
+query GetShaDate($owner: String!, $repo: String!, $sha: GitObjectID!) {
+  repository(owner: $owner, name: $repo) {
+    startCommit: object(oid: $sha) {
+      ... on Commit {
+        committedDate
+      }
+    }
+  }
+}"#;
+
+#[derive(Debug, Deserialize)]
+pub struct StartCommit {
+    #[serde(rename = "committedDate")]
+    pub committed_date: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StartCommitRepo {
+    #[serde(rename = "startCommit")]
+    pub start_commit: StartCommit,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StartCommitData {
+    pub repository: StartCommitRepo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StartCommitResult {
+    pub data: StartCommitData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ShaDateQueryVariables {
+    pub owner: String,
+    pub repo: String,
+    pub sha: String,
+}
+
+pub const TAG_SEARCH_QUERY: &str = r#"
+query GetRepoTagsDescending(
+    $owner: String!
+    $repo: String!
+    $first: Int
+    $cursor: String
+) {
+    repository(owner: $owner, name: $repo) {
+        refs(
+            refPrefix: "refs/tags/"
+            first: $first
+            orderBy: { field: TAG_COMMIT_DATE, direction: DESC }
+            after: $cursor
+        ) {
+            nodes {
+                name
+                target {
+                    __typename
+                    ... on Commit {
+                        oid
+                        committedDate
+                    }
+                    ... on Tag {
+                        oid
+                        target {
+                            ... on Commit {
+                                oid
+                                committedDate
+                            }
+                        }
+                    }
+                }
+            }
+            pageInfo {
+                endCursor
+                hasNextPage
+            }
+        }
+    }
+}
+"#;
+
+#[derive(Debug, Deserialize)]
+pub struct TagSearchCommitNestedTarget {
+    pub oid: String,
+    #[serde(rename = "committedDate")]
+    pub committed_date: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub enum TagSearchTypeName {
+    Commit,
+    Tag,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TagSearchCommitTarget {
+    pub __typename: TagSearchTypeName,
+    pub oid: String,
+    #[serde(rename = "committedDate")]
+    pub committed_date: Option<String>,
+    pub target: Option<TagSearchCommitNestedTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TagSearchNode {
+    pub name: String,
+    pub target: TagSearchCommitTarget,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TagSearchRefs {
+    pub nodes: Vec<TagSearchNode>,
+    #[serde(rename = "pageInfo")]
+    pub page_info: PageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TagSearchRepository {
+    pub refs: TagSearchRefs,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TagSearchData {
+    pub repository: TagSearchRepository,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TagSearchResult {
+    pub data: TagSearchData,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TagSearchQueryVariables {
+    pub owner: String,
+    pub repo: String,
+    pub first: usize,
+    pub cursor: Option<String>,
+}

--- a/src/forge/github/types.rs
+++ b/src/forge/github/types.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+pub struct GithubTreeEntry {
+    pub path: String,
+    pub mode: String,
+    pub content: String,
+    #[serde(rename = "type")]
+    pub kind: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct GithubTree {
+    pub base_tree: String,
+    pub tree: Vec<GithubTreeEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Tree {
+    pub sha: String,
+}
+
+pub const TREE_BLOB_MODE: &str = "100644";
+pub const TREE_BLOB_TYPE: &str = "blob";

--- a/src/forge/gitlab/graphql.rs
+++ b/src/forge/gitlab/graphql.rs
@@ -1,0 +1,65 @@
+use graphql_client::{GraphQLQuery, QueryBody};
+use serde::{Deserialize, Serialize};
+
+const COMMIT_DIFF_QUERY: &str = r#"
+query GetCommitDiff($project_id: ID!, $commit_sha: String!) {
+  project(fullPath: $project_id) {
+    repository {
+      commit(ref: $commit_sha) {
+        diffs {
+            newPath
+            oldPath
+        }
+      }
+    }
+  }
+}"#;
+
+#[derive(Debug, Serialize)]
+pub struct CommitDiffQueryVars {
+    pub project_id: String,
+    pub commit_sha: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitFilenameDiff {
+    #[serde(rename = "oldPath")]
+    pub old_path: Option<String>,
+    #[serde(rename = "newPath")]
+    pub new_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitDiffCommit {
+    pub diffs: Vec<CommitFilenameDiff>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitDiffRepository {
+    pub commit: CommitDiffCommit,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitDiffProject {
+    pub repository: CommitDiffRepository,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitDiffResponse {
+    pub project: CommitDiffProject,
+}
+
+pub struct CommitDiffQuery {}
+
+impl GraphQLQuery for CommitDiffQuery {
+    type ResponseData = CommitDiffResponse;
+    type Variables = CommitDiffQueryVars;
+
+    fn build_query(variables: Self::Variables) -> QueryBody<Self::Variables> {
+        QueryBody {
+            variables,
+            query: COMMIT_DIFF_QUERY,
+            operation_name: "GetCommitDiff",
+        }
+    }
+}

--- a/src/forge/gitlab/types.rs
+++ b/src/forge/gitlab/types.rs
@@ -1,0 +1,50 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct FileInfo {
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MergeRequestInfo {
+    pub iid: u64,
+    pub merge_commit_sha: Option<String>,
+    pub sha: String,
+    pub merged_at: Option<String>,
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LabelInfo {
+    pub name: String,
+}
+
+/// Information about a commit associated with a release.
+#[derive(Debug, Deserialize)]
+pub struct GitlabCommit {
+    pub id: String,
+    pub message: String,
+    pub author_name: String,
+    pub author_email: String,
+    pub parent_ids: Vec<String>,
+    pub created_at: String,
+    pub web_url: String,
+}
+
+/// Represents a Gitlab project Tag
+#[derive(Debug, Deserialize)]
+pub struct GitlabTag {
+    pub name: String,
+    pub commit: GitlabCommit,
+}
+
+/// Represents a Gitlab release
+#[derive(Debug, Deserialize)]
+pub struct GitlabRelease {
+    pub description: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreatedCommit {
+    pub id: String,
+}

--- a/src/forge/tests/common/run.rs
+++ b/src/forge/tests/common/run.rs
@@ -138,7 +138,8 @@ pub async fn run_forge_test(
         pr_number: release_pr.number,
     };
     forge.replace_pr_labels(replace_labels_req).await.unwrap();
-    sleep(padding).await;
+    // extra padding here
+    sleep(padding * 10).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_open_release_pr -> Found
@@ -171,7 +172,8 @@ pub async fn run_forge_test(
     ////////////////////////////////////////////////////////////////////////////
     log::info!("merging release PR via helper");
     helper.merge_pr(release_pr.number).await.unwrap();
-    sleep(padding).await;
+    // extra padding here
+    sleep(padding * 10).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_merged_release_pr -> Found

--- a/src/forge/tests/github.rs
+++ b/src/forge/tests/github.rs
@@ -30,5 +30,5 @@ async fn test_github_forge() {
             .unwrap();
     let helper = GithubForgeTestHelper::new(&repo, &token, &reset_sha).await;
 
-    run_forge_test(&gitea_forge, &helper, Duration::from_millis(20000)).await;
+    run_forge_test(&gitea_forge, &helper, Duration::from_millis(2000)).await;
 }


### PR DESCRIPTION
## Description

In Gitlab we ensure tags are sorted by descending semantic version to
make sure we're always looking at the latest tag for a version.

In Github we switch to performing a graphql query which allows us to
sort by tag commit date descendingly. From here we can pick the first
that matches prefix as it will be the latest by date.

In Gitea we perform a client side sort on tags according to their
semantic version to find the latest for a prefix.

In all forges we are limiting the search depth for tags to 100 as this
should be suffienct for finding the latest based on rules used to fetch
- commit date descending: github
- tag created date descending: gitea
- semantic descending: gitlab

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)
