### PR TITLE
feat: adds support for gitlab scoped labels

### DIFF
--- a/crates/releasaurus-core/src/forge/config.rs
+++ b/crates/releasaurus-core/src/forge/config.rs
@@ -96,9 +96,19 @@ pub const DEFAULT_PR_BRANCH_PREFIX: &str = "releasaurus-release";
 /// Default color for releasaurus labels in hex format.
 pub const DEFAULT_LABEL_COLOR: &str = "a47dab";
 /// Label applied to release PRs after tagging is complete.
-pub const TAGGED_LABEL: &str = "releasaurus:tagged";
+/// Uses the GitLab scoped-label separator `::` so that applying
+/// this label automatically removes `PENDING_LABEL` on GitLab.
+/// On GitHub and Gitea the `::` is treated as literal characters.
+pub const TAGGED_LABEL: &str = "releasaurus::tagged";
 /// Label applied to release PRs while waiting for merge.
-pub const PENDING_LABEL: &str = "releasaurus:pending";
+/// Uses the GitLab scoped-label separator `::` so that applying
+/// this label automatically removes `TAGGED_LABEL` on GitLab.
+/// On GitHub and Gitea the `::` is treated as literal characters.
+pub const PENDING_LABEL: &str = "releasaurus::pending";
+/// Legacy pending label used before the scoped-label migration.
+/// Retained so that existing release PRs created by an older
+/// version of releasaurus can still be found after an upgrade.
+pub const LEGACY_PENDING_LABEL: &str = "releasaurus:pending";
 
 /// Represents the default token variable names that are checked for
 /// authenticating each forge type

--- a/crates/releasaurus-core/src/forge/gitea.rs
+++ b/crates/releasaurus-core/src/forge/gitea.rs
@@ -20,8 +20,8 @@ use crate::{
     forge::{
         config::{
             DEFAULT_COMMIT_SEARCH_DEPTH, DEFAULT_LABEL_COLOR,
-            DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, PENDING_LABEL,
-            RepoUrl, TokenVar, resolve_token,
+            DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, LEGACY_PENDING_LABEL,
+            PENDING_LABEL, RepoUrl, TokenVar, resolve_token,
         },
         gitea::types::{
             CreateLabel, CreatePull, CreateRelease, GiteaCommitQueryObject,
@@ -603,52 +603,63 @@ impl Forge for Gitea {
         &self,
         req: GetPrRequest,
     ) -> Result<Option<PullRequest>> {
-        let mut has_more = true;
-        let mut page = 1;
-        let page_limit = DEFAULT_PAGE_SIZE.to_string();
         let mut found_prs = vec![];
 
-        while has_more {
-            // Search for open issues with the pending label
-            let mut issues_url = self.base_url.join(&format!(
-                "issues?state=open&type=pulls&labels={}",
-                PENDING_LABEL
-            ))?;
-
-            issues_url
-                .query_pairs_mut()
-                .append_pair("limit", &page_limit.to_string())
-                .append_pair("page", &page.to_string());
-
-            let request = self.client.get(issues_url).build()?;
-            let response = self.client.execute(request).await?;
-            let headers = response.headers();
-
-            has_more = headers
-                .get("x-hasmore")
-                .map(|h| h.to_str().unwrap() == "true")
-                .unwrap_or(false);
-
-            let result = response.error_for_status()?;
-            let issues: Vec<GiteaIssue> = result.json().await?;
-
-            for issue in issues.iter() {
-                let pr_url =
-                    self.base_url.join(&format!("pulls/{}", issue.number))?;
-                let request = self.client.get(pr_url).build()?;
-                let response = self.client.execute(request).await?;
-                let result = response.error_for_status()?;
-                let found_pr: GiteaPullRequest = result.json().await?;
-                if found_pr.head.label == req.head_branch {
-                    found_prs.push(PullRequest {
-                        number: found_pr.number,
-                        sha: found_pr.head.sha,
-                        body: found_pr.body,
-                    });
-                }
+        // Try the current label first, then fall back to the
+        // legacy single-colon label for users upgrading from an
+        // older version of releasaurus.
+        for pending_label in [PENDING_LABEL, LEGACY_PENDING_LABEL] {
+            if !found_prs.is_empty() {
+                break;
             }
 
-            page += 1;
+            let mut has_more = true;
+            let mut page = 1;
+            let page_limit = DEFAULT_PAGE_SIZE.to_string();
+
+            while has_more {
+                // Search for open issues with the pending label
+                let mut issues_url = self.base_url.join(&format!(
+                    "issues?state=open&type=pulls&labels={}",
+                    pending_label
+                ))?;
+
+                issues_url
+                    .query_pairs_mut()
+                    .append_pair("limit", &page_limit.to_string())
+                    .append_pair("page", &page.to_string());
+
+                let request = self.client.get(issues_url).build()?;
+                let response = self.client.execute(request).await?;
+                let headers = response.headers();
+
+                has_more = headers
+                    .get("x-hasmore")
+                    .map(|h| h.to_str().unwrap() == "true")
+                    .unwrap_or(false);
+
+                let result = response.error_for_status()?;
+                let issues: Vec<GiteaIssue> = result.json().await?;
+
+                for issue in issues.iter() {
+                    let pr_url = self
+                        .base_url
+                        .join(&format!("pulls/{}", issue.number))?;
+                    let request = self.client.get(pr_url).build()?;
+                    let response = self.client.execute(request).await?;
+                    let result = response.error_for_status()?;
+                    let found_pr: GiteaPullRequest = result.json().await?;
+                    if found_pr.head.label == req.head_branch {
+                        found_prs.push(PullRequest {
+                            number: found_pr.number,
+                            sha: found_pr.head.sha,
+                            body: found_pr.body,
+                        });
+                    }
+                }
+
+                page += 1;
+            }
         }
 
         if found_prs.is_empty() {
@@ -673,71 +684,83 @@ impl Forge for Gitea {
         &self,
         req: GetPrRequest,
     ) -> Result<Option<PullRequest>> {
-        let mut has_more = true;
-        let mut page = 1;
-        let page_limit = DEFAULT_PAGE_SIZE.to_string();
         let mut found_prs = vec![];
 
-        while has_more {
-            // Search for closed issues with the pending label
-            let mut issues_url = self.base_url.join(&format!(
-                "issues?state=closed&labels={} ",
-                PENDING_LABEL
-            ))?;
-
-            issues_url
-                .query_pairs_mut()
-                .append_pair("limit", &page_limit.to_string())
-                .append_pair("page", &page.to_string());
-
-            let request = self.client.get(issues_url).build()?;
-            let response = self.client.execute(request).await?;
-            let headers = response.headers();
-
-            has_more = headers
-                .get("x-hasmore")
-                .map(|h| h.to_str().unwrap() == "true")
-                .unwrap_or(false);
-
-            let result = response.error_for_status()?;
-            let issues: Vec<GiteaIssue> = result.json().await?;
-
-            for issue in issues.iter() {
-                let is_merged = issue
-                    .pull_request
-                    .as_ref()
-                    .map(|pr| pr.merged)
-                    .unwrap_or(false);
-                if !is_merged {
-                    log::warn!(
-                        "found unmerged closed pr {} with pending label: skipping",
-                        issue.number
-                    );
-                    continue;
-                }
-
-                let pr_url =
-                    self.base_url.join(&format!("pulls/{}", issue.number))?;
-                let request = self.client.get(pr_url).build()?;
-                let response = self.client.execute(request).await?;
-                let result = response.error_for_status()?;
-                let found_pr: GiteaPullRequest = result.json().await?;
-                if found_pr.head.label == req.head_branch {
-                    let sha = found_pr.merge_commit_sha.ok_or_else(|| {
-                        ReleasaurusError::forge(format!(
-                            "no merge_commit_sha found for pr {}",
-                            found_pr.number
-                        ))
-                    })?;
-                    found_prs.push(PullRequest {
-                        number: found_pr.number,
-                        sha,
-                        body: found_pr.body,
-                    });
-                }
+        // Try the current label first, then fall back to the
+        // legacy single-colon label for users upgrading from an
+        // older version of releasaurus.
+        for pending_label in [PENDING_LABEL, LEGACY_PENDING_LABEL] {
+            if !found_prs.is_empty() {
+                break;
             }
 
-            page += 1;
+            let mut has_more = true;
+            let mut page = 1;
+            let page_limit = DEFAULT_PAGE_SIZE.to_string();
+
+            while has_more {
+                // Search for closed issues with the pending label
+                let mut issues_url = self.base_url.join(&format!(
+                    "issues?state=closed&labels={}",
+                    pending_label
+                ))?;
+
+                issues_url
+                    .query_pairs_mut()
+                    .append_pair("limit", &page_limit.to_string())
+                    .append_pair("page", &page.to_string());
+
+                let request = self.client.get(issues_url).build()?;
+                let response = self.client.execute(request).await?;
+                let headers = response.headers();
+
+                has_more = headers
+                    .get("x-hasmore")
+                    .map(|h| h.to_str().unwrap() == "true")
+                    .unwrap_or(false);
+
+                let result = response.error_for_status()?;
+                let issues: Vec<GiteaIssue> = result.json().await?;
+
+                for issue in issues.iter() {
+                    let is_merged = issue
+                        .pull_request
+                        .as_ref()
+                        .map(|pr| pr.merged)
+                        .unwrap_or(false);
+                    if !is_merged {
+                        log::warn!(
+                            "found unmerged closed pr {} with pending label: skipping",
+                            issue.number
+                        );
+                        continue;
+                    }
+
+                    let pr_url = self
+                        .base_url
+                        .join(&format!("pulls/{}", issue.number))?;
+                    let request = self.client.get(pr_url).build()?;
+                    let response = self.client.execute(request).await?;
+                    let result = response.error_for_status()?;
+                    let found_pr: GiteaPullRequest = result.json().await?;
+                    if found_pr.head.label == req.head_branch {
+                        let sha =
+                            found_pr.merge_commit_sha.ok_or_else(|| {
+                                ReleasaurusError::forge(format!(
+                                    "no merge_commit_sha found for pr {}",
+                                    found_pr.number
+                                ))
+                            })?;
+                        found_prs.push(PullRequest {
+                            number: found_pr.number,
+                            sha,
+                            body: found_pr.body,
+                        });
+                    }
+                }
+
+                page += 1;
+            }
         }
 
         if found_prs.is_empty() {

--- a/crates/releasaurus-core/src/forge/github.rs
+++ b/crates/releasaurus-core/src/forge/github.rs
@@ -26,8 +26,8 @@ use crate::{
     forge::{
         config::{
             DEFAULT_COMMIT_SEARCH_DEPTH, DEFAULT_LABEL_COLOR,
-            DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, PENDING_LABEL,
-            RepoUrl, TokenVar, resolve_token,
+            DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, LEGACY_PENDING_LABEL,
+            PENDING_LABEL, RepoUrl, TokenVar, resolve_token,
         },
         github::{
             graphql::{
@@ -723,8 +723,9 @@ impl Forge for Github {
 
         while let Some(pr) = stream.try_next().await? {
             if let Some(labels) = pr.labels
-                && let Some(_pending_label) =
-                    labels.iter().find(|l| l.name == PENDING_LABEL)
+                && labels.iter().any(|l| {
+                    l.name == PENDING_LABEL || l.name == LEGACY_PENDING_LABEL
+                })
             {
                 found_prs.push(PullRequest {
                     number: pr.number,
@@ -759,48 +760,60 @@ impl Forge for Github {
         let issues_handler =
             self.instance.issues(&self.url.owner, &self.url.name);
 
-        let stream = issues_handler
-            .list()
-            .direction(params::Direction::Descending)
-            .labels(&[PENDING_LABEL.into()])
-            .state(params::State::Closed)
-            .send()
-            .await?
-            .into_stream(&self.instance);
-
-        pin!(stream);
-
         let mut found_prs = vec![];
 
-        while let Some(issue) = stream.try_next().await? {
-            let pr = self
-                .instance
-                .pulls(&self.url.owner, &self.url.name)
-                .get(issue.number)
-                .await?;
+        // Try the current label first, then fall back to the
+        // legacy single-colon label for users upgrading from an
+        // older version of releasaurus.
+        for pending_label in [PENDING_LABEL, LEGACY_PENDING_LABEL] {
+            if !found_prs.is_empty() {
+                break;
+            }
 
-            if let Some(label) = pr.head.label
-                && label == format!("{}:{}", self.url.owner, req.head_branch)
-            {
-                if let Some(merged) = pr.merged
-                    && !merged
+            let stream = issues_handler
+                .list()
+                .direction(params::Direction::Descending)
+                .labels(&[pending_label.into()])
+                .state(params::State::Closed)
+                .send()
+                .await?
+                .into_stream(&self.instance);
+
+            pin!(stream);
+
+            while let Some(issue) = stream.try_next().await? {
+                let pr = self
+                    .instance
+                    .pulls(&self.url.owner, &self.url.name)
+                    .get(issue.number)
+                    .await?;
+
+                if let Some(head_label) = pr.head.label
+                    && head_label
+                        == format!("{}:{}", self.url.owner, req.head_branch)
                 {
-                    log::warn!(
-                        "found unmerged closed pr {} with pending label: skipping",
-                        pr.number
-                    );
-                    continue;
+                    if let Some(merged) = pr.merged
+                        && !merged
+                    {
+                        log::warn!(
+                            "found unmerged closed pr {} with pending label: skipping",
+                            pr.number
+                        );
+                        continue;
+                    }
+
+                    let sha = pr.merge_commit_sha.ok_or_else(|| {
+                        ReleasaurusError::forge(
+                            "no merge_commit_sha found for pr",
+                        )
+                    })?;
+
+                    found_prs.push(PullRequest {
+                        number: pr.number,
+                        sha,
+                        body: pr.body.unwrap_or_default(),
+                    });
                 }
-
-                let sha = pr.merge_commit_sha.ok_or_else(|| {
-                    ReleasaurusError::forge("no merge_commit_sha found for pr")
-                })?;
-
-                found_prs.push(PullRequest {
-                    number: pr.number,
-                    sha,
-                    body: pr.body.unwrap_or_default(),
-                });
             }
         }
 

--- a/crates/releasaurus-core/src/forge/gitlab.rs
+++ b/crates/releasaurus-core/src/forge/gitlab.rs
@@ -49,8 +49,8 @@ use crate::{
     forge::{
         config::{
             DEFAULT_COMMIT_SEARCH_DEPTH, DEFAULT_LABEL_COLOR,
-            DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, PENDING_LABEL,
-            RepoUrl, TokenVar, resolve_token,
+            DEFAULT_PAGE_SIZE, DEFAULT_TAG_SEARCH_DEPTH, LEGACY_PENDING_LABEL,
+            PENDING_LABEL, RepoUrl, TokenVar, resolve_token,
         },
         gitlab::{
             graphql::{CommitDiffQuery, CommitDiffQueryVars},
@@ -650,20 +650,31 @@ impl Forge for Gitlab {
         &self,
         req: GetPrRequest,
     ) -> Result<Option<PullRequest>> {
-        // Search for closed merge requests with the pending label
-        let endpoint = MergeRequests::builder()
-            .project(&self.project_id)
-            .state(MergeRequestState::Merged)
-            .source_branch(req.head_branch.clone())
-            .labels(vec![PENDING_LABEL])
-            .build()?;
+        let mut merge_requests: Vec<MergeRequestInfo> = vec![];
 
-        let merge_requests: Vec<MergeRequestInfo> = paged(
-            endpoint,
-            Pagination::AllPerPageLimit(DEFAULT_PAGE_SIZE.into()),
-        )
-        .query_async(&self.gl)
-        .await?;
+        // Try the current label first, then fall back to the
+        // legacy single-colon label for users upgrading from an
+        // older version of releasaurus.
+        for pending_label in [PENDING_LABEL, LEGACY_PENDING_LABEL] {
+            if !merge_requests.is_empty() {
+                break;
+            }
+
+            // Search for merged MRs with the pending label
+            let endpoint = MergeRequests::builder()
+                .project(&self.project_id)
+                .state(MergeRequestState::Merged)
+                .source_branch(req.head_branch.clone())
+                .labels(vec![pending_label])
+                .build()?;
+
+            merge_requests = paged(
+                endpoint,
+                Pagination::AllPerPageLimit(DEFAULT_PAGE_SIZE.into()),
+            )
+            .query_async(&self.gl)
+            .await?;
+        }
 
         if merge_requests.is_empty() {
             return Ok(None);

--- a/crates/releasaurus-core/src/forge/tests/common/run.rs
+++ b/crates/releasaurus-core/src/forge/tests/common/run.rs
@@ -6,8 +6,7 @@ use crate::{
     config::Config,
     error::ReleasaurusError,
     forge::{
-        config::Scheme,
-        config::{PENDING_LABEL, RepoUrl},
+        config::{LEGACY_PENDING_LABEL, PENDING_LABEL, RepoUrl, Scheme},
         manager::ForgeManager,
         request::{
             CreateCommitRequest, CreatePrRequest, CreateReleaseBranchRequest,
@@ -184,9 +183,42 @@ pub async fn run_forge_test(
     sleep(SHORT_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
-    // replace_pr_labels -> succeeds
+    // replace_pr_labels(legacy) -> succeeds
     ////////////////////////////////////////////////////////////////////////////
-    log::info!("replacing PR labels");
+    log::info!(
+        "replacing PR labels with legacy pending label: {}",
+        LEGACY_PENDING_LABEL
+    );
+    let replace_labels_req = PrLabelsRequest {
+        labels: vec![LEGACY_PENDING_LABEL.into()],
+        pr_number: release_pr.number,
+    };
+    forge.replace_pr_labels(replace_labels_req).await.unwrap();
+    // extra padding here
+    sleep(LONG_WAIT).await;
+
+    ////////////////////////////////////////////////////////////////////////////
+    // get_open_release_pr(legacy label) -> Found
+    ////////////////////////////////////////////////////////////////////////////
+    log::info!("looking for newly created open PR with legacy label");
+    let get_pr_req = GetPrRequest {
+        base_branch: default_branch.to_string(),
+        head_branch: release_branch.to_string(),
+    };
+    let open_pr = forge.get_open_release_pr(get_pr_req).await.unwrap();
+    assert!(open_pr.is_some());
+    let open_pr = open_pr.unwrap();
+    assert_ne!(open_pr.number, 0);
+    assert!(!open_pr.body.is_empty());
+    assert!(!open_pr.sha.is_empty());
+
+    ////////////////////////////////////////////////////////////////////////////
+    // replace_pr_labels(new-scoped) -> succeeds
+    ////////////////////////////////////////////////////////////////////////////
+    log::info!(
+        "replacing PR labels with new scoped pending label: {}",
+        PENDING_LABEL
+    );
     let replace_labels_req = PrLabelsRequest {
         labels: vec![PENDING_LABEL.into()],
         pr_number: release_pr.number,
@@ -196,9 +228,9 @@ pub async fn run_forge_test(
     sleep(LONG_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
-    // get_open_release_pr -> Found
+    // get_open_release_pr(new scoped label) -> Found
     ////////////////////////////////////////////////////////////////////////////
-    log::info!("looking for newly created open PR");
+    log::info!("looking for newly created open PR with new scoped label");
     let get_pr_req = GetPrRequest {
         base_branch: default_branch.to_string(),
         head_branch: release_branch.to_string(),


### PR DESCRIPTION
## Description

Switches to using :: as the separator in all labels in all forges. This winds up having no effect in github and gitea as the extra colon is treated as just another character; however, in gitlab this creates a scoped, mutually exclusive, label. This commit ensures backward compatibility by falling back to the legacy pending label when nothing is found for the new variant

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)

## Related Issues

Fixes #250
