### PR TITLE
refactor: parses straight to GitUrl from cli

### DIFF
--- a/src/forge/config.rs
+++ b/src/forge/config.rs
@@ -1,5 +1,6 @@
 //! Configuration for Git forge platform connections.
 use derive_builder::Builder;
+use git_url_parse::GitUrl;
 use secrecy::SecretString;
 
 /// Default number of commits to search when finding releases.
@@ -64,7 +65,7 @@ pub enum Remote {
     Github(RemoteConfig),
     Gitlab(RemoteConfig),
     Gitea(RemoteConfig),
-    Local(String),
+    Local(GitUrl),
 }
 
 #[cfg(test)]

--- a/src/forge/factory.rs
+++ b/src/forge/factory.rs
@@ -1,5 +1,8 @@
 //! Factory for creating forge implementations based on configuration.
 
+use git_url_parse::GitUrl;
+use std::path::Path;
+
 use crate::{
     Result,
     forge::{
@@ -44,7 +47,7 @@ impl ForgeFactory {
         Ok(Box::new(Gitea::new(config.clone()).await?))
     }
 
-    fn create_local(repo_path: &str) -> Result<Box<dyn Forge>> {
-        Ok(Box::new(LocalRepo::new(repo_path.to_string())?))
+    fn create_local(repo: &GitUrl) -> Result<Box<dyn Forge>> {
+        Ok(Box::new(LocalRepo::new(Path::new(&repo.path))?))
     }
 }

--- a/src/forge/tests/common/gitea.rs
+++ b/src/forge/tests/common/gitea.rs
@@ -38,9 +38,7 @@ pub struct GiteaForgeTestHelper {
 }
 
 impl GiteaForgeTestHelper {
-    pub async fn new(repo: &str, token: &str, reset_sha: &str) -> Self {
-        let parsed = GitUrl::parse(repo).unwrap();
-
+    pub async fn new(repo: &GitUrl, token: &str, reset_sha: &str) -> Self {
         let mut headers = HeaderMap::new();
 
         let token_value =
@@ -53,17 +51,17 @@ impl GiteaForgeTestHelper {
             .build()
             .unwrap();
 
-        let host = parsed.host.unwrap();
+        let host = repo.host.as_ref().unwrap().clone();
 
         let mut base_url = format!(
             "{}://{}/api/v1/repos/{}/",
-            parsed.scheme, host, parsed.fullname
+            repo.scheme, host, repo.fullname
         );
 
-        if let Some(port) = parsed.port {
+        if let Some(port) = repo.port {
             base_url = format!(
                 "{}://{}:{}/api/v1/repos/{}/",
-                parsed.scheme, host, port, parsed.fullname
+                repo.scheme, host, port, repo.fullname
             );
         }
 

--- a/src/forge/tests/common/github.rs
+++ b/src/forge/tests/common/github.rs
@@ -18,14 +18,12 @@ pub struct GithubForgeTestHelper {
 }
 
 impl GithubForgeTestHelper {
-    pub async fn new(repo: &str, token: &str, reset_sha: &str) -> Self {
-        let parsed = GitUrl::parse(repo).unwrap();
+    pub async fn new(repo: &GitUrl, token: &str, reset_sha: &str) -> Self {
+        let host = repo.host.as_ref().unwrap().clone();
+        let owner = repo.owner.as_ref().unwrap().clone();
+        let repo_str = repo.name.clone();
 
-        let host = parsed.host.unwrap();
-        let owner = parsed.owner.unwrap();
-        let repo_str = parsed.name;
-
-        let base_uri = format!("{}://api.{}", parsed.scheme, host);
+        let base_uri = format!("{}://api.{}", repo.scheme, host);
 
         let builder = Octocrab::builder()
             .personal_token(token)

--- a/src/forge/tests/common/gitlab.rs
+++ b/src/forge/tests/common/gitlab.rs
@@ -121,11 +121,9 @@ pub struct GitlabForgeTestHelper {
 }
 
 impl GitlabForgeTestHelper {
-    pub async fn new(repo: &str, token: &str, reset_sha: &str) -> Self {
-        let parsed = GitUrl::parse(repo).unwrap();
-
-        let host = parsed.host.unwrap();
-        let project_id = parsed.fullname.clone();
+    pub async fn new(repo: &GitUrl, token: &str, reset_sha: &str) -> Self {
+        let host = repo.host.as_ref().unwrap().clone();
+        let project_id = repo.fullname.clone();
 
         let gl = gitlab::GitlabBuilder::new(host, token)
             .build_async()

--- a/src/forge/tests/gitea.rs
+++ b/src/forge/tests/gitea.rs
@@ -1,3 +1,4 @@
+use git_url_parse::GitUrl;
 use std::env;
 use tokio::time::Duration;
 
@@ -13,7 +14,7 @@ use crate::{
 #[tokio::test]
 #[test_log::test]
 async fn test_gitea_forge() {
-    let repo = env::var("GITEA_TEST_REPO").unwrap();
+    let repo = GitUrl::parse(&env::var("GITEA_TEST_REPO").unwrap()).unwrap();
     let token = env::var("GITEA_TEST_TOKEN").unwrap();
     let reset_sha = env::var("GITEA_RESET_SHA").unwrap();
 

--- a/src/forge/tests/github.rs
+++ b/src/forge/tests/github.rs
@@ -1,3 +1,4 @@
+use git_url_parse::GitUrl;
 use std::env;
 use tokio::time::Duration;
 
@@ -13,7 +14,7 @@ use crate::{
 #[tokio::test]
 #[test_log::test]
 async fn test_github_forge() {
-    let repo = env::var("GITHUB_TEST_REPO").unwrap();
+    let repo = GitUrl::parse(&env::var("GITHUB_TEST_REPO").unwrap()).unwrap();
     let token = env::var("GITHUB_TEST_TOKEN").unwrap();
     let reset_sha = env::var("GITHUB_RESET_SHA").unwrap();
 

--- a/src/forge/tests/gitlab.rs
+++ b/src/forge/tests/gitlab.rs
@@ -1,3 +1,4 @@
+use git_url_parse::GitUrl;
 use std::env;
 use tokio::time::Duration;
 
@@ -13,7 +14,7 @@ use crate::{
 #[tokio::test]
 #[test_log::test]
 async fn test_gitlab_forge() {
-    let repo = env::var("GITLAB_TEST_REPO").unwrap();
+    let repo = GitUrl::parse(&env::var("GITLAB_TEST_REPO").unwrap()).unwrap();
     let token = env::var("GITLAB_TEST_TOKEN").unwrap();
     let reset_sha = env::var("GITLAB_RESET_SHA").unwrap();
 


### PR DESCRIPTION
## Description

Parses directly to GitUrl from provided Cli arg and avoids the unnecessary step of manually calling GitUrl::parse. Additionally this commit passes a Path type to the Local forge implementation which has better type safety and ergonomics.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Chore: refactor

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)


