### PR TITLE
feat: support local git variant for all forges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d7ff03a34ea818a59cf30c0d7aa55354925484fa30bcc4cb96d784ff07578f"
 dependencies = [
- "strum",
+ "strum 0.26.3",
  "thiserror 1.0.69",
  "url",
 ]
@@ -1620,6 +1620,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,6 +1998,29 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2395,6 +2427,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,6 +2517,8 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
+ "strum 0.28.0",
+ "temp-env",
  "tempfile",
  "tera",
  "test-log",
@@ -2712,6 +2755,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.106",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -3019,7 +3068,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -3032,6 +3090,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.106",
 ]
 
@@ -3102,6 +3172,15 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,11 @@ merge = "0.2.0"
 gitlab = "0.1807.0"
 futures-util = "0.3.31"
 md5 = "0.8.0"
+strum = { version = "0.28.0", features = ["derive"] }
 
 [dev-dependencies]
 mockall = "0.13.1"
 nanoid = "0.4.0"
+temp-env = "0.3.6"
 tempfile = "3.23.0"
 test-log = "0.2.19"

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -473,6 +473,55 @@ repository and does not require forge authentication tokens. See the
 [Troubleshooting](./troubleshooting.md) guide for help diagnosing
 configuration issues.
 
+### Hybrid Mode (Local Git + Remote Forge)
+
+Use a local repository checkout for git operations while still creating
+real PRs and releases on your remote forge. This is useful when you
+already have the repository cloned locally and want to reduce the
+volume of API calls for the data-gathering phase (reading commits,
+fetching tags, loading file content).
+
+**Normal mode vs. `--local-path`:**
+
+- **Normal mode** performs all operations entirely through forge API
+  calls — no local git operations at all. Zero setup required; just
+  point it at any repository URL. Ideal for CI environments where you
+  don't want or need a local checkout.
+- **`--local-path` mode** performs all git operations (reading commits,
+  reading tags, reading files, creating branches, committing, and
+  pushing) using a local clone via git2. Only PR creation and release
+  publishing are delegated to the remote forge API. Best suited for
+  workflows where a local clone is already available and you want to
+  avoid the cost of repeated API calls for data gathering.
+
+**Usage:**
+
+```bash
+# GitHub
+releasaurus release-pr \
+  --forge github \
+  --repo "https://github.com/owner/repo" \
+  --token "$GITHUB_TOKEN" \
+  --local-path /path/to/checkout
+
+# GitLab
+releasaurus release-pr \
+  --forge gitlab \
+  --repo "https://gitlab.com/owner/repo" \
+  --token "$GITLAB_TOKEN" \
+  --local-path /path/to/checkout
+
+# Gitea
+releasaurus release-pr \
+  --forge gitea \
+  --repo "https://gitea.example.com/owner/repo" \
+  --token "$GITEA_TOKEN" \
+  --local-path /path/to/checkout
+```
+
+**Note:** A forge authentication token is still required for PR
+creation and release publishing.
+
 ### Configuration Overrides
 
 Override configuration properties from the command line without modifying your

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,11 @@ use git_url_parse::GitUrl;
 use merge::Merge;
 use secrecy::SecretString;
 use serde::Deserialize;
-use std::{collections::HashMap, path::Path};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 pub mod get;
 
@@ -14,7 +18,11 @@ use crate::{
     config::{changelog::RewordedCommit, prerelease::PrereleaseStrategy},
     error::ReleasaurusError,
     forge::{
-        gitea::Gitea, github::Github, gitlab::Gitlab, local::LocalRepo,
+        config::{TokenVar, resolve_token},
+        gitea::Gitea,
+        github::Github,
+        gitlab::Gitlab,
+        local::{LocalRepo, Remote},
         traits::Forge,
     },
 };
@@ -49,6 +57,12 @@ pub struct ForgeArgs {
     #[arg(short, long, global = true)]
     pub repo: Option<GitUrl>,
 
+    /// Optional path to local repository. Performs local git operations for
+    /// commit analysis, file updates, commits, tagging, pushing, and only uses
+    /// remote forge for PR and release creation
+    #[arg(long, global = true)]
+    pub local_path: Option<PathBuf>,
+
     /// Authentication token. Falls back to env vars: GITHUB_TOKEN, GITLAB_TOKEN, GITEA_TOKEN
     #[arg(short, long, global = true)]
     pub token: Option<SecretString>,
@@ -60,17 +74,52 @@ impl ForgeArgs {
             && let Some(repo) = self.repo.as_ref()
         {
             let forge: Box<dyn Forge> = match forge_type {
-                ForgeType::Github => Box::new(
-                    Github::new(repo.to_owned(), self.token.clone()).await?,
-                ),
-                ForgeType::Gitlab => Box::new(
-                    Gitlab::new(repo.to_owned(), self.token.clone()).await?,
-                ),
-                ForgeType::Gitea => Box::new(
-                    Gitea::new(repo.to_owned(), self.token.clone()).await?,
-                ),
+                ForgeType::Github => {
+                    let github =
+                        Github::new(repo.to_owned(), self.token.clone())
+                            .await?;
+                    if let Some(local_path) = self.local_path.as_ref() {
+                        self.resolve_hybrid_forge(
+                            Arc::new(github),
+                            local_path,
+                            repo,
+                            TokenVar::Github,
+                        )?
+                    } else {
+                        Box::new(github)
+                    }
+                }
+                ForgeType::Gitlab => {
+                    let gitlab =
+                        Gitlab::new(repo.to_owned(), self.token.clone())
+                            .await?;
+                    if let Some(local_path) = self.local_path.as_ref() {
+                        self.resolve_hybrid_forge(
+                            Arc::new(gitlab),
+                            local_path,
+                            repo,
+                            TokenVar::Gitlab,
+                        )?
+                    } else {
+                        Box::new(gitlab)
+                    }
+                }
+                ForgeType::Gitea => {
+                    let gitea =
+                        Gitea::new(repo.to_owned(), self.token.clone()).await?;
+                    if let Some(local_path) = self.local_path.as_ref() {
+                        self.resolve_hybrid_forge(
+                            Arc::new(gitea),
+                            local_path,
+                            repo,
+                            TokenVar::Gitea,
+                        )?
+                    } else {
+                        Box::new(gitea)
+                    }
+                }
                 ForgeType::Local => {
-                    Box::new(LocalRepo::new(Path::new(&repo.path))?)
+                    Box::new(LocalRepo::new(Path::new(&repo.path), None)?)
                 }
             };
 
@@ -80,6 +129,26 @@ impl ForgeArgs {
                 "missing one of required options: [--forge, --repo]".into(),
             ))
         }
+    }
+
+    fn resolve_hybrid_forge(
+        &self,
+        forge: Arc<dyn Forge>,
+        local_path: &Path,
+        repo: &GitUrl,
+        token_var: TokenVar,
+    ) -> Result<Box<dyn Forge>> {
+        let token =
+            resolve_token(self.token.clone(), repo.token.as_ref(), token_var)?;
+
+        Ok(Box::new(LocalRepo::new(
+            local_path,
+            Some(Remote {
+                forge,
+                token: SecretString::from(token),
+                url: repo.clone(),
+            }),
+        )?))
     }
 }
 
@@ -468,6 +537,7 @@ mod tests {
             forge: None,
             repo: Some(repo),
             token: Some(token),
+            local_path: None,
         };
 
         let result = forge_args.forge().await;
@@ -490,6 +560,7 @@ mod tests {
             forge: Some(ForgeType::Github),
             repo: None,
             token: Some(token),
+            local_path: None,
         };
 
         let result = forge_args.forge().await;

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,9 @@ pub enum ReleasaurusError {
     #[error("Git operation failed: {0}")]
     GitError(#[from] git2::Error),
 
+    #[error("Git operation failed: {0}")]
+    GitOther(String),
+
     // Network/API errors
     #[error("Network request failed: {0}")]
     NetworkError(String),
@@ -97,6 +100,11 @@ impl ReleasaurusError {
     /// Create a forge error with context
     pub fn forge(msg: impl Into<String>) -> Self {
         Self::ForgeError(msg.into())
+    }
+
+    /// Create a git error with context
+    pub fn git_other(msg: impl Into<String>) -> Self {
+        Self::GitOther(msg.into())
     }
 
     /// Create an invalid config error

--- a/src/forge/config.rs
+++ b/src/forge/config.rs
@@ -22,6 +22,18 @@ pub const TAGGED_LABEL: &str = "releasaurus:tagged";
 /// Label applied to release PRs while waiting for merge.
 pub const PENDING_LABEL: &str = "releasaurus:pending";
 
+/// Represents the default token variable names that are checked for
+/// authenticating each forge type
+#[derive(Clone, Copy, strum::Display)]
+pub(crate) enum TokenVar {
+    #[strum(to_string = "GITHUB_TOKEN")]
+    Github,
+    #[strum(to_string = "GITLAB_TOKEN")]
+    Gitlab,
+    #[strum(to_string = "GITEA_TOKEN")]
+    Gitea,
+}
+
 /// Validate that repository URL uses HTTP or HTTPS scheme, rejecting SSH and
 /// other protocols.
 fn validate_scheme(scheme: git_url_parse::Scheme) -> Result<()> {
@@ -44,12 +56,12 @@ fn validate_scheme(scheme: git_url_parse::Scheme) -> Result<()> {
 pub fn resolve_token(
     cli_token: Option<SecretString>,
     url_token: Option<&String>,
-    env_var: &str,
+    token_var: TokenVar,
 ) -> Result<String> {
     cli_token
         .map(|t| t.expose_secret().to_string())
         .or_else(|| url_token.cloned())
-        .or_else(|| env::var(env_var).ok())
+        .or_else(|| env::var(token_var.to_string()).ok())
         .ok_or_else(|| {
             ReleasaurusError::AuthenticationError(
                 "Token not provided".to_string(),
@@ -229,7 +241,7 @@ mod tests {
         let cli_token = Some(SecretString::from("cli_token"));
         let url_token = Some(&"url_token".to_string());
 
-        let result = resolve_token(cli_token, url_token, "NONEXISTENT_VAR");
+        let result = resolve_token(cli_token, url_token, TokenVar::Github);
 
         assert_eq!(result.unwrap(), "cli_token");
     }
@@ -238,74 +250,56 @@ mod tests {
     fn resolve_token_falls_back_to_url_token() {
         let url_token = Some(&"url_token".to_string());
 
-        let result = resolve_token(None, url_token, "NONEXISTENT_VAR");
+        let result = resolve_token(None, url_token, TokenVar::Gitlab);
 
         assert_eq!(result.unwrap(), "url_token");
     }
 
     #[test]
     fn resolve_token_falls_back_to_env_var() {
-        // Use a unique env var name to avoid conflicts
-        let env_var = "RELEASAURUS_TEST_TOKEN_12345";
-        // SAFETY: This test runs in isolation and uses a unique env var name
-        unsafe {
-            env::set_var(env_var, "env_token");
-        }
-
-        let result = resolve_token(None, None, env_var);
-
-        // SAFETY: Cleaning up the env var we set above
-        unsafe {
-            env::remove_var(env_var);
-        }
-
-        assert_eq!(result.unwrap(), "env_token");
+        temp_env::with_var(
+            TokenVar::Github.to_string(),
+            Some("env_token"),
+            || {
+                let result = resolve_token(None, None, TokenVar::Github);
+                assert_eq!(result.unwrap(), "env_token");
+            },
+        );
     }
 
     #[test]
     fn resolve_token_errors_when_no_token_available() {
-        let result = resolve_token(None, None, "NONEXISTENT_VAR_67890");
-
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err, ReleasaurusError::AuthenticationError(_)));
+        temp_env::with_var_unset(TokenVar::Gitea.to_string(), || {
+            let result = resolve_token(None, None, TokenVar::Gitea);
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(matches!(err, ReleasaurusError::AuthenticationError(_)));
+        });
     }
 
     #[test]
     fn resolve_token_cli_takes_precedence_over_env() {
-        let env_var = "RELEASAURUS_TEST_TOKEN_PRECEDENCE";
-        // SAFETY: This test runs in isolation and uses a unique env var name
-        unsafe {
-            env::set_var(env_var, "env_token");
-        }
-
-        let cli_token = Some(SecretString::from("cli_token"));
-        let result = resolve_token(cli_token, None, env_var);
-
-        // SAFETY: Cleaning up the env var we set above
-        unsafe {
-            env::remove_var(env_var);
-        }
-
-        assert_eq!(result.unwrap(), "cli_token");
+        temp_env::with_var(
+            TokenVar::Gitea.to_string(),
+            Some("env_token"),
+            || {
+                let cli_token = Some(SecretString::from("cli_token"));
+                let result = resolve_token(cli_token, None, TokenVar::Gitea);
+                assert_eq!(result.unwrap(), "cli_token");
+            },
+        );
     }
 
     #[test]
     fn resolve_token_url_takes_precedence_over_env() {
-        let env_var = "RELEASAURUS_TEST_TOKEN_URL_PRECEDENCE";
-        // SAFETY: This test runs in isolation and uses a unique env var name
-        unsafe {
-            env::set_var(env_var, "env_token");
-        }
-
-        let url_token = Some(&"url_token".to_string());
-        let result = resolve_token(None, url_token, env_var);
-
-        // SAFETY: Cleaning up the env var we set above
-        unsafe {
-            env::remove_var(env_var);
-        }
-
-        assert_eq!(result.unwrap(), "url_token");
+        temp_env::with_var(
+            TokenVar::Gitlab.to_string(),
+            Some("env_token"),
+            || {
+                let url_token = Some(&"url_token".to_string());
+                let result = resolve_token(None, url_token, TokenVar::Gitlab);
+                assert_eq!(result.unwrap(), "url_token");
+            },
+        );
     }
 }

--- a/src/forge/gitea.rs
+++ b/src/forge/gitea.rs
@@ -23,7 +23,7 @@ use crate::{
         config::{
             DEFAULT_COMMIT_SEARCH_DEPTH, DEFAULT_LABEL_COLOR,
             DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, PENDING_LABEL,
-            RemoteConfig, resolve_token,
+            RemoteConfig, TokenVar, resolve_token,
         },
         gitea::types::{
             CreateLabel, CreatePull, CreateRelease, GiteaCommitQueryObject,
@@ -59,7 +59,7 @@ impl Gitea {
     /// Create Gitea client with token authentication and API base URL
     /// configuration for self-hosted instances.
     pub async fn new(url: GitUrl, token: Option<SecretString>) -> Result<Self> {
-        let token = resolve_token(token, url.token.as_ref(), "GITEA_TOKEN")?;
+        let token = resolve_token(token, url.token.as_ref(), TokenVar::Gitea)?;
 
         let config = RemoteConfig::from_url(url)?;
 

--- a/src/forge/github.rs
+++ b/src/forge/github.rs
@@ -28,7 +28,7 @@ use crate::{
         config::{
             DEFAULT_COMMIT_SEARCH_DEPTH, DEFAULT_LABEL_COLOR,
             DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, PENDING_LABEL,
-            RemoteConfig, resolve_token,
+            RemoteConfig, TokenVar, resolve_token,
         },
         github::{
             graphql::{
@@ -66,7 +66,7 @@ impl Github {
     /// Create GitHub client with personal access token authentication and API
     /// base URL configuration.
     pub async fn new(url: GitUrl, token: Option<SecretString>) -> Result<Self> {
-        let token = resolve_token(token, url.token.as_ref(), "GITHUB_TOKEN")?;
+        let token = resolve_token(token, url.token.as_ref(), TokenVar::Github)?;
 
         let config = RemoteConfig::from_url(url)?;
 

--- a/src/forge/gitlab.rs
+++ b/src/forge/gitlab.rs
@@ -51,7 +51,7 @@ use crate::{
         config::{
             DEFAULT_COMMIT_SEARCH_DEPTH, DEFAULT_LABEL_COLOR,
             DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, PENDING_LABEL,
-            RemoteConfig, resolve_token,
+            RemoteConfig, TokenVar, resolve_token,
         },
         gitlab::{
             graphql::{CommitDiffQuery, CommitDiffQueryVars},
@@ -86,7 +86,7 @@ impl Gitlab {
     /// Create GitLab client with personal access token authentication and
     /// project ID resolution.
     pub async fn new(url: GitUrl, token: Option<SecretString>) -> Result<Self> {
-        let token = resolve_token(token, url.token.as_ref(), "GITLAB_TOKEN")?;
+        let token = resolve_token(token, url.token.as_ref(), TokenVar::Gitlab)?;
 
         let config = RemoteConfig::from_url(url)?;
 

--- a/src/forge/local.rs
+++ b/src/forge/local.rs
@@ -1,8 +1,13 @@
 //! Local forge implementation for offline development and testing.
 use async_trait::async_trait;
 use color_eyre::eyre::{Context, OptionExt};
-use git2::{BranchType, Commit as Git2Commit, Sort, TreeWalkMode};
+use git_url_parse::GitUrl;
+use git2::{
+    BranchType, Commit as Git2Commit, Oid, RemoteCallbacks, Sort,
+    StatusOptions, TreeWalkMode,
+};
 use regex::Regex;
+use secrecy::{ExposeSecret, SecretString};
 use std::{
     path::{self, Path, PathBuf},
     sync::Arc,
@@ -18,13 +23,31 @@ use crate::{
     forge::{
         request::{
             Commit, CreateCommitRequest, CreatePrRequest,
-            CreateReleaseBranchRequest, ForgeCommit, GetFileContentRequest,
-            GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
-            UpdatePrRequest,
+            CreateReleaseBranchRequest, FileChange, FileUpdateType,
+            ForgeCommit, GetFileContentRequest, GetPrRequest, PrLabelsRequest,
+            PullRequest, ReleaseByTagResponse, UpdatePrRequest,
         },
         traits::Forge,
     },
 };
+
+/// Create Git authentication callbacks for token-based HTTPS auth.
+/// Uses "git" as a fixed username placeholder — all supported forges
+/// (GitHub, GitLab, Gitea) authenticate solely via the token/password
+/// and ignore the username field.
+fn get_auth_callbacks<'r>(token: String) -> RemoteCallbacks<'r> {
+    let mut callbacks = git2::RemoteCallbacks::new();
+    callbacks.credentials(move |_url, _username, _allowed| {
+        git2::Cred::userpass_plaintext("git", &token)
+    });
+    callbacks
+}
+
+pub(crate) struct Remote {
+    pub forge: Arc<dyn Forge>,
+    pub token: SecretString,
+    pub url: GitUrl,
+}
 
 /// LocalRepo forge implementation using git2 for local repository operations.
 pub struct LocalRepo {
@@ -33,10 +56,11 @@ pub struct LocalRepo {
     repo: Arc<Mutex<git2::Repository>>,
     default_branch: String,
     link_base_url: Url,
+    remote: Option<Remote>,
 }
 
 impl LocalRepo {
-    pub fn new(repo_path: &Path) -> Result<Self> {
+    pub fn new(repo_path: &Path, remote: Option<Remote>) -> Result<Self> {
         let repo_str = repo_path.to_string_lossy();
         let abs_repo_path = path::absolute(repo_path)?;
 
@@ -71,7 +95,7 @@ impl LocalRepo {
             .to_string_lossy()
             .to_string();
 
-        let repo = git2::Repository::init(repo_path)?;
+        let repo = git2::Repository::open(repo_path)?;
 
         let head = repo.head()?;
 
@@ -88,28 +112,198 @@ impl LocalRepo {
             repo: Arc::new(Mutex::new(repo)),
             default_branch,
             link_base_url,
+            remote,
         })
     }
 }
 
-impl LocalRepo {}
+impl LocalRepo {
+    /// Create new branch from current HEAD (force creates, overwrites existing).
+    async fn create_branch(&self, branch: &str) -> Result<()> {
+        log::info!("creating branch: {branch}");
+        let repo = self.repo.lock().await;
+        let head = repo.head()?;
+        let commit = head.peel_to_commit()?;
+        repo.branch(branch, &commit, true)?;
+        Ok(())
+    }
+
+    /// Switch to branch and update working directory.
+    async fn switch_branch(&self, branch: &str) -> Result<()> {
+        log::info!("switching to branch: {branch}");
+        let repo = self.repo.lock().await;
+        let ref_name = format!("refs/heads/{}", branch);
+        let target_obj = repo.revparse_single(&ref_name)?;
+        repo.checkout_tree(&target_obj, None)?;
+        repo.set_head(&ref_name)?;
+        Ok(())
+    }
+
+    /// Add file path to git index (equivalent to `git add <file_path>`).
+    /// Accepts both absolute paths and paths relative to the workdir.
+    async fn stage_file(&self, path: &Path) -> Result<()> {
+        log::info!("adding file path to index: {}", path.display());
+        let repo = self.repo.lock().await;
+        let mut index = repo.index()?;
+        // git2 requires a path relative to the repo workdir.
+        // Strip the repo root prefix for absolute paths, or the
+        // leading "./" for explicitly relative ones.
+        let relative = if path.is_absolute() {
+            path.strip_prefix(&self.repo_path).unwrap_or(path)
+        } else {
+            path.strip_prefix("./").unwrap_or(path)
+        };
+        index.add_path(relative)?;
+        index.write()?;
+        Ok(())
+    }
+
+    /// Create commit with staged changes and specified message.
+    async fn local_commit(
+        &self,
+        msg: &str,
+        file_changes: &[FileChange],
+    ) -> Result<Commit> {
+        for change in file_changes {
+            let mut content = change.content.clone();
+            if change.update_type == FileUpdateType::Prepend {
+                let existing_content = fs::read_to_string(&change.path).await?;
+                content = format!("{content}{existing_content}");
+            }
+            fs::write(&change.path, content).await?;
+            self.stage_file(Path::new(&change.path)).await?;
+        }
+
+        log::debug!("committing changes with msg: {msg}");
+        let repo = self.repo.lock().await;
+
+        let mut options = StatusOptions::new();
+        let statuses = repo.statuses(Some(&mut options))?;
+
+        // If the list of statuses is empty, there are no changes to be committed
+        if !statuses.is_empty() {
+            let config = repo.config()?.snapshot()?;
+            let user = config.get_str("user.name")?;
+            let email = config.get_str("user.email")?;
+            log::debug!("using committer: user: {user}, email: {email}");
+            let mut index = repo.index()?;
+            let oid = index.write_tree()?;
+            let tree = repo.find_tree(oid)?;
+            let parent_commit = repo.head()?.peel_to_commit()?;
+            let committer = git2::Signature::now(user, email)?;
+            let oid = repo.commit(
+                Some("HEAD"),
+                &committer,
+                &committer,
+                msg,
+                &tree,
+                &[&parent_commit],
+            )?;
+
+            Ok(Commit {
+                sha: oid.to_string(),
+            })
+        } else {
+            Err(ReleasaurusError::git_other("nothing to commit"))
+        }
+    }
+
+    /// Push branch to remote with option to force push.
+    async fn push_branch(&self, branch: &str, force: bool) -> Result<()> {
+        if let Some(remote) = self.remote.as_ref() {
+            log::info!("pushing branch {branch}");
+            let repo = self.repo.lock().await;
+            let token = remote.token.expose_secret().to_string();
+            let callbacks = get_auth_callbacks(token);
+            let mut push_opts = git2::PushOptions::default();
+            push_opts.remote_callbacks(callbacks);
+
+            let mut git_remote =
+                repo.remote_anonymous(&remote.url.to_string())?;
+
+            let mut ref_spec = format!("refs/heads/{branch}");
+
+            if force {
+                // + indicates "force" push
+                ref_spec = format!("+{ref_spec}");
+            }
+
+            git_remote.push(&[ref_spec], Some(&mut push_opts))?;
+        } else {
+            log::warn!("no remote configured: skipping branch push")
+        }
+
+        Ok(())
+    }
+
+    /// Create annotated git tag pointing to specified commit.
+    async fn local_tag_commit(&self, tag: &str, sha: &str) -> Result<()> {
+        let repo = self.repo.lock().await;
+        let config = repo.config()?.snapshot()?;
+        let user = config.get_str("user.name")?;
+        let email = config.get_str("user.email")?;
+
+        let oid = Oid::from_str(sha)?;
+        let commit = repo.find_commit(oid)?;
+        let tagger = git2::Signature::now(user, email)?;
+
+        repo.tag(tag, commit.as_object(), &tagger, tag, false)?;
+
+        Ok(())
+    }
+
+    /// Push git tag to remote repository.
+    async fn push_tag(&self, tag: &str) -> Result<()> {
+        if let Some(remote) = self.remote.as_ref() {
+            let repo = self.repo.lock().await;
+            let token = remote.token.expose_secret().to_string();
+            let callbacks = get_auth_callbacks(token);
+            let mut push_opts = git2::PushOptions::default();
+            push_opts.remote_callbacks(callbacks);
+            let mut git_remote =
+                repo.remote_anonymous(&remote.url.to_string())?;
+            let ref_spec = format!("refs/tags/{tag}");
+            git_remote.push(&[ref_spec], Some(&mut push_opts))?;
+        } else {
+            log::warn!("no remote configured: skipping tag push")
+        }
+
+        Ok(())
+    }
+}
 
 #[async_trait]
 impl Forge for LocalRepo {
     fn repo_name(&self) -> String {
-        self.repo_name.clone()
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.repo_name()
+        } else {
+            self.repo_name.clone()
+        }
     }
 
     fn default_branch(&self) -> String {
-        self.default_branch.clone()
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.default_branch()
+        } else {
+            self.default_branch.clone()
+        }
     }
 
     fn release_link_base_url(&self) -> Url {
-        self.link_base_url.clone()
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.release_link_base_url()
+        } else {
+            self.link_base_url.clone()
+        }
     }
 
     fn compare_link_base_url(&self) -> Url {
-        self.link_base_url.clone()
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.compare_link_base_url()
+        } else {
+            self.link_base_url.clone()
+        }
     }
 
     async fn get_file_content(
@@ -333,61 +527,104 @@ impl Forge for LocalRepo {
         &self,
         req: CreateReleaseBranchRequest,
     ) -> Result<Commit> {
-        log::warn!("local_mode: would create branch: req: {:#?}", req);
-        Ok(Commit { sha: "None".into() })
+        if self.remote.is_some() {
+            self.create_branch(&req.release_branch).await?;
+            self.switch_branch(&req.release_branch).await?;
+            let commit =
+                self.local_commit(&req.message, &req.file_changes).await?;
+            self.push_branch(&req.release_branch, true).await?;
+            Ok(commit)
+        } else {
+            log::warn!("local_mode: would create branch: req: {:#?}", req);
+            Ok(Commit { sha: "None".into() })
+        }
     }
 
     async fn create_commit(&self, req: CreateCommitRequest) -> Result<Commit> {
-        log::warn!("local_mode: would create commit: req: {:#?}", req);
-        Ok(Commit { sha: "None".into() })
+        if self.remote.is_some() {
+            let commit =
+                self.local_commit(&req.message, &req.file_changes).await?;
+            self.push_branch(&req.target_branch, false).await?;
+            Ok(commit)
+        } else {
+            log::warn!("local_mode: would create commit: req: {:#?}", req);
+            Ok(Commit { sha: "None".into() })
+        }
     }
 
     async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()> {
-        log::warn!(
-            "local_mode: would tag commit: tag_name: {tag_name}, sha: {sha}"
-        );
-        Ok(())
+        if self.remote.is_some() {
+            self.local_tag_commit(tag_name, sha).await?;
+            self.push_tag(tag_name).await?;
+            Ok(())
+        } else {
+            log::warn!(
+                "local_mode: would tag commit: \
+                 tag_name: {tag_name}, sha: {sha}"
+            );
+            Ok(())
+        }
     }
 
     async fn get_open_release_pr(
         &self,
         req: GetPrRequest,
     ) -> Result<Option<PullRequest>> {
-        log::warn!(
-            "local_mode: would request open release pr: req: {:#?}",
-            req
-        );
-        Ok(None)
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.get_open_release_pr(req).await
+        } else {
+            log::warn!(
+                "local_mode: would request open release pr: req: {:#?}",
+                req
+            );
+            Ok(None)
+        }
     }
 
     async fn get_merged_release_pr(
         &self,
         req: GetPrRequest,
     ) -> Result<Option<PullRequest>> {
-        log::warn!(
-            "local_mode: would request merged release pr: req: {:#?}",
-            req
-        );
-        Ok(None)
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.get_merged_release_pr(req).await
+        } else {
+            log::warn!(
+                "local_mode: would request merged release pr: req: {:#?}",
+                req
+            );
+            Ok(None)
+        }
     }
 
     async fn create_pr(&self, req: CreatePrRequest) -> Result<PullRequest> {
-        log::warn!("local_mode: would create release pr: req: {:#?}", req);
-        Ok(PullRequest {
-            number: 0,
-            sha: "None".into(),
-            body: req.body,
-        })
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.create_pr(req).await
+        } else {
+            log::warn!("local_mode: would create release pr: req: {:#?}", req);
+            Ok(PullRequest {
+                number: 0,
+                sha: "None".into(),
+                body: req.body,
+            })
+        }
     }
 
     async fn update_pr(&self, req: UpdatePrRequest) -> Result<()> {
-        log::warn!("local_mode: would update release pr: req: {:#?}", req);
-        Ok(())
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.update_pr(req).await
+        } else {
+            log::warn!("local_mode: would update release pr: req: {:#?}", req);
+            Ok(())
+        }
     }
 
     async fn replace_pr_labels(&self, req: PrLabelsRequest) -> Result<()> {
-        log::warn!("local_mode: would replace pr labels: req: {:#?}", req);
-        Ok(())
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.replace_pr_labels(req).await
+        } else {
+            log::warn!("local_mode: would replace pr labels: req: {:#?}", req);
+            Ok(())
+        }
     }
 
     async fn create_release(
@@ -396,16 +633,21 @@ impl Forge for LocalRepo {
         sha: &str,
         notes: &str,
     ) -> Result<()> {
-        log::warn!(
-            "local_mode: would create release: tag: {tag}, sha: {sha}, notes: {notes}"
-        );
-        Ok(())
+        if let Some(remote) = self.remote.as_ref() {
+            remote.forge.create_release(tag, sha, notes).await
+        } else {
+            log::warn!(
+                "local_mode: would create release: tag: {tag}, sha: {sha}, notes: {notes}"
+            );
+            Ok(())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::forge::request::{FileChange, FileUpdateType};
     use tempfile::TempDir;
 
     /// Creates a commit on whatever HEAD currently points to.
@@ -422,12 +664,18 @@ mod tests {
             .unwrap()
     }
 
+    fn configure_git_user(repo: &git2::Repository) {
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Test").unwrap();
+        config.set_str("user.email", "test@example.com").unwrap();
+    }
+
     fn tag_oid(repo: &git2::Repository, name: &str, oid: git2::Oid) {
         let obj = repo.find_object(oid, None).unwrap();
         repo.tag_lightweight(name, &obj, false).unwrap();
     }
 
-    fn default_branch(repo: &git2::Repository) -> String {
+    fn current_branch_name(repo: &git2::Repository) -> String {
         repo.head().unwrap().shorthand().unwrap().to_string()
     }
 
@@ -441,15 +689,248 @@ mod tests {
         let repo = git2::Repository::init(dir.path()).unwrap();
         let oid = add_commit(&repo, "initial commit");
         tag_oid(&repo, "v1.0.0", oid);
-        let branch = default_branch(&repo);
+        let branch = current_branch_name(&repo);
         drop(repo);
 
-        let forge = LocalRepo::new(dir.path()).unwrap();
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
         let result =
             forge.get_latest_tag_for_prefix("v", &branch).await.unwrap();
 
         assert!(result.is_some(), "tag at branch head should be found");
         assert_eq!(result.unwrap().name, "v1.0.0");
+    }
+
+    /// `create_branch` must create a branch pointing to current HEAD.
+    #[tokio::test]
+    async fn create_branch_from_head() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let oid = add_commit(&repo, "initial commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        forge.create_branch("release").await.unwrap();
+
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let branch = repo
+            .find_branch("release", git2::BranchType::Local)
+            .unwrap();
+        let branch_oid = branch.get().peel_to_commit().unwrap().id();
+        assert_eq!(branch_oid, oid);
+    }
+
+    /// `create_branch` must force-overwrite an existing branch,
+    /// moving it to the current HEAD.
+    #[tokio::test]
+    async fn create_branch_overwrites_existing() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        add_commit(&repo, "initial commit");
+        let second_oid = add_commit(&repo, "second commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        // Create once, then overwrite from second commit (HEAD).
+        forge.create_branch("release").await.unwrap();
+        forge.create_branch("release").await.unwrap();
+
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let branch = repo
+            .find_branch("release", git2::BranchType::Local)
+            .unwrap();
+        let branch_oid = branch.get().peel_to_commit().unwrap().id();
+        assert_eq!(branch_oid, second_oid);
+    }
+
+    /// `switch_branch` must move HEAD to the target branch.
+    #[tokio::test]
+    async fn switch_branch_updates_head() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        add_commit(&repo, "initial commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        forge.create_branch("release").await.unwrap();
+        forge.switch_branch("release").await.unwrap();
+
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let head = current_branch_name(&repo);
+        assert_eq!(head, "release");
+    }
+
+    /// `stage_file` must add the file to the git index.
+    #[tokio::test]
+    async fn stage_file_adds_to_index() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        add_commit(&repo, "initial commit");
+        drop(repo);
+
+        // Write a new file to the working directory.
+        let file_path = dir.path().join("staged.txt");
+        std::fs::write(&file_path, "hello").unwrap();
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        forge
+            .stage_file(std::path::Path::new("staged.txt"))
+            .await
+            .unwrap();
+
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let index = repo.index().unwrap();
+        let entry = index.get_path(std::path::Path::new("staged.txt"), 0);
+        assert!(entry.is_some(), "staged.txt should be in the index");
+    }
+
+    /// `local_commit` must create a commit with the given message
+    /// and write the supplied file content to disk.
+    #[tokio::test]
+    async fn local_commit_creates_commit_with_message() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+        add_commit(&repo, "initial commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        let change = FileChange {
+            path: dir.path().join("version.txt").to_string_lossy().to_string(),
+            content: "1.2.3".to_string(),
+            update_type: FileUpdateType::Replace,
+        };
+
+        let commit = forge
+            .local_commit("chore: bump version", &[change])
+            .await
+            .unwrap();
+
+        assert!(!commit.sha.is_empty());
+
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let msg = repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .message()
+            .unwrap()
+            .to_string();
+        assert_eq!(msg, "chore: bump version");
+
+        let written =
+            std::fs::read_to_string(dir.path().join("version.txt")).unwrap();
+        assert_eq!(written, "1.2.3");
+    }
+
+    /// `local_commit` with `Prepend` update type must prepend the new
+    /// content in front of the existing file content.
+    #[tokio::test]
+    async fn local_commit_with_prepend_updates_content() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+
+        // Create the initial file and commit it.
+        let file_path = dir.path().join("CHANGELOG.md");
+        std::fs::write(&file_path, "existing\n").unwrap();
+        let mut index = repo.index().unwrap();
+        index
+            .add_path(std::path::Path::new("CHANGELOG.md"))
+            .unwrap();
+        index.write().unwrap();
+        add_commit(&repo, "initial commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        let change = FileChange {
+            path: file_path.to_string_lossy().to_string(),
+            content: "new\n".to_string(),
+            update_type: FileUpdateType::Prepend,
+        };
+
+        forge
+            .local_commit("chore: update changelog", &[change])
+            .await
+            .unwrap();
+
+        let written = std::fs::read_to_string(&file_path).unwrap();
+        assert!(
+            written.starts_with("new\n"),
+            "prepended content should come first"
+        );
+        assert!(
+            written.contains("existing\n"),
+            "existing content should be preserved"
+        );
+    }
+
+    /// `local_commit` must return an error when there are no staged
+    /// changes to commit.
+    #[tokio::test]
+    async fn local_commit_returns_error_when_nothing_to_commit() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+        add_commit(&repo, "initial commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        let result = forge.local_commit("chore: empty", &[]).await;
+        assert!(
+            result.is_err(),
+            "should error when there is nothing to commit"
+        );
+    }
+
+    /// `local_tag_commit` must create an annotated tag pointing to
+    /// the specified commit OID.
+    #[tokio::test]
+    async fn local_tag_commit_creates_annotated_tag() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+        let oid = add_commit(&repo, "initial commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        forge
+            .local_tag_commit("v1.0.0", &oid.to_string())
+            .await
+            .unwrap();
+
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        // find_tag resolves annotated tags only (not lightweight).
+        let tag_ref = repo.find_reference("refs/tags/v1.0.0").unwrap();
+        let tag = tag_ref.peel_to_tag().unwrap();
+        assert_eq!(tag.name().unwrap(), "v1.0.0");
+        assert_eq!(tag.target_id(), oid);
+    }
+
+    /// `push_branch` must succeed (no-op) when no remote is
+    /// configured.
+    #[tokio::test]
+    async fn push_branch_without_remote_is_noop() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        add_commit(&repo, "initial commit");
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        forge.push_branch("main", false).await.unwrap();
+    }
+
+    /// `push_tag` must succeed (no-op) when no remote is configured.
+    #[tokio::test]
+    async fn push_tag_without_remote_is_noop() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let oid = add_commit(&repo, "initial commit");
+        tag_oid(&repo, "v1.0.0", oid);
+        drop(repo);
+
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
+        forge.push_tag("v1.0.0").await.unwrap();
     }
 
     /// A tag that lives on a divergent branch must NOT be returned
@@ -463,7 +944,7 @@ mod tests {
         // Commit on the main branch and tag it v1.0.0.
         let base_oid = add_commit(&repo, "initial commit");
         tag_oid(&repo, "v1.0.0", base_oid);
-        let main_branch = default_branch(&repo);
+        let main_branch = current_branch_name(&repo);
 
         // Create a divergent branch from that same base commit,
         // add a commit there, and tag it v2.0.0.
@@ -480,7 +961,7 @@ mod tests {
         repo.set_head(&format!("refs/heads/{main_branch}")).unwrap();
         drop(repo);
 
-        let forge = LocalRepo::new(dir.path()).unwrap();
+        let forge = LocalRepo::new(dir.path(), None).unwrap();
 
         // Querying main_branch must return v1.0.0 only; v2.0.0 is
         // not in main_branch's history.

--- a/src/forge/tests/gitea.rs
+++ b/src/forge/tests/gitea.rs
@@ -24,6 +24,7 @@ async fn test_gitea_forge() {
         forge: Some(ForgeType::Gitea),
         repo: Some(repo.clone()),
         token: Some(token_secret),
+        local_path: None,
     };
 
     let forge = forge_args.forge().await.unwrap();

--- a/src/forge/tests/github.rs
+++ b/src/forge/tests/github.rs
@@ -23,6 +23,7 @@ async fn test_github_forge() {
         forge: Some(ForgeType::Github),
         repo: Some(repo.clone()),
         token: Some(token_secret),
+        local_path: None,
     };
 
     let forge = forge_args.forge().await.unwrap();

--- a/src/forge/tests/gitlab.rs
+++ b/src/forge/tests/gitlab.rs
@@ -23,6 +23,7 @@ async fn test_gitlab_forge() {
         forge: Some(ForgeType::Gitlab),
         repo: Some(repo.clone()),
         token: Some(token_secret),
+        local_path: None,
     };
 
     let forge = forge_args.forge().await.unwrap();


### PR DESCRIPTION
## Description

Adds a "--local-path" for all forges to allow users to perform local git operations on a pre-checked-out local repository and only use the remote forge calls for creating PRs and releases.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

## Related Issues

Fixes #244 