### PR TITLE
fix: address issues with tag ordering when analyzing

### DIFF
--- a/book/src/library-api.md
+++ b/book/src/library-api.md
@@ -6,12 +6,12 @@ directly in your own tooling rather than shelling out to the CLI.
 
 ## When to use the library vs the CLI
 
-| Situation | Recommendation |
-|---|---|
-| CI/CD pipeline, GitHub Actions | Use the CLI |
-| Custom Rust tooling or internal build system | Use the library |
+| Situation                                            | Recommendation  |
+| ---------------------------------------------------- | --------------- |
+| CI/CD pipeline, GitHub Actions                       | Use the CLI     |
+| Custom Rust tooling or internal build system         | Use the library |
 | Need to integrate release data into another workflow | Use the library |
-| Simple changelog + tag automation | Use the CLI |
+| Simple changelog + tag automation                    | Use the CLI     |
 
 ## Adding the dependency
 
@@ -85,11 +85,11 @@ dependencies to construct a `SecretString`.
 `Forge` is the extension point for platform support. The crate ships
 four implementations:
 
-| Type | When to use |
-|---|---|
-| `forge::github::Github` | GitHub (cloud or Enterprise) |
-| `forge::gitlab::Gitlab` | GitLab (cloud or self-hosted) |
-| `forge::gitea::Gitea` | Gitea self-hosted |
+| Type                      | When to use                     |
+| ------------------------- | ------------------------------- |
+| `forge::github::Github`   | GitHub (cloud or Enterprise)    |
+| `forge::gitlab::Gitlab`   | GitLab (cloud or self-hosted)   |
+| `forge::gitea::Gitea`     | Gitea self-hosted               |
 | `forge::local::LocalRepo` | Local git2 operations (testing) |
 
 To target a custom platform, implement the `Forge` trait from
@@ -142,8 +142,8 @@ impl Forge for MyForge {
     #     -> Result<Commit> { todo!() }
     # async fn tag_commit(&self, _: &str, _: &str)
     #     -> Result<()> { todo!() }
-    # async fn get_latest_tag_for_prefix(&self, _: &str, _: &str)
-    #     -> Result<Option<Tag>> { todo!() }
+    # async fn get_latest_tags_for_prefix(&self, _: &str, _: &str)
+    #     -> Result<Vec<Tag>> { todo!() }
     # async fn get_commits(&self, _: Option<String>, _: Option<String>)
     #     -> Result<Vec<ForgeCommit>> { todo!() }
     # async fn get_open_release_pr(&self, _: GetPrRequest)

--- a/crates/releasaurus-core/src/forge/gitea.rs
+++ b/crates/releasaurus-core/src/forge/gitea.rs
@@ -286,21 +286,20 @@ impl Forge for Gitea {
         })
     }
 
-    // Note: Tags are returned in reverse chronological order. We return the
-    // first tag (by semver descending) that matches the prefix AND is an
-    // ancestor of the target base branch.
-    async fn get_latest_tag_for_prefix(
+    // We return only tags that matches the prefix AND are ancestors of
+    // the target base branch.
+    async fn get_latest_tags_for_prefix(
         &self,
         prefix: &str,
         branch: &str,
-    ) -> Result<Option<Tag>> {
+    ) -> Result<Vec<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
         let mut has_more = true;
         let mut page = 1;
         let page_limit = DEFAULT_PAGE_SIZE.to_string();
         let mut count = 0;
 
-        let mut tag_matches = vec![];
+        let mut tags = vec![];
 
         while has_more {
             let mut tags_url = self.base_url.join("tags")?;
@@ -321,9 +320,9 @@ impl Forge for Gitea {
                 .unwrap_or(false);
 
             let result = response.error_for_status()?;
-            let tags: Vec<GiteaTag> = result.json().await?;
+            let page_tags: Vec<GiteaTag> = result.json().await?;
 
-            for tag in tags.into_iter() {
+            for tag in page_tags.into_iter() {
                 if count >= DEFAULT_TAG_SEARCH_DEPTH {
                     has_more = false;
                     break;
@@ -331,8 +330,21 @@ impl Forge for Gitea {
                 count += 1;
                 if re.is_match(&tag.name) {
                     let stripped = re.replace_all(&tag.name, "").to_string();
-                    if let Ok(sver) = semver::Version::parse(&stripped) {
-                        tag_matches.push((tag, sver))
+                    if let Ok(sver) = semver::Version::parse(&stripped)
+                        && self
+                            .is_tag_ancestor_of_branch(&tag.commit.sha, branch)
+                            .await?
+                    {
+                        tags.push(Tag {
+                            name: tag.name,
+                            semver: sver,
+                            sha: tag.commit.sha,
+                            timestamp: DateTime::parse_from_rfc3339(
+                                &tag.commit.created,
+                            )
+                            .map(|t| t.timestamp())
+                            .ok(),
+                        });
                     }
                 }
             }
@@ -340,34 +352,7 @@ impl Forge for Gitea {
             page += 1;
         }
 
-        if tag_matches.is_empty() {
-            return Ok(None);
-        }
-
-        // tags are returned in reverse chronological order (newest first),
-        // which means they could be out of order, so here we sort by
-        // semantic version (descending) to get latest
-        tag_matches.sort_by(|a, b| b.1.cmp(&a.1));
-
-        for (tag, sver) in tag_matches.into_iter() {
-            if self
-                .is_tag_ancestor_of_branch(&tag.commit.sha, branch)
-                .await?
-            {
-                return Ok(Some(Tag {
-                    name: tag.name.clone(),
-                    semver: sver.clone(),
-                    sha: tag.commit.sha.clone(),
-                    timestamp: DateTime::parse_from_rfc3339(
-                        &tag.commit.created,
-                    )
-                    .map(|t| t.timestamp())
-                    .ok(),
-                }));
-            }
-        }
-
-        Ok(None)
+        Ok(tags)
     }
 
     async fn get_commits(

--- a/crates/releasaurus-core/src/forge/github.rs
+++ b/crates/releasaurus-core/src/forge/github.rs
@@ -355,19 +355,19 @@ impl Forge for Github {
         })
     }
 
-    // Note: we use graphql query with tags sorted by commit date descending.
-    // We return the first tag that matches the prefix AND is an ancestor of
+    // We return only tags that matches the prefix AND are ancestors of
     // the target base branch.
-    async fn get_latest_tag_for_prefix(
+    async fn get_latest_tags_for_prefix(
         &self,
         prefix: &str,
         branch: &str,
-    ) -> Result<Option<Tag>> {
+    ) -> Result<Vec<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
 
         let mut cursor = None;
         let mut has_next_page = true;
         let mut count = 0;
+        let mut tags = vec![];
 
         while has_next_page {
             let vars = TagSearchQueryVariables {
@@ -386,7 +386,7 @@ impl Forge for Github {
             cursor = result.data.repository.refs.page_info.end_cursor;
             has_next_page = result.data.repository.refs.page_info.has_next_page;
 
-            for tag in result.data.repository.refs.nodes {
+            for tag in result.data.repository.refs.nodes.into_iter() {
                 if count >= DEFAULT_TAG_SEARCH_DEPTH {
                     has_next_page = false;
                     break;
@@ -404,17 +404,16 @@ impl Forge for Github {
                             .map(|t| t.oid.clone())
                             .unwrap_or(tag.target.oid.clone());
 
-                        let committed_date =
-                            tag.target.committed_date.unwrap_or(
-                                tag.target
-                                    .target
-                                    .as_ref()
-                                    .map(|t| t.committed_date.clone())
-                                    .unwrap_or_default(),
-                            );
-
                         if self.is_tag_ancestor_of_branch(&sha, branch).await? {
-                            return Ok(Some(Tag {
+                            let committed_date =
+                                tag.target.committed_date.unwrap_or(
+                                    tag.target
+                                        .target
+                                        .as_ref()
+                                        .map(|t| t.committed_date.clone())
+                                        .unwrap_or_default(),
+                                );
+                            tags.push(Tag {
                                 name: tag.name,
                                 semver: sver,
                                 sha,
@@ -423,14 +422,14 @@ impl Forge for Github {
                                 )
                                 .map(|t| t.timestamp())
                                 .ok(),
-                            }));
+                            });
                         }
                     }
                 }
             }
         }
 
-        Ok(None)
+        Ok(tags)
     }
 
     async fn get_commits(

--- a/crates/releasaurus-core/src/forge/gitlab.rs
+++ b/crates/releasaurus-core/src/forge/gitlab.rs
@@ -328,14 +328,13 @@ impl Forge for Gitlab {
         }
     }
 
-    // Note: Our query orders tags by semantic version descending. We return
-    // the first tag that matches the prefix AND is an ancestor of the target
-    // base branch.
-    async fn get_latest_tag_for_prefix(
+    // We return only tags that matches the prefix AND are ancestors of
+    // the target base branch.
+    async fn get_latest_tags_for_prefix(
         &self,
         prefix: &str,
         branch: &str,
-    ) -> Result<Option<Tag>> {
+    ) -> Result<Vec<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
         let endpoint = Tags::builder()
             .project(&self.project_id)
@@ -343,33 +342,36 @@ impl Forge for Gitlab {
             .sort(SortOrder::Descending)
             .build()?;
 
-        let tags: Vec<GitlabTag> =
+        let gitlab_tags: Vec<GitlabTag> =
             paged(endpoint, Pagination::Limit(DEFAULT_TAG_SEARCH_DEPTH.into()))
                 .query_async(&self.gl)
                 .await?;
 
-        for t in tags.into_iter() {
-            if re.is_match(&t.name) {
-                let stripped = re.replace_all(&t.name, "").to_string();
+        let mut tags = vec![];
+
+        for tag in gitlab_tags.into_iter() {
+            if re.is_match(&tag.name) {
+                let stripped = re.replace_all(&tag.name, "").to_string();
                 if let Ok(sver) = semver::Version::parse(&stripped)
                     && self
-                        .is_tag_ancestor_of_branch(&t.commit.id, branch)
+                        .is_tag_ancestor_of_branch(&tag.commit.id, branch)
                         .await?
                 {
-                    return Ok(Some(Tag {
-                        name: t.name,
+                    tags.push(Tag {
+                        name: tag.name,
                         semver: sver,
-                        sha: t.commit.id,
+                        sha: tag.commit.id,
                         timestamp: DateTime::parse_from_rfc3339(
-                            &t.commit.created_at,
+                            &tag.commit.created_at,
                         )
                         .map(|t| t.timestamp())
                         .ok(),
-                    }));
+                    });
                 }
             }
         }
-        Ok(None)
+
+        Ok(tags)
     }
 
     async fn get_commits(

--- a/crates/releasaurus-core/src/forge/local.rs
+++ b/crates/releasaurus-core/src/forge/local.rs
@@ -413,11 +413,11 @@ impl Forge for LocalRepo {
         }
     }
 
-    async fn get_latest_tag_for_prefix(
+    async fn get_latest_tags_for_prefix(
         &self,
         prefix: &str,
         branch: &str,
-    ) -> Result<Option<Tag>> {
+    ) -> Result<Vec<Tag>> {
         let regex_prefix = format!(r"^{}", prefix);
         let tag_prefix_regex = Regex::new(&regex_prefix)?;
 
@@ -453,7 +453,7 @@ impl Forge for LocalRepo {
         }
 
         if commits.is_empty() {
-            return Ok(None);
+            return Ok(vec![]);
         }
 
         let branch_head_oid = repo
@@ -474,17 +474,7 @@ impl Forge for LocalRepo {
                     .unwrap_or(false)
         });
 
-        if commits.is_empty() {
-            return Ok(None);
-        }
-
-        // sort commits by time descending so the first one should contain
-        // the latest tag
-        commits.sort_by(|(c1, _), (c2, _)| c2.time().cmp(&c1.time()));
-
-        let (_, tag) = commits[0].clone();
-
-        Ok(Some(tag))
+        Ok(commits.into_iter().map(|(_, tag)| tag).collect())
     }
 
     async fn get_commits(
@@ -791,11 +781,14 @@ mod tests {
         let branch = current_branch_name(&repo);
 
         let forge = LocalRepo::new(dir.path(), None).unwrap();
-        let result =
-            forge.get_latest_tag_for_prefix("v", &branch).await.unwrap();
+        let mut result = forge
+            .get_latest_tags_for_prefix("v", &branch)
+            .await
+            .unwrap();
+        result.sort_by(|a, b| b.semver.cmp(&a.semver));
 
-        assert!(result.is_some(), "tag at branch head should be found");
-        assert_eq!(result.unwrap().name, "v1.0.0");
+        assert!(!result.is_empty(), "tag at branch head should be found");
+        assert_eq!(result[0].name, "v1.0.0");
     }
 
     /// `create_branch` must create a branch pointing to current HEAD.
@@ -1124,18 +1117,18 @@ mod tests {
 
         // Querying main_branch must return v1.0.0 only; v2.0.0 is
         // not in main_branch's history.
-        let result = forge
-            .get_latest_tag_for_prefix("v", &main_branch)
+        let mut result = forge
+            .get_latest_tags_for_prefix("v", &main_branch)
             .await
             .unwrap();
+        result.sort_by(|a, b| b.semver.cmp(&a.semver));
 
         assert!(
-            result.is_some(),
+            !result.is_empty(),
             "v1.0.0 (ancestor of main) should be found"
         );
         assert_eq!(
-            result.unwrap().name,
-            "v1.0.0",
+            result[0].name, "v1.0.0",
             "v2.0.0 (only on divergent branch) must be excluded"
         );
     }

--- a/crates/releasaurus-core/src/forge/manager.rs
+++ b/crates/releasaurus-core/src/forge/manager.rs
@@ -104,7 +104,23 @@ impl ForgeManager {
         prefix: &str,
         branch: &str,
     ) -> Result<Option<Tag>> {
-        self.forge.get_latest_tag_for_prefix(prefix, branch).await
+        let mut tags = self
+            .forge
+            .get_latest_tags_for_prefix(prefix, branch)
+            .await?;
+
+        if tags.is_empty() {
+            return Ok(None);
+        }
+
+        // Sort by semantic version descending so the highest version is
+        // first. Tag ordering from forge APIs is unreliable — forges differ
+        // in whether they sort by date, name, or version, and none handle
+        // pre-release ordering correctly (e.g. 1.0.0-rc.1 vs 1.0.0).
+        // Semver ordering is the single source of truth for "latest"
+        // across all forge backends.
+        tags.sort_by(|a, b| b.semver.cmp(&a.semver));
+        Ok(tags.into_iter().next())
     }
 
     pub async fn get_commits(
@@ -350,9 +366,136 @@ impl FileLoader for ForgeManager {
 mod tests {
     use super::*;
     use crate::{
+        analyzer::release::Tag,
         file_loader::FileLoader,
         forge::{request::GetFileContentRequest, traits::MockForge},
     };
+
+    fn make_tag(prefix: &str, version: &str) -> Tag {
+        Tag {
+            name: format!("{prefix}{version}"),
+            semver: semver::Version::parse(version).unwrap(),
+            sha: format!("sha-{version}"),
+            timestamp: None,
+        }
+    }
+
+    fn mock_returning_tags(tags: Vec<Tag>) -> MockForge {
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(move |_, _| Ok(tags.clone()));
+        mock
+    }
+
+    #[tokio::test]
+    async fn get_latest_tag_returns_none_when_no_tags() {
+        let mock = mock_returning_tags(vec![]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_tag_for_prefix("v", "main")
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_latest_tag_returns_single_tag() {
+        let mock = mock_returning_tags(vec![make_tag("v", "1.0.0")]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_tag_for_prefix("v", "main")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.name, "v1.0.0");
+    }
+
+    #[tokio::test]
+    async fn get_latest_tag_returns_highest_semver_regardless_of_input_order() {
+        // Tags arrive in arbitrary order (simulating an unreliable forge API).
+        let mock = mock_returning_tags(vec![
+            make_tag("v", "1.0.0"),
+            make_tag("v", "2.0.0"),
+            make_tag("v", "1.5.0"),
+        ]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_tag_for_prefix("v", "main")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.name, "v2.0.0");
+    }
+
+    #[tokio::test]
+    async fn get_latest_tag_prefers_stable_over_prerelease() {
+        // A pre-release tag may have a later commit date than the stable
+        // release it preceded, causing date-based sorting to pick it
+        // incorrectly. Semver ordering must place 1.0.0 above 1.0.0-rc.1.
+        let mock = mock_returning_tags(vec![
+            make_tag("v", "1.0.0-rc.1"),
+            make_tag("v", "1.0.0"),
+        ]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_tag_for_prefix("v", "main")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.name, "v1.0.0");
+    }
+
+    #[tokio::test]
+    async fn get_latest_tag_orders_prereleases_by_semver() {
+        // When only pre-release tags exist the highest pre-release wins.
+        let mock = mock_returning_tags(vec![
+            make_tag("v", "2.0.0-rc.1"),
+            make_tag("v", "2.0.0-beta.1"),
+            make_tag("v", "2.0.0-alpha.1"),
+        ]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_tag_for_prefix("v", "main")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.name, "v2.0.0-rc.1");
+    }
+
+    #[tokio::test]
+    async fn get_latest_tag_prefers_beta_over_alpha_prerelease() {
+        // Semver compares pre-release identifiers lexicographically, so
+        // "beta" > "alpha" and 2.0.0-beta.1 is the correct winner.
+        let mock = mock_returning_tags(vec![
+            make_tag("v", "2.0.0-alpha.1"),
+            make_tag("v", "2.0.0-beta.1"),
+        ]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_tag_for_prefix("v", "main")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.name, "v2.0.0-beta.1");
+    }
 
     #[tokio::test]
     async fn file_loader_returns_file_content() {

--- a/crates/releasaurus-core/src/forge/traits.rs
+++ b/crates/releasaurus-core/src/forge/traits.rs
@@ -53,13 +53,14 @@ pub trait Forge: Any + Send + Sync {
     async fn create_commit(&self, req: CreateCommitRequest) -> Result<Commit>;
     /// Create a git tag pointing to a specific commit SHA.
     async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()>;
-    /// Find the most recent tag matching the given prefix (e.g., "v" or
-    /// "api-v") that is an ancestor of the given branch.
-    async fn get_latest_tag_for_prefix(
+    /// Find all tags matching the given prefix (e.g., "v" or "api-v") that
+    /// are ancestors of the given branch, returned as normalized Tag structs
+    /// in no guaranteed order.
+    async fn get_latest_tags_for_prefix(
         &self,
         prefix: &str,
         branch: &str,
-    ) -> Result<Option<Tag>>;
+    ) -> Result<Vec<Tag>>;
     /// Fetch commits for a package path, optionally starting from a specific
     /// SHA.
     async fn get_commits(

--- a/crates/releasaurus-core/src/orchestrator/commits.rs
+++ b/crates/releasaurus-core/src/orchestrator/commits.rs
@@ -533,23 +533,23 @@ mod tests {
 
         // One tag fetch per package (collected once, not re-fetched later)
         mock_forge
-            .expect_get_latest_tag_for_prefix()
+            .expect_get_latest_tags_for_prefix()
             .times(2)
             .returning(|prefix, _branch| {
                 if prefix.contains("pkg-a") {
                     // pkg-a has newer tag (timestamp 2000)
-                    Ok(Some(Tag {
+                    Ok(vec![Tag {
                         sha: "newer-sha".to_string(),
                         timestamp: Some(2000),
                         ..Default::default()
-                    }))
+                    }])
                 } else {
                     // pkg-b has older tag (timestamp 1000)
-                    Ok(Some(Tag {
+                    Ok(vec![Tag {
                         sha: "older-sha".to_string(),
                         timestamp: Some(1000),
                         ..Default::default()
-                    }))
+                    }])
                 }
             });
 
@@ -638,18 +638,18 @@ mod tests {
         // Tags are collected once in a single pass (2 calls total).
         // The fallback fetch reuses the already-collected tags.
         mock_forge
-            .expect_get_latest_tag_for_prefix()
+            .expect_get_latest_tags_for_prefix()
             .times(2)
             .returning(|prefix, _branch| {
                 if prefix.contains("pkg-a") {
-                    Ok(Some(Tag {
+                    Ok(vec![Tag {
                         sha: "some-sha".to_string(),
                         timestamp: Some(1000),
                         ..Default::default()
-                    }))
+                    }])
                 } else {
                     // pkg-b has no tag yet
-                    Ok(None)
+                    Ok(vec![])
                 }
             });
 

--- a/crates/releasaurus-core/src/orchestrator/core/tests/prepare.rs
+++ b/crates/releasaurus-core/src/orchestrator/core/tests/prepare.rs
@@ -16,8 +16,8 @@ async fn generate_prepared_with_dummy_commit_skips_untagged_packages() {
     let mut mock_forge = MockForge::new();
 
     mock_forge
-        .expect_get_latest_tag_for_prefix()
-        .returning(|_, _| Ok(None)); // No tags exist
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _| Ok(vec![])); // No tags exist
 
     let orchestrator = create_core(mock_forge, None, None);
 
@@ -46,13 +46,13 @@ async fn generate_prepared_with_dummy_commit_filters_by_targets() {
 
     let mut mock_forge = MockForge::new();
 
-    mock_forge.expect_get_latest_tag_for_prefix().returning(
+    mock_forge.expect_get_latest_tags_for_prefix().returning(
         |prefix, _branch| {
-            Ok(Some(Tag {
+            Ok(vec![Tag {
                 name: format!("{prefix}1.0.0"),
                 timestamp: Some(1000),
                 ..Default::default()
-            }))
+            }])
         },
     );
 

--- a/crates/releasaurus-core/src/orchestrator/tests/current_releases.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/current_releases.rs
@@ -21,12 +21,12 @@ async fn get_current_releases_retrieves_release_data() {
     let mut mock_forge = MockForge::new();
 
     mock_forge
-        .expect_get_latest_tag_for_prefix()
+        .expect_get_latest_tags_for_prefix()
         .returning(|_, _| {
-            Ok(Some(Tag {
+            Ok(vec![Tag {
                 name: "v1.0.0".to_string(),
                 ..Default::default()
-            }))
+            }])
         });
 
     mock_forge
@@ -54,8 +54,8 @@ async fn get_next_releases_filters_by_package_name() {
     let mut mock_forge = MockForge::new();
 
     mock_forge
-        .expect_get_latest_tag_for_prefix()
-        .returning(|_, _| Ok(None));
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![

--- a/crates/releasaurus-core/src/orchestrator/tests/next_release.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/next_release.rs
@@ -19,12 +19,12 @@ async fn start_next_release_creates_commits_for_tagged_packages() {
     let mut mock_forge = MockForge::new();
 
     mock_forge
-        .expect_get_latest_tag_for_prefix()
+        .expect_get_latest_tags_for_prefix()
         .returning(|_, _| {
-            Ok(Some(Tag {
+            Ok(vec![Tag {
                 semver: Version::parse("1.0.0").unwrap(),
                 ..Default::default()
-            }))
+            }])
         });
 
     mock_forge.expect_get_commits().returning(|_, _| Ok(vec![]));
@@ -50,19 +50,19 @@ async fn start_next_release_filters_by_target_packages() {
     let mut mock_forge = MockForge::new();
 
     mock_forge
-        .expect_get_latest_tag_for_prefix()
+        .expect_get_latest_tags_for_prefix()
         .times(2)
         .returning(|prefix, _branch| {
             if prefix.contains("pkg-a") {
-                Ok(Some(Tag {
+                Ok(vec![Tag {
                     semver: Version::parse("1.0.0").unwrap(),
                     ..Default::default()
-                }))
+                }])
             } else {
-                Ok(Some(Tag {
+                Ok(vec![Tag {
                     semver: Version::parse("2.0.0").unwrap(),
                     ..Default::default()
-                }))
+                }])
             }
         });
 
@@ -107,8 +107,8 @@ async fn start_next_release_skips_untagged_packages() {
 
     // Return None indicating no tag exists for this package
     mock_forge
-        .expect_get_latest_tag_for_prefix()
-        .returning(|_, _| Ok(None));
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _| Ok(vec![]));
 
     // Should NOT call create_commit since package has no tag
     mock_forge.expect_create_commit().times(0);

--- a/crates/releasaurus-core/src/orchestrator/tests/pr_workflow.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/pr_workflow.rs
@@ -23,14 +23,14 @@ async fn create_release_prs_succeeds_when_no_commits_since_last_tag() {
 
     // Has tag, but no new commits
     mock_forge
-        .expect_get_latest_tag_for_prefix()
+        .expect_get_latest_tags_for_prefix()
         .returning(|_, _| {
-            Ok(Some(crate::analyzer::release::Tag {
+            Ok(vec![crate::analyzer::release::Tag {
                 name: "v1.0.0".to_string(),
                 semver: Version::parse("1.0.0").unwrap(),
                 sha: "abc123".to_string(),
                 timestamp: Some(1234567890),
-            }))
+            }])
         });
 
     // No commits since tag
@@ -52,8 +52,8 @@ async fn create_release_prs_returns_error_when_merged_pr_not_yet_released() {
 
     // No tags exist yet
     mock_forge
-        .expect_get_latest_tag_for_prefix()
-        .returning(|_, _| Ok(None));
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -97,8 +97,8 @@ async fn create_release_prs_creates_new_prs() {
 
     // No tags exist yet
     mock_forge
-        .expect_get_latest_tag_for_prefix()
-        .returning(|_, _| Ok(None));
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -188,8 +188,8 @@ async fn create_release_prs_targets_specific_package() {
 
     // No tags exist yet
     mock_forge
-        .expect_get_latest_tag_for_prefix()
-        .returning(|_, _| Ok(None));
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -306,14 +306,14 @@ async fn create_release_prs_updates_existing_prs() {
     let mut mock_forge = MockForge::new();
 
     mock_forge
-        .expect_get_latest_tag_for_prefix()
+        .expect_get_latest_tags_for_prefix()
         .returning(|_, _| {
-            Ok(Some(crate::analyzer::release::Tag {
+            Ok(vec![crate::analyzer::release::Tag {
                 name: "v1.0.0".to_string(),
                 semver: Version::parse("1.0.0").unwrap(),
                 sha: "abc123".to_string(),
                 timestamp: Some(100),
-            }))
+            }])
         });
 
     mock_forge.expect_get_commits().returning(|_, _| {

--- a/crates/releasaurus-core/src/orchestrator/tests/release_workflow.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/release_workflow.rs
@@ -137,12 +137,12 @@ Release notes
 
     // Expect auto-start-next flow
     mock_forge
-        .expect_get_latest_tag_for_prefix()
+        .expect_get_latest_tags_for_prefix()
         .returning(|_, _| {
-            Ok(Some(Tag {
+            Ok(vec![Tag {
                 semver: Version::parse("1.0.0").unwrap(),
                 ..Default::default()
-            }))
+            }])
         });
 
     mock_forge.expect_get_commits().returning(|_, _| Ok(vec![]));


### PR DESCRIPTION
## Description

Ensures tags are sorted by semantic version client side when searching for latest tag for a target prefix. This ensures pre-release tags are always handled properly.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

## Related Issues

Fixes #254 
