### PR TITLE
fix: make GiteaIssue pull_request field optional

### DIFF
--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -705,7 +705,12 @@ impl Forge for Gitea {
             let issues: Vec<GiteaIssue> = result.json().await?;
 
             for issue in issues.iter() {
-                if !issue.pull_request.merged {
+                let is_merged = issue
+                    .pull_request
+                    .as_ref()
+                    .map(|pr| pr.merged)
+                    .unwrap_or(false);
+                if !is_merged {
                     log::warn!(
                         "found unmerged closed pr {} with pending label: skipping",
                         issue.number

--- a/src/forge/gitea/types.rs
+++ b/src/forge/gitea/types.rs
@@ -40,7 +40,7 @@ pub struct GiteaIssuePr {
 #[derive(Debug, Deserialize)]
 pub struct GiteaIssue {
     pub number: u64,
-    pub pull_request: GiteaIssuePr,
+    pub pull_request: Option<GiteaIssuePr>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Summary

Fixes #241.

Gitea's issues API returns `"pull_request": null` for plain issues that are not
pull requests, causing JSON deserialization to fail with a network error.

This change makes the `pull_request` field on `GiteaIssue` optional and updates
`get_merged_release_pr` to treat issues without pull request data as unmerged,
skipping them as before.