### PR TITLE
feat: PR body edits are reflected in release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "tera",
  "test-log",
  "thiserror 2.0.18",
+ "tl",
  "tokio",
  "toml",
  "toml_edit",
@@ -3408,6 +3409,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tl"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b130bd8a58c163224b44e217b4239ca7b927d82bf6cc2fea1fc561d15056e3f7"
 
 [[package]]
 name = "tokio"

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,12 @@
 all:
     @just -l
 
+fmt:
+    cargo fmt
+
+lint:
+    cargo clippy --all-targets --all-features
+
 test *args:
     cargo test {{ args }}
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
 # User Guide
 
 - [Commands](./commands.md)
+- [Editing Release Notes](./release-notes-editing.md)
 - [CI/CD Integration](./ci-cd-integration.md)
 - [Troubleshooting](./troubleshooting.md)
 - [Supported Languages & Frameworks](./supported-languages.md)

--- a/book/src/release-notes-editing.md
+++ b/book/src/release-notes-editing.md
@@ -1,0 +1,127 @@
+# Editing Release Notes
+
+Releasaurus lets you customize the release notes for a specific release
+directly in the pull request body — without touching `releasaurus.toml`
+or the `CHANGELOG.md`.
+
+## How It Works
+
+When `release-pr` creates or updates a release PR, it renders the PR
+body with a structured layout per package:
+
+```html
+<details open>
+<summary>v1.2.3</summary>
+<div id="my-package-header"></div>
+<div id="my-package" data-tag="v1.2.3">
+<!--{"metadata":{"sha_compare_link":"...","tag_compare_link":"..."}}-->
+
+## [v1.2.3](...) - 2026-04-10
+### Features
+- feat: some new feature (abc1234)
+</div>
+<div id="my-package-footer"></div>
+</details>
+```
+
+At release time, `releasaurus release` reads the notes directly from
+the PR body rather than regenerating them from commit history. This
+means any edits you make before merging are reflected in the published
+forge release.
+
+> **Note**: Edits to the PR body affect only the **forge release
+> notes**. `CHANGELOG.md` is generated from commit history and is
+> not affected.
+
+## Editing the Release Notes
+
+Open the PR body and edit the text inside the notes `<div>`. The
+metadata comment (`<!--{...}-->`) must be left intact — it carries
+the tag and link information needed at publish time.
+
+**Before editing:**
+
+```html
+<div id="my-package" data-tag="v1.2.3">
+<!--{"metadata":{"sha_compare_link":"...","tag_compare_link":"..."}}-->
+
+## [v1.2.3](...) - 2026-04-10
+### Features
+- feat: some new feature (abc1234)
+</div>
+```
+
+**After editing:**
+
+```html
+<div id="my-package" data-tag="v1.2.3">
+<!--{"metadata":{"sha_compare_link":"...","tag_compare_link":"..."}}-->
+
+## [v1.2.3](...) - 2026-04-10
+
+This release improves startup performance and fixes a crash on
+empty input. See the [migration guide](https://example.com) for
+details.
+
+### Features
+- feat: some new feature (abc1234)
+</div>
+```
+
+## Persistent Header and Footer
+
+For content that should survive re-runs of `release-pr` (for example,
+if you run the command again after new commits land), place it in the
+dedicated header and footer `<div>`s.
+
+```html
+<div id="my-package-header">
+## Highlights
+
+This is a major stability release. All users on v1.x are encouraged
+to upgrade.
+</div>
+
+<div id="my-package-footer">
+Full migration guide: https://example.com/migrate
+</div>
+```
+
+When `release-pr` regenerates the PR body, it reads back the content
+of these `<div>`s and re-embeds it. The header is prepended and the
+footer is appended to the final release notes at publish time.
+
+> **Tip**: Leave the header and footer `<div>`s empty (the default)
+> if you have nothing to add. They will not appear in the published
+> release notes.
+
+## Monorepo: Multiple Packages
+
+In a monorepo, each package gets its own set of sections. The `id`
+attributes are derived from the package name with any characters
+outside `[a-zA-Z0-9-_]` replaced by `-`.
+
+For example, a package named `@scope/my-pkg` gets:
+
+- `<div id="-scope-my-pkg">` — notes
+- `<div id="-scope-my-pkg-header">` — header
+- `<div id="-scope-my-pkg-footer">` — footer
+
+Edit each package's sections independently.
+
+## Backward Compatibility
+
+PRs created by an older version of Releasaurus use a different body
+format. The `release` command detects the format automatically and
+falls back to reading release notes from the hidden metadata for those
+PRs — no manual migration required.
+
+## Limits
+
+- The metadata comment (`<!--{...}-->`) inside the notes `<div>` must
+  not be removed or modified.
+- Header and footer content is preserved verbatim. Markdown is
+  supported by all major forge platforms.
+- Re-running `release-pr` regenerates the notes from commit history
+  and overwrites any direct edits to the notes `<div>`. Use the
+  header/footer sections for content you want to survive re-runs.

--- a/crates/releasaurus-core/Cargo.toml
+++ b/crates/releasaurus-core/Cargo.toml
@@ -42,6 +42,7 @@ serde_json = { version = "1.0.149", features = ["preserve_order"] }
 strum = { version = "0.28.0", features = ["derive"] }
 tera = "1.20.0"
 thiserror = "2.0.9"
+tl = "0.7.8"
 tokio = { version = "1.50.0", features = ["fs", "macros", "rt-multi-thread"] }
 toml = "0.9.5"
 toml_edit = "0.23.4"

--- a/crates/releasaurus-core/src/forge/manager.rs
+++ b/crates/releasaurus-core/src/forge/manager.rs
@@ -216,7 +216,7 @@ impl ForgeManager {
         req: CreateReleaseBranchRequest,
     ) -> Result<Commit> {
         if self.options.dry_run {
-            log::warn!("dry_run: would create release branch: req: {:#?}", req);
+            log::warn!("dry_run: would create release branch: req: {:?}", req);
             return Ok(Commit { sha: "fff".into() });
         }
 
@@ -243,7 +243,7 @@ impl ForgeManager {
         req: CreateCommitRequest,
     ) -> Result<Commit> {
         if self.options.dry_run {
-            log::warn!("dry_run: would create commit: req: {:#?}", req);
+            log::warn!("dry_run: would create commit: req: {:?}", req);
             return Ok(Commit { sha: "fff".into() });
         }
 
@@ -317,7 +317,7 @@ impl ForgeManager {
 
     pub async fn update_pr(&self, req: UpdatePrRequest) -> Result<()> {
         if self.options.dry_run {
-            log::warn!("dry_run: would update PR: req: {:#?}", req);
+            log::warn!("dry_run: would update PR: req: {:?}", req);
             return Ok(());
         }
 

--- a/crates/releasaurus-core/src/orchestrator.rs
+++ b/crates/releasaurus-core/src/orchestrator.rs
@@ -1,8 +1,7 @@
-use color_eyre::eyre::{OptionExt, eyre};
+use color_eyre::eyre::eyre;
 use derive_builder::Builder;
-use regex::Regex;
 use serde::Serialize;
-use std::{path::Path, rc::Rc, sync::LazyLock};
+use std::{path::Path, rc::Rc};
 use tokio::fs;
 
 use crate::{
@@ -17,11 +16,12 @@ use crate::{
     },
     orchestrator::{
         config::OrchestratorConfig,
-        core::{Core, PRMetadata},
+        core::{Core, PrBranchResult},
         package::{
             releasable::SerializableReleasablePackage,
             resolved::{ResolvedPackage, ResolvedPackageHash},
         },
+        pr_body::{parse_legacy_pr_body, parse_pr_body},
     },
 };
 
@@ -29,10 +29,7 @@ pub mod commits;
 pub mod config;
 pub mod core;
 pub mod package;
-
-static METADATA_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?ms)^<!--(?<metadata>.*?)-->\n*<details"#).unwrap()
-});
+pub mod pr_body;
 
 /// Information about a package's current release
 #[derive(Serialize)]
@@ -192,31 +189,28 @@ impl Orchestrator {
         log::info!("releasable packages: {:#?}", releasable);
 
         let pr_packages =
-            self.core.release_pr_packages_by_branch(releasable)?;
+            self.core.release_pr_packages_by_branch(releasable).await?;
 
         if pr_packages.is_empty() {
             return Ok(());
         }
 
-        let requests = self.core.create_pr_branches(pr_packages).await?;
+        let results = self.core.create_pr_branches(pr_packages).await?;
 
-        for request in requests {
-            let pr = if let Some(pr) = self
-                .forge
-                .get_open_release_pr(GetPrRequest {
-                    head_branch: request.head_branch.clone(),
-                    base_branch: request.base_branch.clone(),
-                })
-                .await?
-            {
+        for PrBranchResult {
+            request,
+            existing_pr,
+        } in results
+        {
+            let pr = if let Some(existing) = existing_pr {
                 self.forge
                     .update_pr(UpdatePrRequest {
-                        pr_number: pr.number,
+                        pr_number: existing.number,
                         title: request.title,
                         body: request.body,
                     })
                     .await?;
-                pr
+                existing
             } else {
                 self.forge.create_pr(request).await?
             };
@@ -404,60 +398,24 @@ impl Orchestrator {
         package: &ResolvedPackage,
         merged_pr: &PullRequest,
     ) -> Result<()> {
-        let meta_caps = METADATA_REGEX.captures_iter(&merged_pr.body);
-
-        let mut metadata = None;
-
-        for cap in meta_caps {
-            let metadata_str = cap
-                .name("metadata")
-                .ok_or_eyre("failed to parse metadata from PR body")?
-                .as_str();
-
-            log::debug!("parsing metadata string: {:#?}", metadata_str);
-
-            let json: PRMetadata = serde_json::from_str(metadata_str)?;
-            let pkg_meta = json.metadata;
-
-            if pkg_meta.name == package.name {
-                metadata = Some(pkg_meta);
-                break;
-            }
-        }
-
-        let metadata_err = format!(
-            "failed to find metadata for package {} in pr {}",
-            package.name, merged_pr.number,
-        );
-
-        let metadata = metadata.ok_or_eyre(metadata_err)?;
-
-        log::debug!(
-            "found package metadata from pr {}: {:#?}",
+        let (tag, notes) = if let Some((tag, notes)) = parse_legacy_pr_body(
+            &package.name,
             merged_pr.number,
-            metadata
-        );
+            &merged_pr.body,
+        )? {
+            (tag, notes)
+        } else {
+            parse_pr_body(&package.name, merged_pr.number, &merged_pr.body)?
+        };
 
-        log::info!(
-            "tagging commit: tag: {}, sha: {}",
-            metadata.tag,
-            merged_pr.sha
-        );
+        log::info!("tagging commit: tag: {}, sha: {}", tag, merged_pr.sha);
 
-        self.forge.tag_commit(&metadata.tag, &merged_pr.sha).await?;
+        self.forge.tag_commit(&tag, &merged_pr.sha).await?;
 
-        log::info!(
-            "creating release: tag: {}, sha: {}",
-            metadata.tag,
-            merged_pr.sha
-        );
+        log::info!("creating release: tag: {}, sha: {}", tag, merged_pr.sha);
 
         self.forge
-            .create_release(
-                &metadata.tag,
-                &merged_pr.sha,
-                metadata.notes.trim(),
-            )
+            .create_release(&tag, &merged_pr.sha, notes.trim())
             .await?;
 
         Ok(())

--- a/crates/releasaurus-core/src/orchestrator/core.rs
+++ b/crates/releasaurus-core/src/orchestrator/core.rs
@@ -14,7 +14,7 @@ use crate::{
         manager::ForgeManager,
         request::{
             CreatePrRequest, CreateReleaseBranchRequest, FileChange,
-            FileUpdateType, ForgeCommit, GetPrRequest,
+            FileUpdateType, ForgeCommit, GetPrRequest, PullRequest,
         },
     },
     orchestrator::{
@@ -28,23 +28,38 @@ use crate::{
                 SerializableReleasablePackage,
             },
             releasable_builder::ReleasablePackageBuilder,
-            release_pr::ReleasePRPackage,
+            release_pr::{PRBundle, ReleasePRPackage},
             resolved::{ResolvedPackage, ResolvedPackageHash},
         },
+        pr_body::{extract_preserved_section, normalize_html_id},
     },
     updater::manager::UpdateManager,
 };
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct PRMetadataFields {
-    pub name: String,
-    pub tag: String,
-    pub notes: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_compare_link: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha_compare_link: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PRMetadata {
     pub metadata: PRMetadataFields,
+}
+
+/// Result of `create_pr_branches`: the forge request paired with the existing
+/// open PR for that branch (if one was found during `release_pr_packages_by_branch`).
+pub struct PrBranchResult {
+    pub request: CreatePrRequest,
+    pub existing_pr: Option<PullRequest>,
 }
 
 pub struct Core {
@@ -278,10 +293,10 @@ impl Core {
         Ok(finalized)
     }
 
-    pub fn release_pr_packages_by_branch(
+    pub async fn release_pr_packages_by_branch(
         &self,
         packages: Vec<ReleasablePackage>,
-    ) -> Result<HashMap<String, Vec<ReleasePRPackage>>> {
+    ) -> Result<HashMap<String, PRBundle>> {
         let release_prs = self.release_pr_packages(packages)?;
 
         let mut map: HashMap<String, Vec<ReleasePRPackage>> = HashMap::new();
@@ -296,16 +311,36 @@ impl Core {
             };
         }
 
-        Ok(map)
+        let mut bundles: HashMap<String, PRBundle> = HashMap::new();
+
+        for (branch, packages) in map {
+            let existing_pr = self
+                .forge
+                .get_open_release_pr(GetPrRequest {
+                    head_branch: branch.clone(),
+                    base_branch: self.config.base_branch.clone(),
+                })
+                .await?;
+
+            bundles.insert(
+                branch,
+                PRBundle {
+                    existing_pr,
+                    packages,
+                },
+            );
+        }
+
+        Ok(bundles)
     }
 
     pub async fn create_pr_branches(
         &self,
-        packages: HashMap<String, Vec<ReleasePRPackage>>,
-    ) -> Result<Vec<CreatePrRequest>> {
-        let mut pr_requests = vec![];
+        bundles: HashMap<String, PRBundle>,
+    ) -> Result<Vec<PrBranchResult>> {
+        let mut pr_results = vec![];
 
-        for (release_branch, pr_packages) in packages.into_iter() {
+        for (release_branch, bundle) in bundles.into_iter() {
             if let Some(pending_release) = self
                 .forge
                 .get_merged_release_pr(GetPrRequest {
@@ -320,13 +355,14 @@ impl Core {
                 ));
             }
 
-            let file_changes: Vec<FileChange> = pr_packages
+            let file_changes: Vec<FileChange> = bundle
+                .packages
                 .iter()
                 .flat_map(|p| p.file_changes.clone())
                 .collect();
 
             let message =
-                self.release_message_for_pr_package_list(&pr_packages);
+                self.release_message_for_pr_package_list(&bundle.packages);
 
             self.forge
                 .create_release_branch(CreateReleaseBranchRequest {
@@ -337,15 +373,26 @@ impl Core {
                 })
                 .await?;
 
-            pr_requests.push(CreatePrRequest {
+            let existing_body =
+                bundle.existing_pr.as_ref().map(|pr| pr.body.as_str());
+
+            let request = CreatePrRequest {
                 base_branch: self.config.base_branch.clone(),
                 head_branch: release_branch.clone(),
                 title: message,
-                body: self.release_pr_body_for_pr_package_list(&pr_packages)?,
+                body: self.release_pr_body_for_pr_package_list(
+                    &bundle.packages,
+                    existing_body,
+                )?,
+            };
+
+            pr_results.push(PrBranchResult {
+                request,
+                existing_pr: bundle.existing_pr,
             });
         }
 
-        Ok(pr_requests)
+        Ok(pr_results)
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -371,32 +418,28 @@ impl Core {
     fn release_pr_body_for_pr_package_list(
         &self,
         pr_packages: &[ReleasePRPackage],
+        existing_body: Option<&str>,
     ) -> Result<String> {
-        let mut body = "".to_string();
+        let mut body = String::new();
 
         for pkg in pr_packages.iter() {
-            let mut start_details = "<details>";
-
-            // auto-open dropdown if there's only one package
-            if pr_packages.len() == 1 {
-                start_details = "<details open>";
-            }
+            let start_details = if pr_packages.len() == 1 {
+                // auto-open dropdown if there's only one package
+                "<details open>"
+            } else {
+                "<details>"
+            };
 
             let metadata = PRMetadata {
                 metadata: PRMetadataFields {
-                    name: pkg.name.clone(),
-                    tag: pkg.tag.name.clone(),
-                    notes: pkg.notes.clone(),
+                    sha_compare_link: Some(pkg.sha_compare_link.clone()),
+                    tag_compare_link: Some(pkg.tag_compare_link.clone()),
+                    ..Default::default()
                 },
             };
 
             let json = serde_json::to_string(&metadata)?;
-
-            let metadata_str = format!(
-                r#"
-<!--{json}-->
-"#,
-            );
+            let metadata_str = format!(r#"<!--{json}-->"#);
 
             // in the PR body link to the comparison with sha instead
             // of tag since the tag doesn't exist yet
@@ -404,10 +447,33 @@ impl Core {
                 .notes
                 .replace(&pkg.tag_compare_link, &pkg.sha_compare_link);
 
+            let html_id = normalize_html_id(&pkg.name);
+
+            let header = existing_body
+                .map(|b| {
+                    extract_preserved_section(b, &format!("{html_id}-header"))
+                })
+                .unwrap_or_default();
+
+            let footer = existing_body
+                .map(|b| {
+                    extract_preserved_section(b, &format!("{html_id}-footer"))
+                })
+                .unwrap_or_default();
+
             // create the drop down
             let package_body = format!(
-                "{metadata_str}{start_details}<summary>{}</summary>\n\n{}</details>",
-                pkg.tag.name, notes
+                r#"{start_details}
+<summary>{}</summary>
+<div id="{html_id}-header">{header}</div>
+<div id="{html_id}" data-tag="{}">
+{metadata_str}
+
+{notes}
+</div>
+<div id="{html_id}-footer">{footer}</div>
+</details>"#,
+                pkg.tag.name, pkg.tag.name
             );
 
             if body.is_empty() {

--- a/crates/releasaurus-core/src/orchestrator/core/tests/pr_grouping.rs
+++ b/crates/releasaurus-core/src/orchestrator/core/tests/pr_grouping.rs
@@ -11,9 +11,13 @@ use crate::{
     forge::traits::MockForge,
 };
 
-#[test]
-fn release_pr_packages_by_branch_groups_all_when_not_separate() {
-    let mock_forge = MockForge::new();
+#[tokio::test]
+async fn release_pr_packages_by_branch_groups_all_when_not_separate() {
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_open_release_pr()
+        .returning(|_| Ok(None));
 
     let toml_config = Config {
         separate_pull_requests: false,
@@ -62,17 +66,22 @@ fn release_pr_packages_by_branch_groups_all_when_not_separate() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable_a, releasable_b])
+        .await
         .unwrap();
     // Should have one branch with both packages
     assert_eq!(grouped.len(), 1);
 
-    let packages = grouped.values().next().unwrap();
-    assert_eq!(packages.len(), 2);
+    let bundle = grouped.values().next().unwrap();
+    assert_eq!(bundle.packages.len(), 2);
 }
 
-#[test]
-fn release_pr_packages_by_branch_separates_when_configured() {
-    let mock_forge = MockForge::new();
+#[tokio::test]
+async fn release_pr_packages_by_branch_separates_when_configured() {
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_open_release_pr()
+        .returning(|_| Ok(None));
 
     let toml_config = Config {
         separate_pull_requests: true,
@@ -121,11 +130,12 @@ fn release_pr_packages_by_branch_separates_when_configured() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable_a, releasable_b])
+        .await
         .unwrap();
     // Should have separate branches
     assert_eq!(grouped.len(), 2);
 
-    for packages in grouped.values() {
-        assert_eq!(packages.len(), 1);
+    for bundle in grouped.values() {
+        assert_eq!(bundle.packages.len(), 1);
     }
 }

--- a/crates/releasaurus-core/src/orchestrator/core/tests/pr_requests.rs
+++ b/crates/releasaurus-core/src/orchestrator/core/tests/pr_requests.rs
@@ -11,9 +11,10 @@ use crate::{
     analyzer::release::Tag,
     config::{Config, package::PackageConfigBuilder},
     forge::{
-        request::{Commit, CreateReleaseBranchRequest},
+        request::{Commit, CreateReleaseBranchRequest, PullRequest},
         traits::MockForge,
     },
+    orchestrator::tests::common::{PrBodyInput, make_pr_body},
 };
 
 #[tokio::test]
@@ -22,6 +23,10 @@ async fn create_pr_branches_creates_branch_before_pr_request() {
 
     mock_forge
         .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_open_release_pr()
         .returning(|_| Ok(None));
 
     // Expect the branch to be created
@@ -55,13 +60,17 @@ async fn create_pr_branches_creates_branch_before_pr_request() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable])
+        .await
         .unwrap();
 
     let pr_requests = orchestrator.create_pr_branches(grouped).await.unwrap();
 
     assert_eq!(pr_requests.len(), 1);
-    assert_eq!(pr_requests[0].base_branch, "main");
-    assert_eq!(pr_requests[0].head_branch, "releasaurus-release-main");
+    assert_eq!(pr_requests[0].request.base_branch, "main");
+    assert_eq!(
+        pr_requests[0].request.head_branch,
+        "releasaurus-release-main"
+    );
 }
 
 #[tokio::test]
@@ -70,6 +79,10 @@ async fn create_pr_branches_includes_metadata_in_body() {
 
     mock_forge
         .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_open_release_pr()
         .returning(|_| Ok(None));
 
     mock_forge
@@ -96,6 +109,7 @@ async fn create_pr_branches_includes_metadata_in_body() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable])
+        .await
         .unwrap();
 
     let pr_requests = orchestrator.create_pr_branches(grouped).await.unwrap();
@@ -104,13 +118,13 @@ async fn create_pr_branches_includes_metadata_in_body() {
 
     let request = &pr_requests[0];
     // Verify metadata is in PR body
-    assert!(request.body.contains("<!--"));
-    assert!(request.body.contains("test-pkg"));
-    assert!(request.body.contains("v1.2.3"));
-    assert!(request.body.contains("Test release notes"));
+    assert!(request.request.body.contains("<!--"));
+    assert!(request.request.body.contains("test-pkg"));
+    assert!(request.request.body.contains("v1.2.3"));
+    assert!(request.request.body.contains("Test release notes"));
     // Verify details tag is present and auto-opened for single package
-    assert!(request.body.contains("<details open>"));
-    assert!(request.body.contains("</details>"));
+    assert!(request.request.body.contains("<details open>"));
+    assert!(request.request.body.contains("</details>"));
 }
 
 #[tokio::test]
@@ -119,6 +133,10 @@ async fn create_pr_branches_uses_sha_compare_link() {
 
     mock_forge
         .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_open_release_pr()
         .returning(|_| Ok(None));
 
     mock_forge
@@ -150,6 +168,7 @@ async fn create_pr_branches_uses_sha_compare_link() {
 
     let grouped = core
         .release_pr_packages_by_branch(vec![releasable])
+        .await
         .unwrap();
 
     let pr_requests = core.create_pr_branches(grouped).await.unwrap();
@@ -159,17 +178,17 @@ async fn create_pr_branches_uses_sha_compare_link() {
     let request = &pr_requests[0];
 
     // Verify metadata is in PR body
-    assert!(request.body.contains("<!--"));
-    assert!(request.body.contains("test-pkg"));
-    assert!(request.body.contains("v1.2.3"));
-    assert!(request.body.contains("Test release notes"));
+    assert!(request.request.body.contains("<!--"));
+    assert!(request.request.body.contains("test-pkg"));
+    assert!(request.request.body.contains("v1.2.3"));
+    assert!(request.request.body.contains("Test release notes"));
     // should have both version of compare links since we still need to
     // use tag_compare_link in PR metadata
-    assert!(request.body.contains(tag_compare_link));
-    assert!(request.body.contains(sha_compare_link));
+    assert!(request.request.body.contains(tag_compare_link));
+    assert!(request.request.body.contains(sha_compare_link));
     // Verify details tag is present and auto-opened for single package
-    assert!(request.body.contains("<details open>"));
-    assert!(request.body.contains("</details>"));
+    assert!(request.request.body.contains("<details open>"));
+    assert!(request.request.body.contains("</details>"));
 }
 
 #[tokio::test]
@@ -178,6 +197,10 @@ async fn create_pr_branches_handles_multiple_packages_on_same_branch() {
 
     mock_forge
         .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_open_release_pr()
         .returning(|_| Ok(None));
 
     // Should only create one branch for multiple packages
@@ -240,6 +263,7 @@ async fn create_pr_branches_handles_multiple_packages_on_same_branch() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable_a, releasable_b])
+        .await
         .unwrap();
 
     let pr_requests = orchestrator.create_pr_branches(grouped).await.unwrap();
@@ -249,13 +273,13 @@ async fn create_pr_branches_handles_multiple_packages_on_same_branch() {
 
     let request = &pr_requests[0];
     // Both packages should be in the body
-    assert!(request.body.contains("pkg-a"));
-    assert!(request.body.contains("pkg-b"));
-    assert!(request.body.contains("v1.0.0"));
-    assert!(request.body.contains("v2.0.0"));
+    assert!(request.request.body.contains("pkg-a"));
+    assert!(request.request.body.contains("pkg-b"));
+    assert!(request.request.body.contains("v1.0.0"));
+    assert!(request.request.body.contains("v2.0.0"));
     // Details should NOT be auto-opened when multiple packages
-    assert!(request.body.contains("<details>"));
-    assert!(!request.body.contains("<details open>"));
+    assert!(request.request.body.contains("<details>"));
+    assert!(!request.request.body.contains("<details open>"));
 }
 
 #[tokio::test]
@@ -264,6 +288,10 @@ async fn create_pr_branches_handles_separate_branches() {
 
     mock_forge
         .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_open_release_pr()
         .returning(|_| Ok(None));
 
     // Should create two separate branches
@@ -325,6 +353,7 @@ async fn create_pr_branches_handles_separate_branches() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable_a, releasable_b])
+        .await
         .unwrap();
 
     let pr_requests = orchestrator.create_pr_branches(grouped).await.unwrap();
@@ -333,8 +362,10 @@ async fn create_pr_branches_handles_separate_branches() {
     assert_eq!(pr_requests.len(), 2);
 
     // Each PR should have its own branch
-    let branches: Vec<&String> =
-        pr_requests.iter().map(|pr| &pr.head_branch).collect();
+    let branches: Vec<&String> = pr_requests
+        .iter()
+        .map(|pr| &pr.request.head_branch)
+        .collect();
     assert!(branches.contains(&&"releasaurus-release-main-pkg-a".to_string()));
     assert!(branches.contains(&&"releasaurus-release-main-pkg-b".to_string()));
 }
@@ -345,6 +376,10 @@ async fn create_pr_branches_includes_file_changes() {
 
     mock_forge
         .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_open_release_pr()
         .returning(|_| Ok(None));
 
     mock_forge
@@ -375,6 +410,7 @@ async fn create_pr_branches_includes_file_changes() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable])
+        .await
         .unwrap();
 
     let pr_requests = orchestrator.create_pr_branches(grouped).await.unwrap();
@@ -388,6 +424,10 @@ async fn create_pr_branches_uses_correct_title_format() {
 
     mock_forge
         .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_open_release_pr()
         .returning(|_| Ok(None));
 
     mock_forge
@@ -414,6 +454,7 @@ async fn create_pr_branches_uses_correct_title_format() {
 
     let grouped = orchestrator
         .release_pr_packages_by_branch(vec![releasable])
+        .await
         .unwrap();
 
     let pr_requests = orchestrator.create_pr_branches(grouped).await.unwrap();
@@ -422,7 +463,72 @@ async fn create_pr_branches_uses_correct_title_format() {
 
     let request = &pr_requests[0];
     // Single package should have specific title format
-    assert!(request.title.contains("chore(main): release"));
-    assert!(request.title.contains("test-pkg"));
-    assert!(request.title.contains("v1.2.3"));
+    assert!(request.request.title.contains("chore(main): release"));
+    assert!(request.request.title.contains("test-pkg"));
+    assert!(request.request.title.contains("v1.2.3"));
+}
+
+#[tokio::test]
+async fn create_pr_branches_handles_existing_pr_body_sections() {
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    let existing_body = make_pr_body(&PrBodyInput {
+        pkg: "test-pkg",
+        tag: "v1.2.2",
+        notes: "Old release notes must not appear",
+        tag_link: "old-tag-link",
+        sha_link: "old-sha-link",
+        header: "My custom header",
+        footer: "My custom footer",
+    });
+
+    mock_forge.expect_get_open_release_pr().returning(move |_| {
+        Ok(Some(PullRequest {
+            number: 42,
+            sha: "old-sha".to_string(),
+            body: existing_body.clone(),
+        }))
+    });
+
+    mock_forge
+        .expect_create_release_branch()
+        .times(1)
+        .returning(|_| {
+            Ok(Commit {
+                sha: "abc123".to_string(),
+            })
+        });
+
+    let orchestrator = create_core(mock_forge, None, None);
+
+    let releasable = ReleasablePackage {
+        name: "test-pkg".to_string(),
+        tag: Tag {
+            name: "v1.2.3".to_string(),
+            semver: Version::parse("1.2.3").unwrap(),
+            ..Default::default()
+        },
+        notes: "Freshly generated release notes".to_string(),
+        ..Default::default()
+    };
+
+    let grouped = orchestrator
+        .release_pr_packages_by_branch(vec![releasable])
+        .await
+        .unwrap();
+
+    let results = orchestrator.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(results.len(), 1);
+    let body = &results[0].request.body;
+    // header and footer are preserved across re-runs
+    assert!(body.contains("My custom header"));
+    assert!(body.contains("My custom footer"));
+    // notes are regenerated; old notes must not bleed through
+    assert!(body.contains("Freshly generated release notes"));
+    assert!(!body.contains("Old release notes must not appear"));
 }

--- a/crates/releasaurus-core/src/orchestrator/package/release_pr.rs
+++ b/crates/releasaurus-core/src/orchestrator/package/release_pr.rs
@@ -1,4 +1,7 @@
-use crate::{analyzer::release::Tag, forge::request::FileChange};
+use crate::{
+    analyzer::release::Tag,
+    forge::request::{FileChange, PullRequest},
+};
 
 /// Represents a fully analyzed and updated package ready for PR creation.
 /// Includes next tag and list of file changes to include in PR
@@ -11,4 +14,11 @@ pub struct ReleasePRPackage {
     pub sha_compare_link: String,
     pub file_changes: Vec<FileChange>,
     pub release_branch: String,
+}
+
+/// Groups the packages sharing a release branch with the existing open PR
+/// for that branch, if one exists.
+pub struct PRBundle {
+    pub existing_pr: Option<PullRequest>,
+    pub packages: Vec<ReleasePRPackage>,
 }

--- a/crates/releasaurus-core/src/orchestrator/pr_body.rs
+++ b/crates/releasaurus-core/src/orchestrator/pr_body.rs
@@ -1,0 +1,490 @@
+use std::sync::LazyLock;
+
+use color_eyre::eyre::eyre;
+use regex::Regex;
+
+use crate::{
+    error::{ReleasaurusError, Result},
+    orchestrator::core::PRMetadata,
+};
+
+pub(crate) static METADATA_REGEX_LEGACY: LazyLock<Regex> =
+    LazyLock::new(|| {
+        Regex::new(r#"(?ms)^<!--(?<metadata>.*?)-->\n*<details"#).unwrap()
+    });
+
+pub(crate) static METADATA_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?ms)^<!--\s*(?<metadata>\{.*?\})\s*-->"#).unwrap()
+});
+
+/// Normalizes a package name for use as an HTML `id` attribute.
+///
+/// Replaces any character that is not ASCII alphanumeric, `-`, or `_`
+/// with `-`, ensuring the value is safe for `id=` and compatible with
+/// `get_element_by_id` lookups.
+pub fn normalize_html_id(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Extracts the inner HTML of an element with the given `id` from a
+/// pre-parsed `VDom`. Returns an empty string if the element is absent
+/// or its content is empty.
+fn extract_section_from_dom(dom: &tl::VDom, id: &str) -> String {
+    let parser = dom.parser();
+    let Some(handle) = dom.get_element_by_id(id.as_bytes()) else {
+        return String::new();
+    };
+    let Some(node) = handle.get(parser) else {
+        return String::new();
+    };
+    node.inner_html(parser).trim().to_string()
+}
+
+/// Extracts the inner HTML of an element with the given `id` from `body`.
+/// Returns an empty string if the element is not found or its content is
+/// empty, so callers can treat a missing section as no preserved content.
+pub fn extract_preserved_section(body: &str, id: &str) -> String {
+    let Ok(dom) = tl::parse(body, tl::ParserOptions::default()) else {
+        log::debug!(
+            "extract_preserved_section: failed to parse body for id={id}"
+        );
+        return String::new();
+    };
+    extract_section_from_dom(&dom, id)
+}
+
+pub fn parse_pr_body(
+    package_name: &str,
+    pr_number: u64,
+    body: &str,
+) -> Result<(String, String)> {
+    let dom = tl::parse(body, tl::ParserOptions::default()).map_err(|e| {
+        ReleasaurusError::Other(eyre!(
+            "failed to parse merged PR body: pkg={} pr={} - {}",
+            package_name,
+            pr_number,
+            e
+        ))
+    })?;
+
+    let parser = dom.parser();
+
+    let normalized_id = normalize_html_id(package_name);
+
+    let handle = dom.get_element_by_id(normalized_id.as_bytes()).ok_or(
+        ReleasaurusError::Other(eyre!(
+            "failed to find details in PR body for package: pkg={} pr={}",
+            package_name,
+            pr_number,
+        )),
+    )?;
+
+    let div = handle.get(parser).ok_or(ReleasaurusError::Other(eyre!(
+        "failed to create PR parser for package: pkg={} pr={}",
+        package_name,
+        pr_number,
+    )))?;
+
+    let div_tag = div.as_tag().ok_or(ReleasaurusError::Other(eyre!(
+        "failed to find details tag matching package: pkg={} pr={}",
+        package_name,
+        pr_number,
+    )))?;
+
+    let pkg_tag = div_tag
+            .attributes()
+            .get("data-tag")
+            .flatten()
+            .ok_or(ReleasaurusError::Other(eyre!(
+                "failed to find data-tag attribute for package details: pkg={} pr={}",
+                package_name,
+                pr_number
+            )))?.as_utf8_str();
+
+    let notes = div.inner_html(parser);
+
+    let cap =
+        METADATA_REGEX
+            .captures(&notes)
+            .ok_or(ReleasaurusError::Other(eyre!(
+                "failed to find metadata for package: pkg={} pr={}",
+                package_name,
+                pr_number
+            )))?;
+
+    let metadata_str = cap
+        .name("metadata")
+        .ok_or(ReleasaurusError::Other(eyre!(
+            "failed to parse metadata from PR body: pkg={} pr={}",
+            package_name,
+            pr_number,
+        )))?
+        .as_str();
+
+    log::debug!("parsing metadata string: {:#?}", metadata_str);
+
+    let json: PRMetadata = serde_json::from_str(metadata_str)?;
+
+    let tag_compare_link =
+        json.metadata
+            .tag_compare_link
+            .ok_or(ReleasaurusError::Other(eyre!(
+                "failed to find tag_compare_link in PR metadata: pkg={} pr={}",
+                package_name,
+                pr_number
+            )))?;
+
+    let sha_compare_link =
+        json.metadata
+            .sha_compare_link
+            .ok_or(ReleasaurusError::Other(eyre!(
+                "failed to find sha_compare_link in PR metadata: pkg={} pr={}",
+                package_name,
+                pr_number
+            )))?;
+
+    let notes = METADATA_REGEX.replace(&notes, "");
+    let notes = notes.replace(&sha_compare_link, &tag_compare_link);
+
+    // Collect header and footer preserved sections, if present.
+    // Re-use the already-parsed dom to avoid two redundant parses.
+    let header =
+        extract_section_from_dom(&dom, &format!("{normalized_id}-header"));
+    let footer =
+        extract_section_from_dom(&dom, &format!("{normalized_id}-footer"));
+
+    let header = header.as_str();
+    let footer = footer.as_str();
+    let notes = notes.trim();
+
+    let mut release_notes = String::new();
+
+    if !header.is_empty() {
+        release_notes.push_str(header);
+        release_notes.push('\n');
+    }
+
+    release_notes.push_str(notes);
+
+    if !footer.is_empty() {
+        release_notes.push('\n');
+        release_notes.push_str(footer);
+    }
+
+    Ok((pkg_tag.to_string(), release_notes))
+}
+
+pub fn parse_legacy_pr_body(
+    package_name: &str,
+    pr_number: u64,
+    body: &str,
+) -> Result<Option<(String, String)>> {
+    let meta_caps = METADATA_REGEX_LEGACY.captures_iter(body);
+
+    for cap in meta_caps {
+        let metadata_str = cap
+            .name("metadata")
+            .ok_or(ReleasaurusError::Other(eyre!(
+                "failed to parse metadata from PR body: pkg={} pr={}",
+                package_name,
+                pr_number
+            )))?
+            .as_str();
+
+        log::debug!("parsing legacy metadata string: {:#?}", metadata_str);
+
+        let json: PRMetadata = serde_json::from_str(metadata_str)?;
+
+        if let Some(name) = json.metadata.name.as_deref()
+            && name == package_name
+        {
+            let tag = json.metadata.tag.ok_or(ReleasaurusError::Other(
+              eyre!(
+                "failed to find tag in legacy metadata: pkg={package_name} pr={pr_number}"
+              )
+            ))?;
+            let notes = json.metadata.notes.ok_or(ReleasaurusError::Other(
+              eyre!(
+                "failed to find notes in legacy metadata: pkg={package_name} pr={pr_number}"
+              )
+            ))?;
+            return Ok(Some((tag, notes)));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::orchestrator::tests::common::{PrBodyInput, make_pr_body};
+
+    use super::*;
+
+    // normalize_html_id
+
+    #[test]
+    fn normalize_html_id_passthrough() {
+        assert_eq!(normalize_html_id("my-pkg_v2"), "my-pkg_v2");
+    }
+
+    #[test]
+    fn normalize_html_id_replaces_slash() {
+        assert_eq!(normalize_html_id("@scope/pkg"), "-scope-pkg");
+    }
+
+    #[test]
+    fn normalize_html_id_replaces_space() {
+        assert_eq!(normalize_html_id("my pkg"), "my-pkg");
+    }
+
+    #[test]
+    fn normalize_html_id_replaces_dot() {
+        assert_eq!(normalize_html_id("pkg.name"), "pkg-name");
+    }
+
+    #[test]
+    fn normalize_html_id_empty_string() {
+        assert_eq!(normalize_html_id(""), "");
+    }
+
+    // extract_preserved_section
+
+    #[test]
+    fn extract_preserved_section_returns_content() {
+        let html = r#"<div id="hdr">User text</div>"#;
+        assert_eq!(extract_preserved_section(html, "hdr"), "User text");
+    }
+
+    #[test]
+    fn extract_preserved_section_returns_empty_for_missing_id() {
+        let html = r#"<div id="other">content</div>"#;
+        assert_eq!(extract_preserved_section(html, "hdr"), "");
+    }
+
+    #[test]
+    fn extract_preserved_section_returns_empty_for_empty_element() {
+        let html = r#"<div id="hdr"></div>"#;
+        assert_eq!(extract_preserved_section(html, "hdr"), "");
+    }
+
+    #[test]
+    fn extract_preserved_section_graceful_on_malformed_html() {
+        // Should not panic and return empty string
+        let result = extract_preserved_section("<<broken>>>", "hdr");
+        assert_eq!(result, "");
+    }
+
+    // parse_pr_body
+
+    #[test]
+    fn parse_pr_body_happy_path() {
+        let body = make_pr_body(&PrBodyInput {
+            pkg: "test-pkg",
+            tag: "v1.2.3",
+            notes: "Release notes",
+            tag_link: "tag_link",
+            sha_link: "sha-link",
+            header: "",
+            footer: "",
+        });
+        let (tag, notes) = parse_pr_body("test-pkg", 1, &body).unwrap();
+        assert_eq!(tag, "v1.2.3");
+        assert!(notes.contains("Release notes"));
+    }
+
+    #[test]
+    fn parse_pr_body_strips_metadata_comment() {
+        let body = make_pr_body(&PrBodyInput {
+            pkg: "test-pkg",
+            tag: "v1.2.3",
+            notes: "Release notes",
+            tag_link: "tag_link",
+            sha_link: "sha-link",
+            header: "",
+            footer: "",
+        });
+        let (_, notes) = parse_pr_body("test-pkg", 1, &body).unwrap();
+        assert!(!notes.contains("<!--"));
+        assert!(!notes.contains("sha-link"));
+        assert!(!notes.contains("tag-link"));
+    }
+
+    #[test]
+    fn parse_pr_body_replaces_sha_link_with_tag_link() {
+        let sha = "https://example.com/sha1...sha2";
+        let tag = "https://example.com/v1.2.2...v1.2.3";
+        let notes = format!("Compare: {sha}");
+        let body = make_pr_body(&PrBodyInput {
+            pkg: "test-pkg",
+            tag: "v1.2.3",
+            notes: &notes,
+            tag_link: tag,
+            sha_link: sha,
+            header: "",
+            footer: "",
+        });
+        let (_, notes) = parse_pr_body("test-pkg", 1, &body).unwrap();
+        assert!(notes.contains(tag));
+        assert!(!notes.contains(sha));
+    }
+
+    #[test]
+    fn parse_pr_body_with_header() {
+        let body = make_pr_body(&PrBodyInput {
+            pkg: "test-pkg",
+            tag: "v1.2.3",
+            notes: "Notes",
+            tag_link: "tag-link",
+            sha_link: "sha-link",
+            header: "Header text",
+            footer: "",
+        });
+        let (_, notes) = parse_pr_body("test-pkg", 1, &body).unwrap();
+        assert!(notes.starts_with("Header text"));
+        assert!(notes.contains("Notes"));
+    }
+
+    #[test]
+    fn parse_pr_body_with_footer() {
+        let body = make_pr_body(&PrBodyInput {
+            pkg: "test-pkg",
+            tag: "v1.2.3",
+            notes: "Notes",
+            tag_link: "tag-link",
+            sha_link: "sha-link",
+            header: "",
+            footer: "Footer text",
+        });
+
+        let (_, notes) = parse_pr_body("test-pkg", 1, &body).unwrap();
+        assert!(notes.ends_with("Footer text"));
+        assert!(notes.contains("Notes"));
+    }
+
+    #[test]
+    fn parse_pr_body_with_header_and_footer() {
+        let body = make_pr_body(&PrBodyInput {
+            pkg: "test-pkg",
+            tag: "v1.2.3",
+            notes: "Notes",
+            tag_link: "tag-link",
+            sha_link: "sha-link",
+            header: "Header text",
+            footer: "Footer text",
+        });
+
+        let (_, notes) = parse_pr_body("test-pkg", 1, &body).unwrap();
+        assert!(notes.starts_with("Header text"));
+        assert!(notes.ends_with("Footer text"));
+        assert!(notes.contains("Notes"));
+    }
+
+    #[test]
+    fn parse_pr_body_error_missing_div() {
+        let body = r#"<details open><summary>v1.0.0</summary></details>"#;
+        assert!(parse_pr_body("test-pkg", 1, body).is_err());
+    }
+
+    #[test]
+    fn parse_pr_body_error_missing_data_tag() {
+        let body = r#"<div id="test-pkg">
+<!--{"metadata":{"sha_compare_link":"sha","tag_compare_link":"tag"}}-->
+notes
+</div>"#;
+        assert!(parse_pr_body("test-pkg", 1, body).is_err());
+    }
+
+    #[test]
+    fn parse_pr_body_error_missing_metadata_comment() {
+        let body = r#"<div id="test-pkg" data-tag="v1.0.0">
+just notes, no metadata comment
+</div>"#;
+        assert!(parse_pr_body("test-pkg", 1, body).is_err());
+    }
+
+    #[test]
+    fn parse_pr_body_error_missing_tag_compare_link() {
+        let body = r#"<div id="test-pkg" data-tag="v1.0.0">
+<!--{"metadata":{"sha_compare_link":"sha"}}-->
+notes
+</div>"#;
+        assert!(parse_pr_body("test-pkg", 1, body).is_err());
+    }
+
+    #[test]
+    fn parse_pr_body_error_missing_sha_compare_link() {
+        let body = r#"<div id="test-pkg" data-tag="v1.0.0">
+<!--{"metadata":{"tag_compare_link":"tag"}}-->
+notes
+</div>"#;
+        assert!(parse_pr_body("test-pkg", 1, body).is_err());
+    }
+
+    // parse_legacy_pr_body
+
+    #[test]
+    fn parse_legacy_pr_body_returns_match() {
+        let body = r#"
+<!--{"metadata":{"name":"test-pkg","tag":"v1.0.0","notes":"Release notes"}}-->
+<details><summary>v1.0.0</summary>
+Release notes
+</details>"#;
+        let result = parse_legacy_pr_body("test-pkg", 1, body).unwrap();
+        let (tag, notes) = result.unwrap();
+        assert_eq!(tag, "v1.0.0");
+        assert_eq!(notes, "Release notes");
+    }
+
+    #[test]
+    fn parse_legacy_pr_body_returns_none_for_missing_package() {
+        let body = r#"
+<!--{"metadata":{"name":"other-pkg","tag":"v1.0.0","notes":"Notes"}}-->
+<details><summary>v1.0.0</summary>
+</details>"#;
+        let result = parse_legacy_pr_body("test-pkg", 1, body).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_legacy_pr_body_finds_correct_block_among_multiple() {
+        let body = r#"
+<!--{"metadata":{"name":"pkg-a","tag":"v1.0.0","notes":"Notes A"}}-->
+<details><summary>v1.0.0</summary>
+</details>
+
+<!--{"metadata":{"name":"pkg-b","tag":"v2.0.0","notes":"Notes B"}}-->
+<details><summary>v2.0.0</summary>
+</details>"#;
+        let result = parse_legacy_pr_body("pkg-b", 1, body).unwrap();
+        let (tag, notes) = result.unwrap();
+        assert_eq!(tag, "v2.0.0");
+        assert_eq!(notes, "Notes B");
+    }
+
+    #[test]
+    fn parse_legacy_pr_body_error_missing_tag_field() {
+        let body = r#"
+<!--{"metadata":{"name":"test-pkg","notes":"Notes"}}-->
+<details><summary>v1.0.0</summary>
+</details>"#;
+        assert!(parse_legacy_pr_body("test-pkg", 1, body).is_err());
+    }
+
+    #[test]
+    fn parse_legacy_pr_body_error_missing_notes_field() {
+        let body = r#"
+<!--{"metadata":{"name":"test-pkg","tag":"v1.0.0"}}-->
+<details><summary>v1.0.0</summary>
+</details>"#;
+        assert!(parse_legacy_pr_body("test-pkg", 1, body).is_err());
+    }
+}

--- a/crates/releasaurus-core/src/orchestrator/tests.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests.rs
@@ -2,7 +2,8 @@
 //!
 //! Test organization:
 //! - `common`: Shared test utilities and helper functions
-//! - `metadata`: PR metadata parsing and regex matching tests
+//! - `metadata`: New-format PR metadata regex tests
+//! - `metadata_legacy`: Legacy PR metadata regex tests
 //! - `package_releases`: Package release creation tests
 //! - `pr_workflow`: Pull request workflow tests
 //! - `release_workflow`: Release creation workflow tests
@@ -10,10 +11,11 @@
 //! - `current_releases`: Release data retrieval tests
 //! - `get_notes`: Get notes functionality tests
 
-mod common;
+pub(crate) mod common;
 mod current_releases;
 mod get_notes;
 mod metadata;
+mod metadata_legacy;
 mod next_release;
 mod package_releases;
 mod pr_workflow;

--- a/crates/releasaurus-core/src/orchestrator/tests/common.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/common.rs
@@ -1,6 +1,6 @@
 //! Common test utilities for orchestrator tests.
 
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, fmt::Display, rc::Rc};
 
 use crate::{
     config::{
@@ -21,6 +21,45 @@ pub use semver::Version;
 use url::Url;
 
 pub const TEST_PKG_NAME: &str = "test-pkg";
+
+/// Input for make_pr_body helper
+pub(crate) struct PrBodyInput<S: Display> {
+    pub(crate) pkg: S,
+    pub(crate) tag: S,
+    pub(crate) notes: S,
+    pub(crate) tag_link: S,
+    pub(crate) sha_link: S,
+    pub(crate) header: S,
+    pub(crate) footer: S,
+}
+
+/// Builds a PR body in the new HTML format
+pub(crate) fn make_pr_body<S: Display>(input: &PrBodyInput<S>) -> String {
+    let json = format!(
+        r#"{{"metadata":{{"sha_compare_link":"{}","tag_compare_link":"{}"}}}}"#,
+        input.sha_link, input.tag_link
+    );
+    format!(
+        r#"<details open>
+<summary>{}</summary>
+<div id="{}-header">{}</div>
+<div id="{}" data-tag="{}">
+<!--{json}-->
+
+{}
+</div>
+<div id="{}-footer">{}</div>
+</details>"#,
+        input.tag,
+        input.pkg,
+        input.header,
+        input.pkg,
+        input.tag,
+        input.notes,
+        input.pkg,
+        input.footer
+    )
+}
 
 /// Creates a test Orchestrator with the provided mock forge.
 /// This allows tests to set expectations on the mock before creating the manager.

--- a/crates/releasaurus-core/src/orchestrator/tests/metadata.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/metadata.rs
@@ -1,105 +1,52 @@
-//! Tests for PR metadata parsing.
+//! Tests for new-format PR metadata parsing.
 //!
 //! Tests for:
-//! - Metadata regex pattern matching
-//! - JSON parsing from HTML comments
-//! - Multiple metadata blocks handling
+//! - New metadata regex pattern matching
+//! - JSON extraction from new-format HTML comments
+//! - Regex behaviour within a div (embedded context)
 
-use super::super::{METADATA_REGEX, PRMetadata};
+use crate::orchestrator::{core::PRMetadata, pr_body::METADATA_REGEX};
 
 #[test]
-fn metadata_regex_matches_json_in_html_comment() {
-    let pr_body = r#"
-<!--{"metadata":{"name":"pkg","tag":"v1.0.0","notes":"notes"}}-->
-<details><summary>v1.0.0</summary>
-notes
-</details>
-"#;
+fn metadata_regex_matches_new_format_comment() {
+    let body = r#"<div id="test-pkg" data-tag="v1.2.3">
+<!--{"metadata":{"sha_compare_link":"sha-url","tag_compare_link":"tag-url"}}-->
 
-    let caps = METADATA_REGEX.captures(pr_body);
-    assert!(caps.is_some());
+Release notes
+</div>"#;
 
-    let metadata_str = caps.unwrap().name("metadata").unwrap().as_str();
+    assert!(METADATA_REGEX.captures(body).is_some());
+}
+
+#[test]
+fn metadata_regex_extracts_json_from_comment() {
+    let body = r#"<div id="test-pkg" data-tag="v1.2.3">
+<!--{"metadata":{"sha_compare_link":"sha-url","tag_compare_link":"tag-url"}}-->
+
+Release notes
+</div>"#;
+
+    let caps = METADATA_REGEX.captures(body).unwrap();
+    let metadata_str = caps.name("metadata").unwrap().as_str();
     let parsed: PRMetadata = serde_json::from_str(metadata_str).unwrap();
-    assert_eq!(parsed.metadata.name, "pkg");
-    assert_eq!(parsed.metadata.tag, "v1.0.0");
+    assert_eq!(parsed.metadata.sha_compare_link.as_deref(), Some("sha-url"));
+    assert_eq!(parsed.metadata.tag_compare_link.as_deref(), Some("tag-url"));
 }
 
 #[test]
-fn metadata_regex_handles_multiple_metadata_blocks() {
-    let pr_body = r#"
-<!--{"metadata":{"name":"pkg-a","tag":"v1.0.0","notes":"notes a"}}-->
-<details><summary>v1.0.0</summary>
-notes a
-</details>
+fn metadata_regex_handles_whitespace_around_json() {
+    let body = r#"<div id="test-pkg" data-tag="v1.0.0">
+<!--  {"metadata":{"sha_compare_link":"s","tag_compare_link":"t"}}  -->
+</div>"#;
 
-<!--{"metadata":{"name":"pkg-b","tag":"v2.0.0","notes":"notes b"}}-->
-<details><summary>v2.0.0</summary>
-notes b
-</details>
-"#;
-
-    let matches: Vec<_> = METADATA_REGEX.captures_iter(pr_body).collect();
-    assert_eq!(matches.len(), 2);
+    assert!(METADATA_REGEX.captures(body).is_some());
 }
 
 #[test]
-fn metadata_regex_extracts_correct_metadata_from_multiple_blocks() {
-    let pr_body = r#"
-<!--{"metadata":{"name":"first-pkg","tag":"v1.0.0","notes":"first notes"}}-->
-<details><summary>v1.0.0</summary>
-first notes
-</details>
-
-<!--{"metadata":{"name":"second-pkg","tag":"v2.5.0","notes":"second notes"}}-->
-<details><summary>v2.5.0</summary>
-second notes
-</details>
-"#;
-
-    let matches: Vec<_> = METADATA_REGEX.captures_iter(pr_body).collect();
-
-    // Verify first metadata block
-    let first_metadata_str = matches[0].name("metadata").unwrap().as_str();
-    let first: PRMetadata = serde_json::from_str(first_metadata_str).unwrap();
-    assert_eq!(first.metadata.name, "first-pkg");
-    assert_eq!(first.metadata.tag, "v1.0.0");
-    assert_eq!(first.metadata.notes, "first notes");
-
-    // Verify second metadata block
-    let second_metadata_str = matches[1].name("metadata").unwrap().as_str();
-    let second: PRMetadata = serde_json::from_str(second_metadata_str).unwrap();
-    assert_eq!(second.metadata.name, "second-pkg");
-    assert_eq!(second.metadata.tag, "v2.5.0");
-    assert_eq!(second.metadata.notes, "second notes");
-}
-
-#[test]
-fn metadata_regex_matches_but_json_parsing_would_fail_for_non_json_comments() {
-    let pr_body = r#"
+fn metadata_regex_does_not_match_plain_comment() {
+    let body = r#"<div id="test-pkg" data-tag="v1.0.0">
 <!-- This is just a regular comment -->
-<details><summary>v1.0.0</summary>
-Some content
-</details>
-"#;
+</div>"#;
 
-    let caps = METADATA_REGEX.captures(pr_body);
-    assert!(caps.is_some());
-
-    // The regex matches, but JSON parsing would fail
-    let metadata_str = caps.unwrap().name("metadata").unwrap().as_str();
-    let parsed: Result<PRMetadata, _> = serde_json::from_str(metadata_str);
-    assert!(parsed.is_err());
-}
-
-#[test]
-fn metadata_regex_requires_details_tag_after_comment() {
-    // Metadata comment without <details> tag should not match
-    let pr_body = r#"
-<!--{"metadata":{"name":"pkg","tag":"v1.0.0","notes":"notes"}}-->
-Some other content
-"#;
-
-    let caps = METADATA_REGEX.captures(pr_body);
-    assert!(caps.is_none());
+    assert!(METADATA_REGEX.captures(body).is_none());
 }

--- a/crates/releasaurus-core/src/orchestrator/tests/metadata_legacy.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/metadata_legacy.rs
@@ -1,0 +1,107 @@
+//! Tests for legacy PR metadata parsing.
+//!
+//! Tests for:
+//! - Legacy metadata regex pattern matching
+//! - JSON parsing from legacy HTML comments
+//! - Multiple legacy metadata blocks handling
+
+use crate::orchestrator::{core::PRMetadata, pr_body::METADATA_REGEX_LEGACY};
+
+#[test]
+fn metadata_regex_matches_json_in_html_comment() {
+    let pr_body = r#"
+<!--{"metadata":{"name":"pkg","tag":"v1.0.0","notes":"notes"}}-->
+<details><summary>v1.0.0</summary>
+notes
+</details>
+"#;
+
+    let caps = METADATA_REGEX_LEGACY.captures(pr_body);
+    assert!(caps.is_some());
+
+    let metadata_str = caps.unwrap().name("metadata").unwrap().as_str();
+    let parsed: PRMetadata = serde_json::from_str(metadata_str).unwrap();
+    assert_eq!(parsed.metadata.name, Some("pkg".into()));
+    assert_eq!(parsed.metadata.tag, Some("v1.0.0".into()));
+}
+
+#[test]
+fn metadata_regex_handles_multiple_metadata_blocks() {
+    let pr_body = r#"
+<!--{"metadata":{"name":"pkg-a","tag":"v1.0.0","notes":"notes a"}}-->
+<details><summary>v1.0.0</summary>
+notes a
+</details>
+
+<!--{"metadata":{"name":"pkg-b","tag":"v2.0.0","notes":"notes b"}}-->
+<details><summary>v2.0.0</summary>
+notes b
+</details>
+"#;
+
+    let matches: Vec<_> =
+        METADATA_REGEX_LEGACY.captures_iter(pr_body).collect();
+    assert_eq!(matches.len(), 2);
+}
+
+#[test]
+fn metadata_regex_extracts_correct_metadata_from_multiple_blocks() {
+    let pr_body = r#"
+<!--{"metadata":{"name":"first-pkg","tag":"v1.0.0","notes":"first notes"}}-->
+<details><summary>v1.0.0</summary>
+first notes
+</details>
+
+<!--{"metadata":{"name":"second-pkg","tag":"v2.5.0","notes":"second notes"}}-->
+<details><summary>v2.5.0</summary>
+second notes
+</details>
+"#;
+
+    let matches: Vec<_> =
+        METADATA_REGEX_LEGACY.captures_iter(pr_body).collect();
+
+    // Verify first metadata block
+    let first_metadata_str = matches[0].name("metadata").unwrap().as_str();
+    let first: PRMetadata = serde_json::from_str(first_metadata_str).unwrap();
+    assert_eq!(first.metadata.name, Some("first-pkg".into()));
+    assert_eq!(first.metadata.tag, Some("v1.0.0".into()));
+    assert_eq!(first.metadata.notes, Some("first notes".into()));
+
+    // Verify second metadata block
+    let second_metadata_str = matches[1].name("metadata").unwrap().as_str();
+    let second: PRMetadata = serde_json::from_str(second_metadata_str).unwrap();
+    assert_eq!(second.metadata.name, Some("second-pkg".into()));
+    assert_eq!(second.metadata.tag, Some("v2.5.0".into()));
+    assert_eq!(second.metadata.notes, Some("second notes".into()));
+}
+
+#[test]
+fn metadata_regex_matches_but_json_parsing_would_fail_for_non_json_comments() {
+    let pr_body = r#"
+<!-- This is just a regular comment -->
+<details><summary>v1.0.0</summary>
+Some content
+</details>
+"#;
+
+    let caps = METADATA_REGEX_LEGACY.captures(pr_body);
+    assert!(caps.is_some());
+
+    // The regex matches, but JSON parsing would fail
+    let metadata_str = caps.unwrap().name("metadata").unwrap().as_str();
+    let parsed: Result<PRMetadata, _> = serde_json::from_str(metadata_str);
+    assert!(parsed.is_err());
+}
+
+#[test]
+fn metadata_regex_requires_details_tag_after_comment() {
+    // Metadata comment without <details> tag should not match
+    let pr_body = r#"
+<!--{"metadata":{"name":"pkg","tag":"v1.0.0","notes":"notes"}}-->
+Some other content
+"#;
+
+    let caps = METADATA_REGEX_LEGACY.captures(pr_body);
+    assert!(caps.is_none());
+}

--- a/crates/releasaurus-core/src/orchestrator/tests/pr_workflow.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/pr_workflow.rs
@@ -77,9 +77,13 @@ async fn create_release_prs_returns_error_when_merged_pr_not_yet_released() {
         })
         .times(1);
 
-    // Should never reach branch creation or PR operations
+    // get_open_release_pr is called once from release_pr_packages_by_branch,
+    // but branch creation and PR operations should never be reached.
+    mock_forge
+        .expect_get_open_release_pr()
+        .times(1)
+        .returning(|_| Ok(None));
     mock_forge.expect_create_release_branch().times(0);
-    mock_forge.expect_get_open_release_pr().times(0);
     mock_forge.expect_create_pr().times(0);
     mock_forge.expect_update_pr().times(0);
     mock_forge.expect_replace_pr_labels().times(0);

--- a/crates/releasaurus-core/src/orchestrator/tests/release_workflow.rs
+++ b/crates/releasaurus-core/src/orchestrator/tests/release_workflow.rs
@@ -349,3 +349,116 @@ async fn create_releases_returns_error_for_invalid_package_name() {
 
     assert!(matches!(err, ReleasaurusError::InvalidArgs(_)));
 }
+
+#[tokio::test]
+async fn create_releases_uses_edited_notes_from_pr_body() {
+    let edited_notes = "User-edited release notes for this version";
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: TEST_PKG_NAME,
+        tag: "v1.0.0",
+        notes: edited_notes,
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "",
+        footer: "",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .times(1)
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge
+        .expect_tag_commit()
+        .times(1)
+        .withf(|tag, sha| tag == "v1.0.0" && sha == "abc123")
+        .returning(|_, _| Ok(()));
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|tag, sha, notes| {
+            tag == "v1.0.0"
+                && sha == "abc123"
+                && notes.contains("User-edited release notes")
+        })
+        .returning(|_, _, _| Ok(()));
+
+    mock_forge.expect_replace_pr_labels().returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator_with_config(
+        mock_forge,
+        vec![
+            PackageConfigBuilder::default()
+                .name(TEST_PKG_NAME)
+                .path(".")
+                .build()
+                .unwrap(),
+        ],
+        None,
+    );
+
+    orchestrator.create_releases(None).await.unwrap();
+}
+
+#[tokio::test]
+async fn create_releases_includes_header_and_footer_in_release_notes() {
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: TEST_PKG_NAME,
+        tag: "v1.0.0",
+        notes: "Release notes",
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "Custom header text",
+        footer: "Custom footer text",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .times(1)
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge.expect_tag_commit().returning(|_, _| Ok(()));
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|_, _, notes| {
+            notes.contains("Custom header text")
+                && notes.contains("Release notes")
+                && notes.contains("Custom footer text")
+        })
+        .returning(|_, _, _| Ok(()));
+
+    mock_forge.expect_replace_pr_labels().returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator_with_config(
+        mock_forge,
+        vec![
+            PackageConfigBuilder::default()
+                .name(TEST_PKG_NAME)
+                .path(".")
+                .build()
+                .unwrap(),
+        ],
+        None,
+    );
+
+    orchestrator.create_releases(None).await.unwrap();
+}


### PR DESCRIPTION
## Description

This allows users to freely edit the notes within the PR body and have those edits be reflected in the final release notes. The edits won't have any effect on the CHANGELOG.

Additionally, user's can edit "special" sections of the release PR body for release headers and footers which will persist across multiple runs of release-pr and be prepended / appended to the release notes during release phase.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

## Related Issues

Fixes #259 
