### PR TITLE
feat: adds explicit support for forgejo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
           GITEA_TEST_REPO: https://gitea.com/rgon/test-repo
           GITEA_TEST_TOKEN: ${{ secrets.GT_TEST_TOKEN }}
           GITEA_RESET_SHA: b353e2f4128a9436540e4f2ddefd9989a9633372
+          FORGEJO_TEST_REPO: https://codeberg.org/rgon/test-repo
+          FORGEJO_TEST_TOKEN: ${{ secrets.FJ_TEST_TOKEN }}
+          FORGEJO_RESET_SHA: 855e0ddc6ddd00d880d0a99638a2f6c678e4109c
         run: |
           cargo llvm-cov \
             --ignore-filename-regex "(_test\.rs$)|(_tests\.rs$)" \

--- a/Justfile
+++ b/Justfile
@@ -50,3 +50,6 @@ test-gitlab-integration: (_test_integration "test_gitlab_forge")
 
 # Runs only the gitea integration tests
 test-gitea-integration: (_test_integration "test_gitea_forge")
+
+# Runs only the forgejo integration tests
+test-forgejo-integration: (_test_integration "test_forgejo_forge")

--- a/book/src/ci-cd-integration.md
+++ b/book/src/ci-cd-integration.md
@@ -1,7 +1,8 @@
 # CI/CD Integration
 
-Releasaurus provides official integrations for GitHub Actions and Gitea
-Actions. For GitLab CI, use the Docker image directly.
+Releasaurus provides official integrations for GitHub Actions, Gitea
+Actions, and Forgejo Actions. For GitLab CI, use the Docker image
+directly.
 
 > **Note on fetch depth:** When using `--local-path` (hybrid mode),
 > Releasaurus reads commit history and tags directly from the local
@@ -10,10 +11,10 @@ Actions. For GitLab CI, use the Docker image directly.
 > when using `--local-path`. Platform-specific instructions are in
 > each section below.
 
-## GitHub Actions & Gitea Actions
+## GitHub Actions, Gitea Actions & Forgejo Actions
 
-A single action works for both GitHub Actions and Gitea Actions
-workflows. See the
+A single action works for GitHub Actions, Gitea Actions, and Forgejo
+Actions workflows. See the
 [action README](https://github.com/robgonnella/releasaurus/tree/main/action)
 for inputs, usage examples, and fetch depth configuration for
 `--local-path`.

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -336,8 +336,11 @@ URL:
 # GitLab
 --forge gitlab --repo "https://gitlab.com/group/project"
 
-# Gitea (or Forgejo)
+# Gitea
 --forge gitea --repo "https://git.example.com/owner/repo"
+
+# Forgejo
+--forge forgejo --repo "https://forgejo.example.com/owner/repo"
 
 # Local repository (for testing)
 --forge local --repo "."
@@ -348,6 +351,7 @@ URL:
 - `github` - For github.com and GitHub Enterprise
 - `gitlab` - For gitlab.com and self-hosted GitLab instances
 - `gitea` - For gitea.com and self-hosted Gitea instances
+- `forgejo` - For codeberg.org and self-hosted Forgejo instances
 - `local` - For testing against local repositories
 
 ### Dry Run Mode
@@ -796,7 +800,7 @@ releasaurus release-pr \
 # Self-hosted GitLab
 releasaurus release-pr \
   --forge gitlab \
-  --repo "https://gitlab.company.com/team/project" \
+  --repo "https://gitlab.company.com/team/group/project" \
   --token "glpat_xxxxxxxxxxxxxxxxxxxx"
 ```
 
@@ -809,9 +813,9 @@ releasaurus release-pr \
   --repo "https://git.company.com/team/project" \
   --token "xxxxxxxxxxxxxxxxxx"
 
-# Works with Forgejo too
+# Self-hosted Forgejo
 releasaurus release-pr \
-  --forge gitea \
+  --forge forgejo \
   --repo "https://forgejo.example.com/org/repo" \
   --token "xxxxxxxxxxxxxxxxxx"
 ```

--- a/book/src/environment-variables.md
+++ b/book/src/environment-variables.md
@@ -97,7 +97,7 @@ releasaurus release-pr \
 
 #### `GITEA_TOKEN`
 
-**Purpose**: Authentication token for Gitea/Forgejo API access
+**Purpose**: Authentication token for Gitea API access
 
 **Required Permissions**:
 
@@ -117,10 +117,29 @@ export GITEA_TOKEN="xxxxxxxxxxxxxxxxxx"
 releasaurus release-pr \
   --forge gitea \
   --repo "https://git.company.com/org/repo"
+```
 
-# Forgejo instance
+#### `FORGEJO_TOKEN`
+
+**Purpose**: Authentication token for Forgejo API access
+
+**Required Permissions**:
+
+- Repository read/write access
+- Issue/PR management permissions
+
+**Example**:
+
+```bash
+export FORGEJO_TOKEN="xxxxxxxxxxxxxxxxxx"
+```
+
+**Usage**:
+
+```bash
+# Self-hosted Forgejo instance
 releasaurus release-pr \
-  --forge gitea \
+  --forge forgejo \
   --repo "https://forgejo.example.com/user/project"
 ```
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -11,6 +11,7 @@ use releasaurus_core::{
     },
     forge::{
         config::{RepoUrl, Scheme, TokenVar, resolve_token},
+        forgejo::Forgejo,
         gitea::Gitea,
         github::Github,
         gitlab::Gitlab,
@@ -111,7 +112,8 @@ impl ForgeArgs {
                 ForgeType::Gitea => {
                     let repo = git_url_to_repo_url(git_url)?;
                     let gitea =
-                        Gitea::new(repo.clone(), self.token.clone()).await?;
+                        Gitea::new(repo.clone(), self.token.clone(), None)
+                            .await?;
                     if let Some(local_path) = self.local_path.as_ref() {
                         self.resolve_hybrid_forge(
                             Arc::new(gitea),
@@ -121,6 +123,21 @@ impl ForgeArgs {
                         )?
                     } else {
                         Box::new(gitea)
+                    }
+                }
+                ForgeType::Forgejo => {
+                    let repo = git_url_to_repo_url(git_url)?;
+                    let forgejo =
+                        Forgejo::new(repo.clone(), self.token.clone()).await?;
+                    if let Some(local_path) = self.local_path.as_ref() {
+                        self.resolve_hybrid_forge(
+                            Arc::new(forgejo),
+                            local_path,
+                            &repo,
+                            TokenVar::Forgejo,
+                        )?
+                    } else {
+                        Box::new(forgejo)
                     }
                 }
                 ForgeType::Local => {
@@ -213,6 +230,8 @@ pub enum ForgeType {
     Gitlab,
     /// Targets Gitea as the remote forge
     Gitea,
+    /// Targets Forgejo as the remote forge
+    Forgejo,
     /// Targets a local repo for testing / debugging
     Local,
 }

--- a/crates/core/src/forge.rs
+++ b/crates/core/src/forge.rs
@@ -1,11 +1,12 @@
 //! Forge platform abstractions and implementations.
 //!
 //! The [`traits::Forge`] trait defines the common interface.
-//! Implementations: [`github`], [`gitlab`], [`gitea`], [`local`].
+//! Implementations: [`github`], [`gitlab`], [`gitea`], [`forgejo`], [`local`].
 //! [`manager::ForgeManager`] wraps any `Forge` with caching,
 //! logging, and dry-run support.
 
 pub mod config;
+pub mod forgejo;
 pub mod gitea;
 pub mod github;
 pub mod gitlab;

--- a/crates/core/src/forge/config.rs
+++ b/crates/core/src/forge/config.rs
@@ -102,6 +102,8 @@ pub enum TokenVar {
     Gitlab,
     #[strum(to_string = "GITEA_TOKEN")]
     Gitea,
+    #[strum(to_string = "FORGEJO_TOKEN")]
+    Forgejo,
 }
 
 /// Resolve authentication token from multiple sources in priority order:

--- a/crates/core/src/forge/forgejo.rs
+++ b/crates/core/src/forge/forgejo.rs
@@ -1,0 +1,147 @@
+use async_trait::async_trait;
+use secrecy::SecretString;
+use url::Url;
+
+use crate::{
+    config::Config,
+    forge::{
+        config::{RepoUrl, TokenVar},
+        gitea::Gitea,
+        request::{
+            Commit, CreateCommitRequest, CreatePrRequest,
+            CreateReleaseBranchRequest, ForgeCommit, GetFileContentRequest,
+            GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            Tag, UpdatePrRequest,
+        },
+        traits::Forge,
+    },
+    result::Result,
+};
+
+pub struct Forgejo {
+    gitea: Gitea,
+}
+
+impl Forgejo {
+    pub async fn new(
+        url: RepoUrl,
+        token: Option<SecretString>,
+    ) -> Result<Self> {
+        let gitea = Gitea::new(url, token, Some(TokenVar::Forgejo)).await?;
+
+        Ok(Self { gitea })
+    }
+}
+
+#[async_trait]
+impl Forge for Forgejo {
+    fn repo_name(&self) -> String {
+        self.gitea.repo_name()
+    }
+
+    fn release_link_base_url(&self) -> Url {
+        self.gitea.release_link_base_url()
+    }
+
+    fn compare_link_base_url(&self) -> Url {
+        self.gitea.compare_link_base_url()
+    }
+
+    fn default_branch(&self) -> String {
+        self.gitea.default_branch()
+    }
+
+    fn set_commit_search_depth(&mut self, depth: usize) {
+        self.gitea.set_commit_search_depth(depth)
+    }
+
+    fn set_tag_search_depth(&mut self, depth: usize) {
+        self.gitea.set_tag_search_depth(depth)
+    }
+
+    async fn get_file_content(
+        &self,
+        req: GetFileContentRequest,
+    ) -> Result<Option<String>> {
+        self.gitea.get_file_content(req).await
+    }
+
+    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
+        self.gitea.load_config(branch).await
+    }
+
+    async fn get_release_by_tag(
+        &self,
+        tag: &str,
+    ) -> Result<ReleaseByTagResponse> {
+        self.gitea.get_release_by_tag(tag).await
+    }
+
+    // We return only tags that matches the prefix AND are ancestors of
+    // the target base branch.
+    async fn get_latest_tags_for_prefix(
+        &self,
+        prefix: &str,
+        branch: &str,
+    ) -> Result<Vec<Tag>> {
+        self.gitea.get_latest_tags_for_prefix(prefix, branch).await
+    }
+
+    async fn get_commits(
+        &self,
+        branch: Option<String>,
+        sha: Option<String>,
+    ) -> Result<Vec<ForgeCommit>> {
+        self.gitea.get_commits(branch, sha).await
+    }
+
+    async fn create_release_branch(
+        &self,
+        req: CreateReleaseBranchRequest,
+    ) -> Result<Commit> {
+        self.gitea.create_release_branch(req).await
+    }
+
+    async fn create_commit(&self, req: CreateCommitRequest) -> Result<Commit> {
+        self.gitea.create_commit(req).await
+    }
+
+    async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()> {
+        self.gitea.tag_commit(tag_name, sha).await
+    }
+
+    async fn get_open_release_pr(
+        &self,
+        req: GetPrRequest,
+    ) -> Result<Option<PullRequest>> {
+        self.gitea.get_open_release_pr(req).await
+    }
+
+    async fn get_merged_release_pr(
+        &self,
+        req: GetPrRequest,
+    ) -> Result<Option<PullRequest>> {
+        self.gitea.get_merged_release_pr(req).await
+    }
+
+    async fn create_pr(&self, req: CreatePrRequest) -> Result<PullRequest> {
+        self.gitea.create_pr(req).await
+    }
+
+    async fn update_pr(&self, req: UpdatePrRequest) -> Result<()> {
+        self.gitea.update_pr(req).await
+    }
+
+    async fn replace_pr_labels(&self, req: PrLabelsRequest) -> Result<()> {
+        self.gitea.replace_pr_labels(req).await
+    }
+
+    async fn create_release(
+        &self,
+        tag: &str,
+        sha: &str,
+        notes: &str,
+    ) -> Result<()> {
+        self.gitea.create_release(tag, sha, notes).await
+    }
+}

--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -60,12 +60,17 @@ impl Gitea {
     pub async fn new(
         url: RepoUrl,
         token: Option<SecretString>,
+        token_var: Option<TokenVar>,
     ) -> Result<Self> {
         rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .ok();
 
-        let token = resolve_token(token, url.token.as_ref(), TokenVar::Gitea)?;
+        let token = resolve_token(
+            token,
+            url.token.as_ref(),
+            token_var.unwrap_or(TokenVar::Gitea),
+        )?;
 
         let link_base_url = url.link_base_url();
 

--- a/crates/core/src/forge/tests.rs
+++ b/crates/core/src/forge/tests.rs
@@ -1,4 +1,5 @@
 mod common;
+mod forgejo;
 mod gitea;
 mod github;
 mod gitlab;

--- a/crates/core/src/forge/tests/common.rs
+++ b/crates/core/src/forge/tests/common.rs
@@ -1,3 +1,4 @@
+pub mod forgejo;
 pub mod gitea;
 pub mod github;
 pub mod gitlab;

--- a/crates/core/src/forge/tests/common/forgejo.rs
+++ b/crates/core/src/forge/tests/common/forgejo.rs
@@ -1,0 +1,31 @@
+use async_trait::async_trait;
+use color_eyre::eyre::Result;
+
+use crate::forge::{
+    config::RepoUrl,
+    tests::common::{gitea::GiteaForgeTestHelper, traits::ForgeTestHelper},
+};
+
+pub struct ForgejoForgeTestHelper {
+    gitea_helper: GiteaForgeTestHelper,
+}
+
+impl ForgejoForgeTestHelper {
+    pub async fn new(repo: &RepoUrl, token: &str, reset_sha: &str) -> Self {
+        let gitea_helper =
+            GiteaForgeTestHelper::new(repo, token, reset_sha).await;
+
+        Self { gitea_helper }
+    }
+}
+
+#[async_trait]
+impl ForgeTestHelper for ForgejoForgeTestHelper {
+    async fn reset(&self) -> Result<()> {
+        self.gitea_helper.reset().await
+    }
+
+    async fn merge_pr(&self, pr_number: u64) -> Result<()> {
+        self.gitea_helper.merge_pr(pr_number).await
+    }
+}

--- a/crates/core/src/forge/tests/common/gitea.rs
+++ b/crates/core/src/forge/tests/common/gitea.rs
@@ -55,14 +55,14 @@ impl GiteaForgeTestHelper {
             .unwrap();
 
         let mut base_url = format!(
-            "{}://{}/api/v1/repos/{}/",
-            repo.scheme, repo.host, repo.path
+            "{}://{}/api/v1/repos/{}/{}/",
+            repo.scheme, repo.host, repo.owner, repo.name
         );
 
         if let Some(port) = repo.port {
             base_url = format!(
-                "{}://{}:{}/api/v1/repos/{}/",
-                repo.scheme, repo.host, port, repo.path
+                "{}://{}:{}/api/v1/repos/{}/{}/",
+                repo.scheme, repo.host, port, repo.owner, repo.name
             );
         }
 

--- a/crates/core/src/forge/tests/forgejo.rs
+++ b/crates/core/src/forge/tests/forgejo.rs
@@ -1,0 +1,42 @@
+use secrecy::SecretString;
+use std::env;
+
+use crate::forge::{
+    forgejo::Forgejo,
+    manager::{ForgeManager, ForgeOptions},
+    tests::common::{
+        forgejo::ForgejoForgeTestHelper,
+        run::{parse_repo_url, run_forge_test},
+    },
+};
+
+#[tokio::test]
+#[test_log::test]
+async fn test_forgejo_forge() {
+    let repo = parse_repo_url(
+        &env::var("FORGEJO_TEST_REPO")
+            .expect("FORGEJO_TEST_REPO env var must be set"),
+    );
+
+    let token_str = env::var("FORGEJO_TEST_TOKEN")
+        .expect("FORGEJO_TEST_TOKEN env var must be set");
+
+    let token_secret = SecretString::from(token_str.clone());
+
+    let reset_sha = env::var("FORGEJO_RESET_SHA")
+        .expect("FORGEJO_RESET_SHA env var must be set");
+
+    let helper =
+        ForgejoForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
+
+    let forgejo_forge = Forgejo::new(repo, Some(token_secret))
+        .await
+        .expect("failed to create Forgejo forge");
+
+    let manager = ForgeManager::new(
+        Box::new(forgejo_forge),
+        ForgeOptions { dry_run: false },
+    );
+
+    run_forge_test(&manager, &helper).await;
+}

--- a/crates/core/src/forge/tests/gitea.rs
+++ b/crates/core/src/forge/tests/gitea.rs
@@ -17,16 +17,21 @@ async fn test_gitea_forge() {
         &env::var("GITEA_TEST_REPO")
             .expect("GITEA_TEST_REPO env var must be set"),
     );
+
     let token_str = env::var("GITEA_TEST_TOKEN")
         .expect("GITEA_TEST_TOKEN env var must be set");
+
     let token_secret = SecretString::from(token_str.clone());
+
     let reset_sha = env::var("GITEA_RESET_SHA")
         .expect("GITEA_RESET_SHA env var must be set");
 
     let helper = GiteaForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
-    let gitea_forge = Gitea::new(repo, Some(token_secret))
+
+    let gitea_forge = Gitea::new(repo, Some(token_secret), None)
         .await
         .expect("failed to create Gitea forge");
+
     let manager = ForgeManager::new(
         Box::new(gitea_forge),
         ForgeOptions { dry_run: false },

--- a/crates/core/src/forge/tests/github.rs
+++ b/crates/core/src/forge/tests/github.rs
@@ -17,17 +17,22 @@ async fn test_github_forge() {
         &env::var("GITHUB_TEST_REPO")
             .expect("GITHUB_TEST_REPO env var must be set"),
     );
+
     let token_str = env::var("GITHUB_TEST_TOKEN")
         .expect("GITHUB_TEST_TOKEN env var must be set");
+
     let token_secret = SecretString::from(token_str.clone());
+
     let reset_sha = env::var("GITHUB_RESET_SHA")
         .expect("GITHUB_RESET_SHA env var must be set");
 
     let helper =
         GithubForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
+
     let github_forge = Github::new(repo, Some(token_secret))
         .await
         .expect("failed to create Github forge");
+
     let manager = ForgeManager::new(
         Box::new(github_forge),
         ForgeOptions { dry_run: false },

--- a/crates/core/src/forge/tests/gitlab.rs
+++ b/crates/core/src/forge/tests/gitlab.rs
@@ -17,17 +17,22 @@ async fn test_gitlab_forge() {
         &env::var("GITLAB_TEST_REPO")
             .expect("GITLAB_TEST_REPO env var must be set"),
     );
+
     let token_str = env::var("GITLAB_TEST_TOKEN")
         .expect("GITLAB_TEST_TOKEN env var must be set");
+
     let token_secret = SecretString::from(token_str.clone());
+
     let reset_sha = env::var("GITLAB_RESET_SHA")
         .expect("GITLAB_RESET_SHA env var must be set");
 
     let helper =
         GitlabForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
+
     let gitlab_forge = Gitlab::new(repo, Some(token_secret))
         .await
         .expect("failed to create Gitlab forge");
+
     let manager = ForgeManager::new(
         Box::new(gitlab_forge),
         ForgeOptions { dry_run: false },


### PR DESCRIPTION
## Description

This commit adds explicit support for forgejo, complete with integration tests. Prior to this, there was implicit support for forgejo by specifying "gitea" as the remote forge.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)