### PR TITLE
fix: --local-path related fixes for local forge

### DIFF
--- a/crates/releasaurus-core/src/forge/local.rs
+++ b/crates/releasaurus-core/src/forge/local.rs
@@ -1141,10 +1141,10 @@ mod tests {
     }
 
     #[tokio::test]
-    #[test_log::test]
     async fn create_release_branch_always_returns_to_starting_branch() {
         let dir = TempDir::new().unwrap();
         let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
         add_commit(&repo, "initial commit");
         add_commit(&repo, "feat: main branch feature");
         let base_branch = current_branch_name(&repo);


### PR DESCRIPTION
Fixes several issues in the local forge triggered when using `--local-path`:

1. **Missing file handling on first release** — `local_commit` failed with "No such file or directory (os error 2)" when a `Prepend` file change targeted a file that did not yet exist, such as CHANGELOG.md on a package's first release. The remote forge implementations all handle this gracefully by falling back to a create operation. Now uses `if let Ok(...)` instead of the hard `?` on `fs::read_to_string` so that missing files get the new content written directly.

2. **Multi-package branch contamination** — `create_release_branch` left HEAD on the newly created release branch after pushing. In multi-package setups with `separate_pull_requests`, the next package's branch was forked from the previous release branch instead of the base branch, inheriting its changes. Now switches back to the base branch after each release branch is pushed.

3. **Relative path resolution** — File I/O in `local_commit` resolved `FileChange.path` against the process CWD rather than the repository root. Paths are now joined against `self.repo_path`, matching `get_file_content`.

4. **Missing parent directories** — `fs::write` failed when a package's changelog path was nested under directories that don't exist in the repo (e.g. `services/object-storage/ui/CHANGELOG.md`). Now creates intermediate directories with `create_dir_all` before writing.

Additionally, debug log output was added to `LocalRepo::new`, `switch_branch`, and `local_commit` covering repo paths, workdir, ref resolution, checkout steps, file paths, and parent directory existence for easier diagnosis of path-related issues.