### PR TITLE
doc: fix gitlab ci/cd example

### DIFF
--- a/book/src/ci-cd-integration.md
+++ b/book/src/ci-cd-integration.md
@@ -51,7 +51,15 @@ jobs:
 
 ## GitLab CI
 
-Use the Releasaurus Docker image directly in your `.gitlab-ci.yml`. Ensure that you have a CI/CD variable named `GITLAB_TOKEN` with the Maintainer role and following scopes: api, read_api, read_repository, write_repository.
+Use the Releasaurus Docker image directly in your `.gitlab-ci.yml`.
+You may provide authentication token either by specifying a CI/CD variable named
+`GITLAB_TOKEN`, or by directly passing the `--token` option with reference to
+your defined variable, i.e. `--token $RELEASE_TOKEN`
+
+**Required Scopes**:
+
+- `api` (full API access)
+- `write_repository` (repository write access)
 
 ### Example
 
@@ -61,6 +69,7 @@ publish-release:
     name: rgonnella/releasaurus:vX.X.X
     entrypoint: [""]
   script:
+    # Assumes use of $GITLAB_TOKEN var for token authentication
     - releasaurus release --forge gitlab --repo $CI_PROJECT_URL
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
@@ -70,7 +79,8 @@ release-pr:
     name: rgonnella/releasaurus:vX.X.X
     entrypoint: [""]
   script:
-    - releasaurus release-pr --forge gitlab --repo $CI_PROJECT_URL
+    # Uses custom var for token authentication
+    - releasaurus release-pr --forge gitlab --repo $CI_PROJECT_URL --token $RELEASE_TOKEN
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```

--- a/book/src/environment-variables.md
+++ b/book/src/environment-variables.md
@@ -69,7 +69,6 @@ releasaurus release-pr \
 **Required Scopes**:
 
 - `api` (full API access)
-- `read_repository` (repository read access)
 - `write_repository` (repository write access)
 
 **Token Types**:


### PR DESCRIPTION
## Description

GitLab CI/CD example updated to clarify the need for a `GITLAB_TOKEN` variable without explicitly defining it in the CI `environment` block. Doing this actually overwrites the variable with an empty string.

## Type of Change

- ~Bug fix (non-breaking change fixing an issue)~
- ~New feature (non-breaking change adding functionality)~
- ~Breaking change (fix or feature causing existing functionality to change)~
- [X] Documentation update

## Testing

- ~Unit tests pass~
- ~Integration tests pass (if applicable)~
- [X] Manual testing completed
- [X] Documentation tested (if applicable)

## Related Issues
N/A

## Additional Notes
N/A