### PR TITLE
fix(gitlab): paginate labels

### DIFF
--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -134,8 +134,9 @@ impl Gitlab {
     async fn get_repo_labels(&self) -> Result<Vec<LabelInfo>> {
         let endpoint = Labels::builder().project(&self.project_id).build()?;
 
-        let labels: Vec<LabelInfo> =
-            paged(endpoint, Pagination::All).query_async(&self.gl).await?;
+        let labels: Vec<LabelInfo> = paged(endpoint, Pagination::All)
+            .query_async(&self.gl)
+            .await?;
 
         Ok(labels)
     }

--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -134,7 +134,8 @@ impl Gitlab {
     async fn get_repo_labels(&self) -> Result<Vec<LabelInfo>> {
         let endpoint = Labels::builder().project(&self.project_id).build()?;
 
-        let labels: Vec<LabelInfo> = endpoint.query_async(&self.gl).await?;
+        let labels: Vec<LabelInfo> =
+            paged(endpoint, Pagination::All).query_async(&self.gl).await?;
 
         Ok(labels)
     }


### PR DESCRIPTION
## Description

Paginate on retreival of labels so if >20 labels are returned we don't fail.

## Type of Change

- [X] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)

## Related Issues
Fixes #281 

## Additional Notes
Untested.
