### PR TITLE
fix: fixes issues resulting from refactor to RepoUrl

### DIFF
--- a/crates/releasaurus-core/src/forge/config.rs
+++ b/crates/releasaurus-core/src/forge/config.rs
@@ -68,7 +68,10 @@ pub struct RepoUrl {
 
 impl RepoUrl {
     pub fn link_base_url(&self) -> String {
-        format!("{}://{}", self.scheme, self.host)
+        match self.port {
+            Some(port) => format!("{}://{}:{}", self.scheme, self.host, port),
+            None => format!("{}://{}", self.scheme, self.host),
+        }
     }
 }
 
@@ -191,6 +194,34 @@ mod tests {
             let err = result.unwrap_err();
             assert!(matches!(err, ReleasaurusError::AuthenticationError(_)));
         });
+    }
+
+    #[test]
+    fn link_base_url_without_port() {
+        let url = RepoUrl {
+            scheme: Scheme::Https,
+            host: "gitea.example.com".to_string(),
+            owner: "org".to_string(),
+            name: "repo".to_string(),
+            path: "/org/repo".to_string(),
+            port: None,
+            token: None,
+        };
+        assert_eq!(url.link_base_url(), "https://gitea.example.com");
+    }
+
+    #[test]
+    fn link_base_url_with_port() {
+        let url = RepoUrl {
+            scheme: Scheme::Https,
+            host: "gitea.example.com".to_string(),
+            owner: "org".to_string(),
+            name: "repo".to_string(),
+            path: "/org/repo".to_string(),
+            port: Some(3000),
+            token: None,
+        };
+        assert_eq!(url.link_base_url(), "https://gitea.example.com:3000");
     }
 
     #[test]

--- a/crates/releasaurus-core/src/forge/gitea.rs
+++ b/crates/releasaurus-core/src/forge/gitea.rs
@@ -86,15 +86,16 @@ impl Gitea {
             .default_headers(headers)
             .build()?;
 
-        let mut base_url =
-            format!("{}://{}/api/v1/repos/{}/", url.scheme, url.host, url.path);
-
-        if let Some(port) = url.port {
-            base_url = format!(
-                "{}://{}:{}/api/v1/repos/{}/",
-                url.scheme, url.host, port, url.path
-            );
-        }
+        let base_url = match url.port {
+            Some(port) => format!(
+                "{}://{}:{}/api/v1/repos/{}/{}/",
+                url.scheme, url.host, port, url.owner, url.name
+            ),
+            None => format!(
+                "{}://{}/api/v1/repos/{}/{}/",
+                url.scheme, url.host, url.owner, url.name
+            ),
+        };
 
         let base_url = Url::parse(&base_url)?;
 

--- a/crates/releasaurus-core/src/forge/gitlab.rs
+++ b/crates/releasaurus-core/src/forge/gitlab.rs
@@ -91,18 +91,15 @@ impl Gitlab {
         let token = resolve_token(token, url.token.as_ref(), TokenVar::Gitlab)?;
 
         let link_base_url = url.link_base_url();
+        let path = url.path.trim_start_matches('/');
 
         let release_link_base_url =
-            Url::parse(&format!("{}/{}/-/releases/", link_base_url, url.path))?;
+            Url::parse(&format!("{}/{}/-/releases/", link_base_url, path))?;
 
         let compare_link_base_url =
-            Url::parse(&format!("{}/{}/-/compare/", link_base_url, url.path))?;
+            Url::parse(&format!("{}/{}/-/compare/", link_base_url, path))?;
 
-        let project_id = url
-            .path
-            .strip_prefix("/")
-            .map(|p| p.to_string())
-            .unwrap_or(url.path.clone());
+        let project_id = path.to_string();
 
         let gl =
             gitlab::GitlabBuilder::new(url.host.clone(), token.expose_secret())

--- a/crates/releasaurus-core/src/forge/tests/common/gitlab.rs
+++ b/crates/releasaurus-core/src/forge/tests/common/gitlab.rs
@@ -122,7 +122,8 @@ pub struct GitlabForgeTestHelper {
 impl GitlabForgeTestHelper {
     pub async fn new(repo: &RepoUrl, token: &str, reset_sha: &str) -> Self {
         let host = repo.host.clone();
-        let project_id = repo.path.clone();
+        let path = repo.path.trim_start_matches("/");
+        let project_id = path.to_string();
 
         let gl = gitlab::GitlabBuilder::new(host, token)
             .build_async()

--- a/crates/releasaurus-core/src/forge/tests/common/run.rs
+++ b/crates/releasaurus-core/src/forge/tests/common/run.rs
@@ -33,7 +33,7 @@ pub fn parse_repo_url(raw: &str) -> RepoUrl {
         .unwrap_or_default();
     let owner = segments.first().copied().unwrap_or("").to_string();
     let name = segments.get(1).copied().unwrap_or("").to_string();
-    let path = format!("{}/{}", owner, name);
+    let path = format!("/{}/{}", owner, name);
     RepoUrl {
         scheme,
         host,


### PR DESCRIPTION
## Description

- fixes issue with Gitea base_url construction - ensures url.name is used over url.path as the latter includes a leading "/" that results in double slashes in url
- fixes issue in link_base_url method of RepoUrl where optional ports were not considered
- cleans up gitlab url and project_id creation by favoring trim_start_matches over trim_prefix on url.path

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)

## Related Issues

Fixes #261 
