### PR TITLE
feat: adds the ability to aggregate changelogs for prereleases

### DIFF
--- a/book/src/configuration-changelog.md
+++ b/book/src/configuration-changelog.md
@@ -95,6 +95,20 @@ Include commit author names in changelog entries:
 include_author = true
 ```
 
+### `aggregate_prereleases` (default: false)
+
+When graduating from a prerelease to a stable release, aggregate
+changelog entries from all prior prerelease versions into the stable
+release notes:
+
+```toml
+[changelog]
+aggregate_prereleases = true
+```
+
+See [Prerelease Workflows](configuration-prerelease.md) for details
+on graduation.
+
 ### `skip_shas` (default: none)
 
 Skip specific commits by SHA prefix:

--- a/book/src/configuration-prerelease.md
+++ b/book/src/configuration-prerelease.md
@@ -115,6 +115,14 @@ Result:   v1.0.0
 
 Remove the `[prerelease]` section or set `suffix = ""` to graduate.
 
+To include changelog entries from all prior prerelease versions in the
+stable release, enable `aggregate_prereleases`:
+
+```toml
+[changelog]
+aggregate_prereleases = true
+```
+
 ## Static Strategy
 
 Fixed suffix without counters, common in Java ecosystems.
@@ -146,6 +154,14 @@ Current:  v1.0.1-SNAPSHOT
 Commit:   fix: final fix
 Config:   (no prerelease section)
 Result:   v1.0.1
+```
+
+To include changelog entries from all prior prerelease versions in the
+stable release, enable `aggregate_prereleases`:
+
+```toml
+[changelog]
+aggregate_prereleases = true
 ```
 
 ## Practical Examples

--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -272,6 +272,21 @@ Include commit author names in changelog.
 include_author = true
 ```
 
+#### `aggregate_prereleases`
+
+**Type**: Boolean (optional)
+
+**Default**: false
+
+Aggregate changelog entries from all prior prerelease versions into
+the graduating stable release. Has no effect when the current version
+is already stable.
+
+```toml
+[changelog]
+aggregate_prereleases = true
+```
+
 #### `skip_shas`
 
 **Type**: Array of strings (optional)

--- a/crates/releasaurus-core/src/config/changelog.rs
+++ b/crates/releasaurus-core/src/config/changelog.rs
@@ -44,6 +44,8 @@ pub struct ChangelogConfig {
     pub reword: Option<Vec<RewordedCommit>>,
     /// Includes commit author name in default body template
     pub include_author: bool,
+    /// Aggregates changelogs from prior prereleases when graduating
+    pub aggregate_prereleases: bool,
 }
 
 impl Default for ChangelogConfig {
@@ -58,6 +60,7 @@ impl Default for ChangelogConfig {
             skip_shas: None,
             reword: None,
             include_author: false,
+            aggregate_prereleases: false,
         }
     }
 }

--- a/crates/releasaurus-core/src/forge/manager.rs
+++ b/crates/releasaurus-core/src/forge/manager.rs
@@ -114,13 +114,46 @@ impl ForgeManager {
         }
 
         // Sort by semantic version descending so the highest version is
-        // first. Tag ordering from forge APIs is unreliable — forges differ
-        // in whether they sort by date, name, or version, and none handle
+        // first. Tag ordering from forge APIs is unreliable and none handle
         // pre-release ordering correctly (e.g. 1.0.0-rc.1 vs 1.0.0).
-        // Semver ordering is the single source of truth for "latest"
-        // across all forge backends.
+        // Semver ordering is the single source of truth for all forge backends.
         tags.sort_by(|a, b| b.semver.cmp(&a.semver));
         Ok(tags.into_iter().next())
+    }
+
+    pub async fn get_latest_stable_release_tag(
+        &self,
+        prefix: &str,
+        branch: &str,
+    ) -> Result<Option<Tag>> {
+        let mut tags = self
+            .forge
+            .get_latest_tags_for_prefix(prefix, branch)
+            .await?;
+
+        if tags.is_empty() {
+            return Ok(None);
+        }
+
+        // Sort by semantic version descending so the highest version is first.
+        // Tag ordering from forge APIs is unreliable and none handle
+        // pre-release ordering correctly (e.g. 1.0.0-rc.1 vs 1.0.0).
+        // Semver ordering is the single source of truth for all forge backends.
+        tags.sort_by(|a, b| b.semver.cmp(&a.semver));
+
+        // iterate to find where current prerelease series stops at last
+        // stable release
+        for tag in tags {
+            // skip prereleases until we get to stable release
+            if !tag.semver.pre.is_empty() {
+                continue;
+            }
+
+            return Ok(Some(tag));
+        }
+
+        // No stable releases found
+        Ok(None)
     }
 
     pub async fn get_commits(
@@ -495,6 +528,61 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.name, "v2.0.0-beta.1");
+    }
+
+    #[tokio::test]
+    async fn get_latest_stable_release_tag_returns_none_when_no_tags() {
+        let mock = mock_returning_tags(vec![]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_stable_release_tag("v", "main")
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_latest_stable_release_tag_returns_none_when_only_prereleases()
+    {
+        let mock = mock_returning_tags(vec![
+            make_tag("v", "1.0.0-rc.1"),
+            make_tag("v", "1.0.0-rc.2"),
+        ]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_stable_release_tag("v", "main")
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_latest_stable_release_tag_returns_highest_stable_from_mixed_list()
+     {
+        // Forge returns tags in arbitrary order; stable tags are interleaved
+        // with prerelease tags. The highest stable version must win.
+        let mock = mock_returning_tags(vec![
+            make_tag("v", "1.0.0-rc.1"),
+            make_tag("v", "1.0.0"),
+            make_tag("v", "2.0.0"),
+            make_tag("v", "0.9.0"),
+        ]);
+        let manager =
+            ForgeManager::new(Box::new(mock), ForgeOptions { dry_run: false });
+
+        let result = manager
+            .get_latest_stable_release_tag("v", "main")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.name, "v2.0.0");
     }
 
     #[tokio::test]

--- a/crates/releasaurus-core/src/orchestrator/commits.rs
+++ b/crates/releasaurus-core/src/orchestrator/commits.rs
@@ -14,6 +14,11 @@ use crate::{
     },
 };
 
+pub struct CurrentTagInfo {
+    pub tag: Option<Tag>,
+    pub graduating_to_stable: bool,
+}
+
 pub struct CommitsCore {
     orchestrator_config: Rc<OrchestratorConfig>,
     forge: Rc<ForgeManager>,
@@ -41,7 +46,7 @@ impl CommitsCore {
     pub async fn get_commits_for_all_packages(
         &self,
         target: Option<&str>,
-    ) -> Result<(Vec<ForgeCommit>, HashMap<String, Option<Tag>>)> {
+    ) -> Result<(Vec<ForgeCommit>, HashMap<String, CurrentTagInfo>)> {
         log::info!("attempting to get commits for all packages at once");
 
         let tags = self.collect_tags_for_packages(target).await?;
@@ -125,12 +130,42 @@ impl CommitsCore {
         package_commits
     }
 
+    pub async fn fetch_additional_commits_for_prerelease_aggregation(
+        &self,
+        pkg: &ResolvedPackage,
+    ) -> Result<Vec<ForgeCommit>> {
+        let mut commits = vec![];
+
+        let latest_stable_tag = self
+            .forge
+            .get_latest_stable_release_tag(
+                &pkg.tag_prefix,
+                &self.orchestrator_config.base_branch,
+            )
+            .await?;
+
+        if let Some(tag) = latest_stable_tag {
+            commits = self
+                .forge
+                .get_commits(
+                    Some(self.orchestrator_config.base_branch.clone()),
+                    Some(tag.sha.clone()),
+                )
+                .await?;
+
+            commits =
+                self.filter_commits_for_package(pkg, Some(&tag), &commits);
+        }
+
+        Ok(commits)
+    }
+
     /// Collects the latest tag for every (target-filtered) package in a
     /// single pass, returning a map keyed by package name.
     async fn collect_tags_for_packages(
         &self,
         target: Option<&str>,
-    ) -> Result<HashMap<String, Option<Tag>>> {
+    ) -> Result<HashMap<String, CurrentTagInfo>> {
         let mut tags = HashMap::new();
         for (name, package) in self.package_configs.hash().iter() {
             if let Some(target) = target
@@ -145,7 +180,44 @@ impl CommitsCore {
                     &self.orchestrator_config.base_branch,
                 )
                 .await?;
-            tags.insert(name.clone(), tag);
+
+            let graduating_to_stable = tag
+                .as_ref()
+                .map(|t| {
+                    // check if current tag has pre-release identifier and
+                    // pre-release configuration is empty, or suffix is empty,
+                    // indicating we are graduating from pre-release to stable
+                    // version
+                    if t.semver.pre.is_empty() {
+                        // current tag does not have pre-release identifier
+                        // so nothing to graduate from
+                        return false;
+                    }
+
+                    // current tag has a pre-release identifier - check config
+
+                    if let Some(prerelease_config) = package.prerelease.as_ref()
+                    {
+                        // suffix is empty = graduating
+                        prerelease_config
+                            .suffix
+                            .as_deref()
+                            .unwrap_or_default()
+                            .is_empty()
+                    } else {
+                        // prerelease config is none = graduating
+                        true
+                    }
+                })
+                .unwrap_or_default();
+
+            tags.insert(
+                name.clone(),
+                CurrentTagInfo {
+                    tag,
+                    graduating_to_stable,
+                },
+            );
         }
         Ok(tags)
     }
@@ -155,12 +227,12 @@ impl CommitsCore {
     /// (i.e. any package has no tag yet).
     async fn get_commits_for_packages_with_tags(
         &self,
-        tags: &HashMap<String, Option<Tag>>,
+        tags: &HashMap<String, CurrentTagInfo>,
     ) -> Result<Vec<ForgeCommit>> {
         let mut cache: HashSet<ForgeCommit> = HashSet::new();
 
         for (name, tag) in tags.iter() {
-            let current_sha = tag.as_ref().map(|t| t.sha.clone());
+            let current_sha = tag.tag.as_ref().map(|t| t.sha.clone());
 
             log::info!(
                 "{name}: current tag sha: {:?} : fetching commits",
@@ -188,9 +260,9 @@ impl CommitsCore {
     /// determined).
     fn oldest_tag_sha_from_map(
         &self,
-        tags: &HashMap<String, Option<Tag>>,
+        tags: &HashMap<String, CurrentTagInfo>,
     ) -> Option<String> {
-        if tags.values().any(|t| t.is_none()) {
+        if tags.values().any(|t| t.tag.is_none()) {
             log::warn!("found package that hasn't been tagged yet");
             return None;
         }
@@ -198,7 +270,7 @@ impl CommitsCore {
         let mut oldest_timestamp = i64::MAX;
         let mut oldest_sha = None;
 
-        for tag in tags.values().flatten() {
+        for tag in tags.values().flat_map(|t| t.tag.iter()) {
             if let Some(ts) = tag.timestamp
                 && ts < oldest_timestamp
             {
@@ -219,7 +291,10 @@ mod tests {
     use crate::{
         analyzer::release::Tag,
         config::{
-            Config, package::PackageConfigBuilder, release_type::ReleaseType,
+            Config,
+            package::{PackageConfig, PackageConfigBuilder},
+            prerelease::{PrereleaseConfig, PrereleaseStrategy},
+            release_type::ReleaseType,
         },
         forge::{
             manager::{ForgeManager, ForgeOptions},
@@ -705,5 +780,387 @@ mod tests {
             .unwrap();
         assert_eq!(commits.len(), 0);
         assert_eq!(tags.len(), 2);
+    }
+
+    // Helper: build a CommitsCore wired to a single package with a custom
+    // mock. Used by graduating_to_stable and aggregation tests.
+    fn make_commits_core_with_package(
+        mock: MockForge,
+        pkg_config: PackageConfig,
+    ) -> CommitsCore {
+        let config = Rc::new(Config::default());
+        let orchestrator_config = Rc::new(
+            OrchestratorConfig::builder()
+                .toml_config(config)
+                .repo_name("test-repo")
+                .repo_default_branch("main")
+                .release_link_base_url(
+                    Url::parse("https://example.com/").unwrap(),
+                )
+                .compare_link_base_url(
+                    Url::parse("https://example.com/compare/").unwrap(),
+                )
+                .package_overrides(std::collections::HashMap::new())
+                .global_overrides(GlobalOverrides::default())
+                .commit_modifiers(CommitModifiers::default())
+                .build()
+                .unwrap(),
+        );
+
+        let forge = Rc::new(ForgeManager::new(
+            Box::new(mock),
+            ForgeOptions { dry_run: false },
+        ));
+
+        let pkg = ResolvedPackage::builder()
+            .orchestrator_config(Rc::clone(&orchestrator_config))
+            .package_config(pkg_config)
+            .build()
+            .unwrap();
+
+        let package_configs =
+            Rc::new(ResolvedPackageHash::new(vec![pkg]).unwrap());
+
+        CommitsCore::new(orchestrator_config, forge, package_configs)
+    }
+
+    // --- graduating_to_stable detection ---
+
+    #[tokio::test]
+    async fn graduating_to_stable_true_when_prerelease_tag_and_no_config() {
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
+            Ok(vec![Tag {
+                name: "v1.0.0-rc.1".to_string(),
+                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                sha: "sha-rc1".to_string(),
+                timestamp: Some(1000),
+            }])
+        });
+        mock.expect_get_commits().returning(|_, _| Ok(vec![]));
+
+        let pkg = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path(".")
+            .release_type(ReleaseType::Node)
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg);
+        let (_, tags) = core.get_commits_for_all_packages(None).await.unwrap();
+
+        assert!(
+            tags.get("test-pkg").unwrap().graduating_to_stable,
+            "expected graduating_to_stable = true"
+        );
+    }
+
+    #[tokio::test]
+    async fn graduating_to_stable_false_when_stable_tag() {
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
+            Ok(vec![Tag {
+                name: "v1.0.0".to_string(),
+                semver: semver::Version::parse("1.0.0").unwrap(),
+                sha: "sha-1.0.0".to_string(),
+                timestamp: Some(1000),
+            }])
+        });
+        mock.expect_get_commits().returning(|_, _| Ok(vec![]));
+
+        let pkg = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path(".")
+            .release_type(ReleaseType::Node)
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg);
+        let (_, tags) = core.get_commits_for_all_packages(None).await.unwrap();
+
+        assert!(
+            !tags.get("test-pkg").unwrap().graduating_to_stable,
+            "expected graduating_to_stable = false"
+        );
+    }
+
+    #[tokio::test]
+    async fn graduating_to_stable_false_when_prerelease_config_present() {
+        // Current tag is a prerelease, but the package config still declares
+        // a prerelease strategy — so we are NOT graduating to stable.
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
+            Ok(vec![Tag {
+                name: "v1.0.0-rc.1".to_string(),
+                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                sha: "sha-rc1".to_string(),
+                timestamp: Some(1000),
+            }])
+        });
+        mock.expect_get_commits().returning(|_, _| Ok(vec![]));
+
+        let pkg = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path(".")
+            .release_type(ReleaseType::Node)
+            .prerelease(PrereleaseConfig {
+                suffix: Some("rc".to_string()),
+                strategy: PrereleaseStrategy::Versioned,
+            })
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg);
+        let (_, tags) = core.get_commits_for_all_packages(None).await.unwrap();
+
+        assert!(
+            !tags.get("test-pkg").unwrap().graduating_to_stable,
+            "expected graduating_to_stable = false"
+        );
+    }
+
+    #[tokio::test]
+    async fn graduating_to_stable_false_when_no_tag() {
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(|_, _| Ok(vec![]));
+        mock.expect_get_commits().returning(|_, _| Ok(vec![]));
+
+        let pkg = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path(".")
+            .release_type(ReleaseType::Node)
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg);
+        let (_, tags) = core.get_commits_for_all_packages(None).await.unwrap();
+
+        assert!(
+            !tags.get("test-pkg").unwrap().graduating_to_stable,
+            "expected graduating_to_stable = false when no tag exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn graduating_to_stable_true_when_prerelease_tag_and_empty_suffix() {
+        // Current tag is a prerelease and the package config has an empty
+        // suffix — the user has cleared the suffix to graduate to stable.
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
+            Ok(vec![Tag {
+                name: "v1.0.0-rc.1".to_string(),
+                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                sha: "sha-rc1".to_string(),
+                timestamp: Some(1000),
+            }])
+        });
+        mock.expect_get_commits().returning(|_, _| Ok(vec![]));
+
+        let pkg = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path(".")
+            .release_type(ReleaseType::Node)
+            .prerelease(PrereleaseConfig {
+                suffix: Some("".to_string()),
+                strategy: PrereleaseStrategy::Versioned,
+            })
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg);
+        let (_, tags) = core.get_commits_for_all_packages(None).await.unwrap();
+
+        assert!(
+            tags.get("test-pkg").unwrap().graduating_to_stable,
+            "expected graduating_to_stable = true when suffix is empty string"
+        );
+    }
+
+    #[tokio::test]
+    async fn graduating_to_stable_true_when_prerelease_tag_and_none_suffix() {
+        // Current tag is a prerelease and the prerelease config has no suffix
+        // set at all — treated the same as empty, i.e. graduating to stable.
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
+            Ok(vec![Tag {
+                name: "v1.0.0-rc.1".to_string(),
+                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                sha: "sha-rc1".to_string(),
+                timestamp: Some(1000),
+            }])
+        });
+        mock.expect_get_commits().returning(|_, _| Ok(vec![]));
+
+        let pkg = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path(".")
+            .release_type(ReleaseType::Node)
+            .prerelease(PrereleaseConfig {
+                suffix: None,
+                strategy: PrereleaseStrategy::Versioned,
+            })
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg);
+        let (_, tags) = core.get_commits_for_all_packages(None).await.unwrap();
+
+        assert!(
+            tags.get("test-pkg").unwrap().graduating_to_stable,
+            "expected graduating_to_stable = true when suffix is None"
+        );
+    }
+
+    // --- fetch_additional_commits_for_prerelease_aggregation ---
+
+    #[tokio::test]
+    async fn fetch_additional_returns_empty_when_no_stable_tag() {
+        // Only prerelease tags exist — no stable tag to aggregate from.
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
+            Ok(vec![
+                Tag {
+                    name: "v1.0.0-rc.1".to_string(),
+                    semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                    sha: "sha-rc1".to_string(),
+                    timestamp: None,
+                },
+                Tag {
+                    name: "v1.0.0-rc.2".to_string(),
+                    semver: semver::Version::parse("1.0.0-rc.2").unwrap(),
+                    sha: "sha-rc2".to_string(),
+                    timestamp: None,
+                },
+            ])
+        });
+
+        let pkg_config = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path("packages/pkg-a")
+            .release_type(ReleaseType::Node)
+            .build()
+            .unwrap();
+        let core = make_commits_core_with_package(mock, pkg_config);
+        let pkg = create_test_package("test-pkg", "packages/pkg-a");
+
+        let result = core
+            .fetch_additional_commits_for_prerelease_aggregation(&pkg)
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_additional_returns_commits_from_stable_tag_sha() {
+        let stable_tag = Tag {
+            name: "v1.0.0".to_string(),
+            semver: semver::Version::parse("1.0.0").unwrap(),
+            sha: "sha-1.0.0".to_string(),
+            timestamp: Some(0),
+        };
+
+        let commit_a = ForgeCommitBuilder::default()
+            .id("commit-a")
+            .short_id("ca")
+            .message("feat: prerelease feature")
+            .timestamp(100i64)
+            .files(vec!["packages/pkg-a/src/lib.rs".to_string()])
+            .build()
+            .unwrap();
+
+        let commit_b = ForgeCommitBuilder::default()
+            .id("commit-b")
+            .short_id("cb")
+            .message("fix: prerelease fix")
+            .timestamp(200i64)
+            .files(vec!["packages/pkg-a/src/main.rs".to_string()])
+            .build()
+            .unwrap();
+
+        let commits = vec![commit_a, commit_b];
+
+        let mut mock = MockForge::new();
+
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(move |_, _| Ok(vec![stable_tag.clone()]));
+        mock.expect_get_commits()
+            .returning(move |_, _| Ok(commits.clone()));
+
+        let pkg_config = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path("packages/pkg-a")
+            .release_type(ReleaseType::Node)
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg_config);
+        // create resolved pkg
+        let pkg = create_test_package("test-pkg", "packages/pkg-a");
+
+        let result = core
+            .fetch_additional_commits_for_prerelease_aggregation(&pkg)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].id, "commit-a");
+        assert_eq!(result[1].id, "commit-b");
+    }
+
+    #[tokio::test]
+    async fn fetch_additional_filters_commits_by_package_path() {
+        let stable_tag = Tag {
+            name: "v1.0.0".to_string(),
+            semver: semver::Version::parse("1.0.0").unwrap(),
+            sha: "sha-1.0.0".to_string(),
+            timestamp: Some(0),
+        };
+
+        let pkg_commit = ForgeCommitBuilder::default()
+            .id("pkg-commit")
+            .short_id("pc")
+            .message("feat: change in pkg-a")
+            .timestamp(100i64)
+            .files(vec!["packages/pkg-a/src/lib.rs".to_string()])
+            .build()
+            .unwrap();
+
+        let other_commit = ForgeCommitBuilder::default()
+            .id("other-commit")
+            .short_id("oc")
+            .message("fix: change in other package")
+            .timestamp(200i64)
+            .files(vec!["packages/pkg-b/src/lib.rs".to_string()])
+            .build()
+            .unwrap();
+
+        let commits = vec![pkg_commit, other_commit];
+
+        let mut mock = MockForge::new();
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(move |_, _| Ok(vec![stable_tag.clone()]));
+        mock.expect_get_commits()
+            .returning(move |_, _| Ok(commits.clone()));
+
+        let pkg_config = PackageConfigBuilder::default()
+            .name("test-pkg")
+            .path("packages/pkg-a")
+            .release_type(ReleaseType::Node)
+            .build()
+            .unwrap();
+
+        let core = make_commits_core_with_package(mock, pkg_config);
+        // create resolved pkg
+        let pkg = create_test_package("test-pkg", "packages/pkg-a");
+
+        let result = core
+            .fetch_additional_commits_for_prerelease_aggregation(&pkg)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "pkg-commit");
     }
 }

--- a/crates/releasaurus-core/src/orchestrator/core.rs
+++ b/crates/releasaurus-core/src/orchestrator/core.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, rc::Rc};
+use std::{
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -139,6 +142,8 @@ impl Core {
             .get_commits_for_all_packages(target)
             .await?;
 
+        let commit_hash_set: HashSet<_> = commits.iter().collect();
+
         for (name, package) in self.package_configs.hash().iter() {
             if let Some(target) = target
                 && package.name != target
@@ -146,13 +151,33 @@ impl Core {
                 continue;
             }
 
-            let current_tag = tags.get(name).cloned().flatten();
+            let tag_info = tags.get(name);
+            let current_tag = tag_info.and_then(|i| i.tag.clone());
+            let is_graduating_to_stable =
+                tag_info.map(|i| i.graduating_to_stable).unwrap_or_default();
 
-            let commits = self.commits_core.filter_commits_for_package(
+            let mut commits = self.commits_core.filter_commits_for_package(
                 package,
                 current_tag.as_ref(),
                 &commits,
             );
+
+            if self.config.changelog.aggregate_prereleases
+                && is_graduating_to_stable
+            {
+                let additional = self
+                    .commits_core
+                    .fetch_additional_commits_for_prerelease_aggregation(
+                        package,
+                    )
+                    .await?;
+                commits.extend(
+                    additional
+                        .into_iter()
+                        .filter(|c| !commit_hash_set.contains(c)),
+                );
+                commits.sort_by_key(|c| c.timestamp);
+            }
 
             prepared_packages.push(PreparedPackage {
                 name: name.clone(),

--- a/crates/releasaurus-core/src/orchestrator/core/tests/prepare.rs
+++ b/crates/releasaurus-core/src/orchestrator/core/tests/prepare.rs
@@ -4,11 +4,17 @@
 //! - Generating prepared packages with dummy commits
 //! - Skipping untagged packages
 //! - Filtering by target packages
+//! - Aggregating prerelease changelogs when graduating to stable
 
 use super::common::*;
 use crate::{
-    analyzer::release::Tag, config::package::PackageConfigBuilder,
-    forge::traits::MockForge,
+    analyzer::release::Tag,
+    config::{
+        Config,
+        changelog::ChangelogConfig,
+        package::{PackageConfig, PackageConfigBuilder},
+    },
+    forge::{request::ForgeCommitBuilder, traits::MockForge},
 };
 
 #[tokio::test]
@@ -65,4 +71,207 @@ async fn generate_prepared_with_dummy_commit_filters_by_targets() {
     // Should only include pkg-a
     assert_eq!(prepared.len(), 1);
     assert_eq!(prepared[0].name, "pkg-a");
+}
+
+// --- aggregate_prereleases tests ---
+
+// Shared test data for graduation scenario:
+// - prerelease tag at timestamp 1000 (current version)
+// - stable tag at timestamp 0 (last stable release)
+// - historical commit at timestamp 500 (between stable and prerelease)
+// - current commit at timestamp 2000 (after prerelease)
+
+fn prerelease_tag() -> Tag {
+    Tag {
+        name: "v1.0.0-rc.1".to_string(),
+        semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+        sha: "sha-rc1".to_string(),
+        timestamp: Some(1000),
+    }
+}
+
+fn stable_tag() -> Tag {
+    Tag {
+        name: "v0.9.0".to_string(),
+        semver: semver::Version::parse("0.9.0").unwrap(),
+        sha: "sha-0.9.0".to_string(),
+        timestamp: Some(0),
+    }
+}
+
+fn pkg_commit(id: &str, ts: i64) -> crate::forge::request::ForgeCommit {
+    ForgeCommitBuilder::default()
+        .id(id)
+        .short_id(id)
+        .message(format!("feat: {id}"))
+        .timestamp(ts)
+        .files(vec!["packages/pkg-a/src/lib.rs".to_string()])
+        .build()
+        .unwrap()
+}
+
+fn aggregate_config() -> Config {
+    Config {
+        changelog: ChangelogConfig {
+            aggregate_prereleases: true,
+            ..ChangelogConfig::default()
+        },
+        ..Config::default()
+    }
+}
+
+fn graduating_pkg() -> PackageConfig {
+    PackageConfigBuilder::default()
+        .name("test-pkg")
+        .path("packages/pkg-a")
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn aggregate_prereleases_disabled_skips_extra_fetch() {
+    // aggregate_prereleases = false (default): even though the package is
+    // graduating to stable, no extra tag or commit fetch should happen.
+    let mut mock = MockForge::new();
+    let pre_tag = prerelease_tag();
+
+    mock.expect_get_latest_tags_for_prefix()
+        .times(1)
+        .returning(move |_, _| Ok(vec![pre_tag.clone()]));
+    mock.expect_get_commits()
+        .times(1)
+        .returning(|_, _| Ok(vec![]));
+
+    let core = create_core(mock, Some(vec![graduating_pkg()]), None);
+
+    let prepared = core.prepare_packages(None).await.unwrap();
+    assert_eq!(prepared.len(), 1);
+}
+
+#[tokio::test]
+async fn aggregate_prereleases_enabled_not_graduating_skips_extra_fetch() {
+    // aggregate_prereleases = true but the current tag is already stable —
+    // no graduation is occurring so no extra fetch should happen.
+    let mut mock = MockForge::new();
+    let s_tag = stable_tag();
+
+    mock.expect_get_latest_tags_for_prefix()
+        .times(1)
+        .returning(move |_, _| Ok(vec![s_tag.clone()]));
+    mock.expect_get_commits()
+        .times(1)
+        .returning(|_, _| Ok(vec![]));
+
+    let core = create_core(
+        mock,
+        Some(vec![graduating_pkg()]),
+        Some(aggregate_config()),
+    );
+
+    let prepared = core.prepare_packages(None).await.unwrap();
+    assert_eq!(prepared.len(), 1);
+}
+
+#[tokio::test]
+async fn aggregate_prereleases_enabled_and_graduating_merges_commits() {
+    // Graduating from prerelease to stable with aggregate_prereleases = true.
+    // Commits from the prior prerelease cycle should be merged into the
+    // prepared package's commit list.
+    let mut mock = MockForge::new();
+    let mut seq = mockall::Sequence::new();
+
+    let pre_tag = prerelease_tag();
+    let s_tag = stable_tag();
+    let current = pkg_commit("current", 2000);
+    let historical = pkg_commit("historical", 500);
+    let current_c = current.clone();
+    let historical_c = historical.clone();
+
+    // Step 1: collect current tag for the package
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![pre_tag.clone()]));
+
+    // Step 2: fetch commits since the prerelease tag SHA
+    mock.expect_get_commits()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![current_c.clone()]));
+
+    // Step 3: look up last stable tag for aggregation
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![s_tag.clone()]));
+
+    // Step 4: fetch commits since the stable tag SHA (historical range)
+    mock.expect_get_commits()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![historical_c.clone(), current.clone()]));
+
+    let core = create_core(
+        mock,
+        Some(vec![graduating_pkg()]),
+        Some(aggregate_config()),
+    );
+
+    let prepared = core.prepare_packages(None).await.unwrap();
+    assert_eq!(prepared.len(), 1);
+    // historical (500) and current (2000); current already in window
+    assert_eq!(prepared[0].commits.len(), 2);
+    // sorted by timestamp: historical first
+    assert_eq!(prepared[0].commits[0].id, "historical");
+    assert_eq!(prepared[0].commits[1].id, "current");
+}
+
+#[tokio::test]
+async fn aggregate_prereleases_deduplicates_overlapping_commits() {
+    // The historical fetch may return commits already present in the
+    // current-window fetch. Each commit must appear only once.
+    let mut mock = MockForge::new();
+    let mut seq = mockall::Sequence::new();
+
+    let pre_tag = prerelease_tag();
+    let s_tag = stable_tag();
+    let current = pkg_commit("current", 2000);
+    let current_c = current.clone();
+    let current_c2 = current.clone();
+
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![pre_tag.clone()]));
+
+    mock.expect_get_commits()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![current_c.clone()]));
+
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![s_tag.clone()]));
+
+    // Historical window contains ONLY the same commit as current window.
+    mock.expect_get_commits()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| Ok(vec![current_c2.clone()]));
+
+    let core = create_core(
+        mock,
+        Some(vec![graduating_pkg()]),
+        Some(aggregate_config()),
+    );
+
+    let prepared = core.prepare_packages(None).await.unwrap();
+    assert_eq!(prepared.len(), 1);
+    assert_eq!(
+        prepared[0].commits.len(),
+        1,
+        "duplicate commit should appear only once"
+    );
+    assert_eq!(prepared[0].commits[0].id, "current");
 }

--- a/releasaurus.toml
+++ b/releasaurus.toml
@@ -5,11 +5,13 @@ skip_ci = true
 skip_chore = true
 skip_miscellaneous = false
 include_author = true
+aggregate_prereleases = true
 
 [[package]]
 name = "workspace"
 tag_prefix = "v"
 release_type = "rust"
+prerelease = { strategy = "versioned", suffix = "rc" }
 additional_manifest_files = [
   { path = "./action/action.yml", version_regex = "v(?<version>\\d+\\.\\d+\\.\\d+)" }
 ]

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -78,7 +78,8 @@
         "skip_release_commits": true,
         "skip_shas": null,
         "reword": null,
-        "include_author": false
+        "include_author": false,
+        "aggregate_prereleases": false
       }
     },
     "package": {
@@ -200,6 +201,11 @@
         },
         "include_author": {
           "description": "Includes commit author name in default body template",
+          "type": "boolean",
+          "default": false
+        },
+        "aggregate_prereleases": {
+          "description": "Aggregates changelogs from prior prereleases when graduating",
           "type": "boolean",
           "default": false
         }


### PR DESCRIPTION
## Description

When graduating to a stable release from a prerelease version, the user is now given an option to aggregate changelog notes from previous prereleases into the stable release changelog and release notes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

## Related Issues

Fixes #251 