### PR TITLE
fix: ensures tag is ancestor of target branch

### DIFF
--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -167,6 +167,28 @@ impl Gitea {
         let label: Label = result.json().await?;
         Ok(label)
     }
+
+    /// Returns true if `tag_sha` is an ancestor of `branch`. Uses the
+    /// Gitea compare API: `total_commits == 0` when base=branch, head=tag
+    /// means the tag has no commits that the branch doesn't, so the tag
+    /// is fully contained within the branch's history.
+    async fn is_tag_ancestor_of_branch(
+        &self,
+        tag_sha: &str,
+        branch: &str,
+    ) -> Result<bool> {
+        let compare_url = Url::parse(&format!(
+            "{}compare/{}...{}",
+            self.base_url.as_str(),
+            branch,
+            tag_sha,
+        ))?;
+        let request = self.client.get(compare_url).build()?;
+        let response = self.client.execute(request).await?;
+        let result: serde_json::Value =
+            response.error_for_status()?.json().await?;
+        Ok(result["total_commits"].as_u64() == Some(0))
+    }
 }
 
 #[async_trait]
@@ -266,10 +288,13 @@ impl Forge for Gitea {
         })
     }
 
-    // Note: Tags are returned in reverse chronological order
+    // Note: Tags are returned in reverse chronological order. We return the
+    // first tag (by semver descending) that matches the prefix AND is an
+    // ancestor of the target base branch.
     async fn get_latest_tag_for_prefix(
         &self,
         prefix: &str,
+        branch: &str,
     ) -> Result<Option<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
         let mut has_more = true;
@@ -322,22 +347,29 @@ impl Forge for Gitea {
         }
 
         // tags are returned in reverse chronological order (newest first),
-        // which means the could be out of order, so here we sort by
+        // which means they could be out of order, so here we sort by
         // semantic version (descending) to get latest
         tag_matches.sort_by(|a, b| b.1.cmp(&a.1));
 
-        if let Some((tag, sver)) = tag_matches.first() {
-            return Ok(Some(Tag {
-                name: tag.name.clone(),
-                semver: sver.clone(),
-                sha: tag.commit.sha.clone(),
-                timestamp: DateTime::parse_from_rfc3339(&tag.commit.created)
+        for (tag, sver) in tag_matches.into_iter() {
+            if self
+                .is_tag_ancestor_of_branch(&tag.commit.sha, branch)
+                .await?
+            {
+                return Ok(Some(Tag {
+                    name: tag.name.clone(),
+                    semver: sver.clone(),
+                    sha: tag.commit.sha.clone(),
+                    timestamp: DateTime::parse_from_rfc3339(
+                        &tag.commit.created,
+                    )
                     .map(|t| t.timestamp())
                     .ok(),
-            }));
-        } else {
-            Ok(None)
+                }));
+            }
         }
+
+        Ok(None)
     }
 
     async fn get_commits(

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -200,6 +200,25 @@ impl Github {
 
         Ok(commit)
     }
+
+    /// Returns true if `tag_sha` is an ancestor of `branch` (i.e., the
+    /// branch has the tag in its history). Uses the GitHub compare API:
+    /// `ahead_by == 0` when base=branch, head=tag means the tag has no
+    /// commits that the branch doesn't, so the tag is fully contained
+    /// within the branch's history.
+    async fn is_tag_ancestor_of_branch(
+        &self,
+        tag_sha: &str,
+        branch: &str,
+    ) -> Result<bool> {
+        let endpoint = format!(
+            "{}/repos/{}/{}/compare/{}...{}",
+            self.base_uri, self.config.owner, self.config.repo, branch, tag_sha,
+        );
+        let result: serde_json::Value =
+            self.instance.get(endpoint, None::<&()>).await?;
+        Ok(result["ahead_by"].as_u64() == Some(0))
+    }
 }
 
 #[async_trait]
@@ -337,10 +356,12 @@ impl Forge for Github {
     }
 
     // Note: we use graphql query with tags sorted by commit date descending.
-    // This allows us to just grab the first one that matches target prefix
+    // We return the first tag that matches the prefix AND is an ancestor of
+    // the target base branch.
     async fn get_latest_tag_for_prefix(
         &self,
         prefix: &str,
+        branch: &str,
     ) -> Result<Option<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
 
@@ -392,16 +413,18 @@ impl Forge for Github {
                                     .unwrap_or_default(),
                             );
 
-                        return Ok(Some(Tag {
-                            name: tag.name,
-                            semver: sver,
-                            sha,
-                            timestamp: DateTime::parse_from_rfc3339(
-                                &committed_date,
-                            )
-                            .map(|t| t.timestamp())
-                            .ok(),
-                        }));
+                        if self.is_tag_ancestor_of_branch(&sha, branch).await? {
+                            return Ok(Some(Tag {
+                                name: tag.name,
+                                semver: sver,
+                                sha,
+                                timestamp: DateTime::parse_from_rfc3339(
+                                    &committed_date,
+                                )
+                                .map(|t| t.timestamp())
+                                .ok(),
+                            }));
+                        }
                     }
                 }
             }

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -20,6 +20,7 @@ use gitlab::{
             },
             releases::{CreateRelease, ProjectReleaseByTag},
             repository::{
+                commits::CompareCommits,
                 commits::{
                     CommitAction, CommitActionType, Commits, CommitsOrder,
                     CreateCommit,
@@ -149,6 +150,25 @@ impl Gitlab {
         let label: LabelInfo = endpoint.query_async(&self.gl).await?;
 
         Ok(label)
+    }
+
+    /// Returns true if `tag_sha` is an ancestor of `branch`. Uses the
+    /// GitLab compare API: commits in tag (to) not in branch (from) is
+    /// empty when the tag is fully contained within the branch's history.
+    async fn is_tag_ancestor_of_branch(
+        &self,
+        tag_sha: &str,
+        branch: &str,
+    ) -> Result<bool> {
+        let endpoint = CompareCommits::builder()
+            .project(&self.project_id)
+            .from(branch)
+            .to(tag_sha)
+            .build()
+            .map_err(|e| ReleasaurusError::forge(e.to_string()))?;
+        let result: serde_json::Value = endpoint.query_async(&self.gl).await?;
+        let commits = result["commits"].as_array();
+        Ok(commits.map(|c| c.is_empty()).unwrap_or(false))
     }
 }
 
@@ -307,11 +327,13 @@ impl Forge for Gitlab {
         }
     }
 
-    // Note: Our query orders tags by semantic version descending so we can just
-    // grab the first that matches the target prefix
+    // Note: Our query orders tags by semantic version descending. We return
+    // the first tag that matches the prefix AND is an ancestor of the target
+    // base branch.
     async fn get_latest_tag_for_prefix(
         &self,
         prefix: &str,
+        branch: &str,
     ) -> Result<Option<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
         let endpoint = Tags::builder()
@@ -328,7 +350,11 @@ impl Forge for Gitlab {
         for t in tags.into_iter() {
             if re.is_match(&t.name) {
                 let stripped = re.replace_all(&t.name, "").to_string();
-                if let Ok(sver) = semver::Version::parse(&stripped) {
+                if let Ok(sver) = semver::Version::parse(&stripped)
+                    && self
+                        .is_tag_ancestor_of_branch(&t.commit.id, branch)
+                        .await?
+                {
                     return Ok(Some(Tag {
                         name: t.name,
                         semver: sver,

--- a/src/forge/local.rs
+++ b/src/forge/local.rs
@@ -1,7 +1,7 @@
 //! Local forge implementation for offline development and testing.
 use async_trait::async_trait;
 use color_eyre::eyre::{Context, OptionExt};
-use git2::{Commit as Git2Commit, Sort, TreeWalkMode};
+use git2::{BranchType, Commit as Git2Commit, Sort, TreeWalkMode};
 use regex::Regex;
 use std::{
     path::{self, Path, PathBuf},
@@ -150,6 +150,7 @@ impl Forge for LocalRepo {
     async fn get_latest_tag_for_prefix(
         &self,
         prefix: &str,
+        branch: &str,
     ) -> Result<Option<Tag>> {
         let regex_prefix = format!(r"^{}", prefix);
         let tag_prefix_regex = Regex::new(&regex_prefix)?;
@@ -184,6 +185,28 @@ impl Forge for LocalRepo {
                 commits.push((commit, tag));
             }
         }
+
+        if commits.is_empty() {
+            return Ok(None);
+        }
+
+        let branch_head_oid = repo
+            .find_branch(branch, BranchType::Local)?
+            .get()
+            .peel_to_commit()?
+            .id();
+
+        // Keep only tags that are ancestors of the branch head.
+        // graph_descendant_of(a, b) returns true if a is a descendant of b,
+        // so graph_descendant_of(branch_head, tag) means tag is an ancestor
+        // of branch_head. We also include the case where the tag IS the
+        // branch head (e.g., immediately after a release is tagged).
+        commits.retain(|(commit, _)| {
+            commit.id() == branch_head_oid
+                || repo
+                    .graph_descendant_of(branch_head_oid, commit.id())
+                    .unwrap_or(false)
+        });
 
         if commits.is_empty() {
             return Ok(None);
@@ -377,5 +400,103 @@ impl Forge for LocalRepo {
             "local_mode: would create release: tag: {tag}, sha: {sha}, notes: {notes}"
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Creates a commit on whatever HEAD currently points to.
+    /// For the very first commit (unborn branch) pass no parent —
+    /// git2 handles that transparently via HEAD resolution.
+    fn add_commit(repo: &git2::Repository, message: &str) -> git2::Oid {
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let mut index = repo.index().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parent = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+        let parents: Vec<_> = parent.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents)
+            .unwrap()
+    }
+
+    fn tag_oid(repo: &git2::Repository, name: &str, oid: git2::Oid) {
+        let obj = repo.find_object(oid, None).unwrap();
+        repo.tag_lightweight(name, &obj, false).unwrap();
+    }
+
+    fn default_branch(repo: &git2::Repository) -> String {
+        repo.head().unwrap().shorthand().unwrap().to_string()
+    }
+
+    /// Regression test: a tag that points to the exact same commit
+    /// as the branch head must be returned. Previously,
+    /// `graph_descendant_of` (a strict check) would return `false`
+    /// here and the tag was wrongly filtered out.
+    #[tokio::test]
+    async fn tag_at_branch_head_is_found() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let oid = add_commit(&repo, "initial commit");
+        tag_oid(&repo, "v1.0.0", oid);
+        let branch = default_branch(&repo);
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path()).unwrap();
+        let result =
+            forge.get_latest_tag_for_prefix("v", &branch).await.unwrap();
+
+        assert!(result.is_some(), "tag at branch head should be found");
+        assert_eq!(result.unwrap().name, "v1.0.0");
+    }
+
+    /// A tag that lives on a divergent branch must NOT be returned
+    /// when querying a branch that does not have that commit in its
+    /// history.
+    #[tokio::test]
+    async fn tag_on_divergent_branch_is_excluded() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        // Commit on the main branch and tag it v1.0.0.
+        let base_oid = add_commit(&repo, "initial commit");
+        tag_oid(&repo, "v1.0.0", base_oid);
+        let main_branch = default_branch(&repo);
+
+        // Create a divergent branch from that same base commit,
+        // add a commit there, and tag it v2.0.0.
+        {
+            let base_commit = repo.find_commit(base_oid).unwrap();
+            repo.branch("other", &base_commit, false).unwrap();
+        }
+        repo.set_head("refs/heads/other").unwrap();
+        let divergent_oid = add_commit(&repo, "divergent commit");
+        tag_oid(&repo, "v2.0.0", divergent_oid);
+
+        // Restore HEAD to the main branch before handing off to
+        // LocalRepo so it detects the correct default branch.
+        repo.set_head(&format!("refs/heads/{main_branch}")).unwrap();
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path()).unwrap();
+
+        // Querying main_branch must return v1.0.0 only; v2.0.0 is
+        // not in main_branch's history.
+        let result = forge
+            .get_latest_tag_for_prefix("v", &main_branch)
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_some(),
+            "v1.0.0 (ancestor of main) should be found"
+        );
+        assert_eq!(
+            result.unwrap().name,
+            "v1.0.0",
+            "v2.0.0 (only on divergent branch) must be excluded"
+        );
     }
 }

--- a/src/forge/manager.rs
+++ b/src/forge/manager.rs
@@ -102,8 +102,9 @@ impl ForgeManager {
     pub async fn get_latest_tag_for_prefix(
         &self,
         prefix: &str,
+        branch: &str,
     ) -> Result<Option<Tag>> {
-        self.forge.get_latest_tag_for_prefix(prefix).await
+        self.forge.get_latest_tag_for_prefix(prefix, branch).await
     }
 
     pub async fn get_commits(

--- a/src/forge/tests/common/run.rs
+++ b/src/forge/tests/common/run.rs
@@ -16,10 +16,12 @@ use crate::{
     },
 };
 
+const SHORT_WAIT: Duration = Duration::from_secs(2);
+const LONG_WAIT: Duration = Duration::from_secs(20);
+
 pub async fn run_forge_test(
     forge: &ForgeManager,
     helper: &dyn ForgeTestHelper,
-    padding: Duration,
 ) {
     log::info!("resetting repository");
     helper.reset().await.unwrap();
@@ -56,7 +58,29 @@ pub async fn run_forge_test(
 
     let created_commit = forge.create_commit(create_commit_req).await.unwrap();
     assert!(!created_commit.sha.is_empty());
-    sleep(padding).await;
+    sleep(SHORT_WAIT).await;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // create_release_branch forked here (before the release tag) so
+    // we can later assert the tag is invisible on this branch
+    ////////////////////////////////////////////////////////////////////////////
+    let pre_tag_branch = "pre-tag-branch";
+    log::info!("creating pre-tag-branch before release merge");
+    let pre_tag_branch_req = CreateReleaseBranchRequest {
+        base_branch: default_branch.to_string(),
+        message: "chore: pre-tag branch".into(),
+        release_branch: pre_tag_branch.to_string(),
+        file_changes: vec![FileChange {
+            content: "pre-tag".to_string(),
+            path: "pre-tag.txt".into(),
+            update_type: FileUpdateType::Replace,
+        }],
+    };
+    forge
+        .create_release_branch(pre_tag_branch_req)
+        .await
+        .unwrap();
+    sleep(SHORT_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_commits -> succeeds
@@ -98,7 +122,7 @@ pub async fn run_forge_test(
         .await
         .unwrap();
     assert!(!release_commit.sha.is_empty());
-    sleep(padding).await;
+    sleep(SHORT_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_open_release_pr: expect -> None
@@ -127,7 +151,7 @@ pub async fn run_forge_test(
     assert_ne!(release_pr.number, 0);
     assert!(!release_pr.body.is_empty());
     assert!(!release_pr.sha.is_empty());
-    sleep(padding).await;
+    sleep(SHORT_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // replace_pr_labels -> succeeds
@@ -139,7 +163,7 @@ pub async fn run_forge_test(
     };
     forge.replace_pr_labels(replace_labels_req).await.unwrap();
     // extra padding here
-    sleep(padding * 10).await;
+    sleep(LONG_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_open_release_pr -> Found
@@ -173,7 +197,7 @@ pub async fn run_forge_test(
     log::info!("merging release PR via helper");
     helper.merge_pr(release_pr.number).await.unwrap();
     // extra padding here
-    sleep(padding * 10).await;
+    sleep(LONG_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_merged_release_pr -> Found
@@ -196,7 +220,10 @@ pub async fn run_forge_test(
     log::info!("looking for non-existent tag by prefix");
     let semver = "1.1.0";
     let tag = format!("v{}", semver);
-    let current_tag = forge.get_latest_tag_for_prefix("v").await.unwrap();
+    let current_tag = forge
+        .get_latest_tag_for_prefix("v", default_branch)
+        .await
+        .unwrap();
     assert!(current_tag.is_none());
 
     ////////////////////////////////////////////////////////////////////////////
@@ -204,18 +231,38 @@ pub async fn run_forge_test(
     ////////////////////////////////////////////////////////////////////////////
     log::info!("tagging commit");
     forge.tag_commit(&tag, &merged_pr.sha).await.unwrap();
-    sleep(padding).await;
+    sleep(SHORT_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_latest_tag_for_prefix -> Found
     ////////////////////////////////////////////////////////////////////////////
     log::info!("looking for newly tagged commit by prefix");
-    let current_tag = forge.get_latest_tag_for_prefix("v").await.unwrap();
+    let current_tag = forge
+        .get_latest_tag_for_prefix("v", default_branch)
+        .await
+        .unwrap();
     assert!(current_tag.is_some());
     let current_tag = current_tag.unwrap();
     assert_eq!(current_tag.name, tag);
     assert_eq!(current_tag.semver, Version::parse(semver).unwrap());
     assert_eq!(current_tag.sha, merged_pr.sha);
+
+    ////////////////////////////////////////////////////////////////////////////
+    // get_latest_tag_for_prefix on pre-tag-branch -> None
+    //
+    // pre-tag-branch was forked before the release merge, so the tag
+    // commit is not in its ancestry and must not be returned.
+    ////////////////////////////////////////////////////////////////////////////
+    log::info!("verifying tag is not visible on branch forked before release");
+    let pre_tag_result = forge
+        .get_latest_tag_for_prefix("v", pre_tag_branch)
+        .await
+        .unwrap();
+    assert!(
+        pre_tag_result.is_none(),
+        "tag must not appear on a branch that diverged before it \
+         was created"
+    );
 
     ////////////////////////////////////////////////////////////////////////////
     // get_release_by_tag -> Err Not Found
@@ -235,7 +282,7 @@ pub async fn run_forge_test(
         .create_release(&current_tag.name, &current_tag.sha, "release notes")
         .await
         .unwrap();
-    sleep(padding).await;
+    sleep(SHORT_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
     // get_release_by_tag -> Found
@@ -279,7 +326,7 @@ pub async fn run_forge_test(
     log::info!("loading newly created releasaurus config file");
     let created_commit = forge.create_commit(create_commit_req).await.unwrap();
     assert!(!created_commit.sha.is_empty());
-    sleep(padding).await;
+    sleep(SHORT_WAIT).await;
 
     let config = forge
         .load_config(Some(default_branch.to_string()))

--- a/src/forge/tests/gitea.rs
+++ b/src/forge/tests/gitea.rs
@@ -1,7 +1,6 @@
 use git_url_parse::GitUrl;
 use secrecy::SecretString;
 use std::env;
-use tokio::time::Duration;
 
 use crate::{
     ForgeManager,
@@ -33,5 +32,5 @@ async fn test_gitea_forge() {
 
     let helper = GiteaForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
 
-    run_forge_test(&manager, &helper, Duration::from_millis(2000)).await;
+    run_forge_test(&manager, &helper).await;
 }

--- a/src/forge/tests/github.rs
+++ b/src/forge/tests/github.rs
@@ -1,7 +1,6 @@
 use git_url_parse::GitUrl;
 use secrecy::SecretString;
 use std::env;
-use tokio::time::Duration;
 
 use crate::{
     ForgeManager,
@@ -33,5 +32,5 @@ async fn test_github_forge() {
     let helper =
         GithubForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
 
-    run_forge_test(&manager, &helper, Duration::from_millis(2000)).await;
+    run_forge_test(&manager, &helper).await;
 }

--- a/src/forge/tests/gitlab.rs
+++ b/src/forge/tests/gitlab.rs
@@ -1,7 +1,6 @@
 use git_url_parse::GitUrl;
 use secrecy::SecretString;
 use std::env;
-use tokio::time::Duration;
 
 use crate::{
     ForgeManager,
@@ -33,5 +32,5 @@ async fn test_gitlab_forge() {
     let helper =
         GitlabForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
 
-    run_forge_test(&manager, &helper, Duration::from_millis(2000)).await;
+    run_forge_test(&manager, &helper).await;
 }

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -54,10 +54,11 @@ pub trait Forge: Any + Send + Sync {
     /// Create a git tag pointing to a specific commit SHA.
     async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()>;
     /// Find the most recent tag matching the given prefix (e.g., "v" or
-    /// "api-v").
+    /// "api-v") that is an ancestor of the given branch.
     async fn get_latest_tag_for_prefix(
         &self,
         prefix: &str,
+        branch: &str,
     ) -> Result<Option<Tag>>;
     /// Fetch commits for a package path, optionally starting from a specific
     /// SHA.

--- a/src/orchestrator.rs
+++ b/src/orchestrator.rs
@@ -290,7 +290,10 @@ impl Orchestrator {
 
             let current = self
                 .forge
-                .get_latest_tag_for_prefix(&package.tag_prefix)
+                .get_latest_tag_for_prefix(
+                    &package.tag_prefix,
+                    &self.config.base_branch,
+                )
                 .await?;
 
             if let Some(tag) = current {

--- a/src/orchestrator/commits.rs
+++ b/src/orchestrator/commits.rs
@@ -131,7 +131,10 @@ impl CommitsCore {
             }
             let current_tag = self
                 .forge
-                .get_latest_tag_for_prefix(&package.tag_prefix)
+                .get_latest_tag_for_prefix(
+                    &package.tag_prefix,
+                    &self.orchestrator_config.base_branch,
+                )
                 .await?;
 
             let current_sha = current_tag.as_ref().map(|t| t.sha.clone());
@@ -175,7 +178,10 @@ impl CommitsCore {
             }
             if let Some(tag) = self
                 .forge
-                .get_latest_tag_for_prefix(&package.tag_prefix)
+                .get_latest_tag_for_prefix(
+                    &package.tag_prefix,
+                    &self.orchestrator_config.base_branch,
+                )
                 .await?
                 && let Some(timestamp) = tag.timestamp
             {
@@ -523,7 +529,7 @@ mod tests {
         mock_forge
             .expect_get_latest_tag_for_prefix()
             .times(2)
-            .returning(|prefix| {
+            .returning(|prefix, _branch| {
                 if prefix.contains("pkg-a") {
                     // pkg-a has newer tag (timestamp 2000)
                     Ok(Some(Tag {
@@ -626,7 +632,7 @@ mod tests {
         mock_forge
             .expect_get_latest_tag_for_prefix()
             .times(3..=4) // Allow either 3 or 4 calls depending on hash order
-            .returning(|prefix| {
+            .returning(|prefix, _branch| {
                 if prefix.contains("pkg-a") {
                     Ok(Some(Tag {
                         sha: "some-sha".to_string(),

--- a/src/orchestrator/core.rs
+++ b/src/orchestrator/core.rs
@@ -93,7 +93,10 @@ impl Core {
 
             let current_tag = self
                 .forge
-                .get_latest_tag_for_prefix(&pkg.tag_prefix)
+                .get_latest_tag_for_prefix(
+                    &pkg.tag_prefix,
+                    &self.config.base_branch,
+                )
                 .await?;
 
             if current_tag.is_none() {
@@ -141,7 +144,10 @@ impl Core {
             }
             let current_tag = self
                 .forge
-                .get_latest_tag_for_prefix(&package.tag_prefix)
+                .get_latest_tag_for_prefix(
+                    &package.tag_prefix,
+                    &self.config.base_branch,
+                )
                 .await?;
             let commits = self.commits_core.filter_commits_for_package(
                 package,

--- a/src/orchestrator/core/tests/prepare.rs
+++ b/src/orchestrator/core/tests/prepare.rs
@@ -17,7 +17,7 @@ async fn generate_prepared_with_dummy_commit_skips_untagged_packages() {
 
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| Ok(None)); // No tags exist
+        .returning(|_, _| Ok(None)); // No tags exist
 
     let orchestrator = create_core(mock_forge, None, None);
 
@@ -46,15 +46,15 @@ async fn generate_prepared_with_dummy_commit_filters_by_targets() {
 
     let mut mock_forge = MockForge::new();
 
-    mock_forge
-        .expect_get_latest_tag_for_prefix()
-        .returning(|prefix| {
+    mock_forge.expect_get_latest_tag_for_prefix().returning(
+        |prefix, _branch| {
             Ok(Some(Tag {
                 name: format!("{prefix}1.0.0"),
                 timestamp: Some(1000),
                 ..Default::default()
             }))
-        });
+        },
+    );
 
     let orchestrator = create_core(mock_forge, Some(pkg_configs), None);
 

--- a/src/orchestrator/tests/current_releases.rs
+++ b/src/orchestrator/tests/current_releases.rs
@@ -22,7 +22,7 @@ async fn get_current_releases_retrieves_release_data() {
 
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| {
+        .returning(|_, _| {
             Ok(Some(Tag {
                 name: "v1.0.0".to_string(),
                 ..Default::default()
@@ -55,7 +55,7 @@ async fn get_next_releases_filters_by_package_name() {
 
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| Ok(None));
+        .returning(|_, _| Ok(None));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![

--- a/src/orchestrator/tests/next_release.rs
+++ b/src/orchestrator/tests/next_release.rs
@@ -20,7 +20,7 @@ async fn start_next_release_creates_commits_for_tagged_packages() {
 
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| {
+        .returning(|_, _| {
             Ok(Some(Tag {
                 semver: Version::parse("1.0.0").unwrap(),
                 ..Default::default()
@@ -52,7 +52,7 @@ async fn start_next_release_filters_by_target_packages() {
     mock_forge
         .expect_get_latest_tag_for_prefix()
         .times(2)
-        .returning(|prefix| {
+        .returning(|prefix, _branch| {
             if prefix.contains("pkg-a") {
                 Ok(Some(Tag {
                     semver: Version::parse("1.0.0").unwrap(),
@@ -108,7 +108,7 @@ async fn start_next_release_skips_untagged_packages() {
     // Return None indicating no tag exists for this package
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| Ok(None));
+        .returning(|_, _| Ok(None));
 
     // Should NOT call create_commit since package has no tag
     mock_forge.expect_create_commit().times(0);

--- a/src/orchestrator/tests/pr_workflow.rs
+++ b/src/orchestrator/tests/pr_workflow.rs
@@ -24,7 +24,7 @@ async fn create_release_prs_succeeds_when_no_commits_since_last_tag() {
     // Has tag, but no new commits
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| {
+        .returning(|_, _| {
             Ok(Some(crate::analyzer::release::Tag {
                 name: "v1.0.0".to_string(),
                 semver: Version::parse("1.0.0").unwrap(),
@@ -53,7 +53,7 @@ async fn create_release_prs_returns_error_when_merged_pr_not_yet_released() {
     // No tags exist yet
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| Ok(None));
+        .returning(|_, _| Ok(None));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -98,7 +98,7 @@ async fn create_release_prs_creates_new_prs() {
     // No tags exist yet
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| Ok(None));
+        .returning(|_, _| Ok(None));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -189,7 +189,7 @@ async fn create_release_prs_targets_specific_package() {
     // No tags exist yet
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| Ok(None));
+        .returning(|_, _| Ok(None));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -307,7 +307,7 @@ async fn create_release_prs_updates_existing_prs() {
 
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| {
+        .returning(|_, _| {
             Ok(Some(crate::analyzer::release::Tag {
                 name: "v1.0.0".to_string(),
                 semver: Version::parse("1.0.0").unwrap(),

--- a/src/orchestrator/tests/release_workflow.rs
+++ b/src/orchestrator/tests/release_workflow.rs
@@ -138,7 +138,7 @@ Release notes
     // Expect auto-start-next flow
     mock_forge
         .expect_get_latest_tag_for_prefix()
-        .returning(|_| {
+        .returning(|_, _| {
             Ok(Some(Tag {
                 semver: Version::parse("1.0.0").unwrap(),
                 ..Default::default()


### PR DESCRIPTION
## Description

Ensures tag is ancestor of target "base branch" when searching for latest tag for a package.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)

## Related Issues

Fixes [#I-237](https://github.com/robgonnella/releasaurus/issues/237)
