### PR TITLE
feat: Azure DevOps basic support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
           FORGEJO_TEST_REPO: https://codeberg.org/rgon/test-repo
           FORGEJO_TEST_TOKEN: ${{ secrets.FJ_TEST_TOKEN }}
           FORGEJO_RESET_SHA: 855e0ddc6ddd00d880d0a99638a2f6c678e4109c
+          AZURE_DEVOPS_TEST_REPO: ${{ vars.AZDO_TEST_REPO }}
+          AZURE_DEVOPS_TEST_TOKEN: ${{ secrets.AZDO_TEST_TOKEN }}
+          AZURE_DEVOPS_RESET_SHA: ${{ vars.AZDO_RESET_SHA }}
         run: |
           cargo llvm-cov \
             --ignore-filename-regex "(_test\.rs$)|(_tests\.rs$)" \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ secrecy = "0.10.3"
 serde = "1.0.228"
 serde_json = { version = "1.0.149", features = ["preserve_order"] }
 tokio = { version = "1.52.1", features = ["fs", "macros", "rt-multi-thread"] }
+url = "2.5.8"

--- a/Justfile
+++ b/Justfile
@@ -53,3 +53,6 @@ test-gitea-integration: (_test_integration "test_gitea_forge")
 
 # Runs only the forgejo integration tests
 test-forgejo-integration: (_test_integration "test_forgejo_forge")
+
+# Runs only the azure devops integration tests
+test-azure-devops-integration: (_test_integration "test_azure_devops_forge")

--- a/book/src/ci-cd-integration.md
+++ b/book/src/ci-cd-integration.md
@@ -1,8 +1,8 @@
 # CI/CD Integration
 
 Releasaurus provides official integrations for GitHub Actions, Gitea
-Actions, and Forgejo Actions. For GitLab CI, use the Docker image
-directly.
+Actions, and Forgejo Actions. For GitLab CI and Azure Pipelines, use
+the Docker image directly.
 
 > **Note on fetch depth:** When using `--local-path` (hybrid mode),
 > Releasaurus reads commit history and tags directly from the local
@@ -78,3 +78,46 @@ before_script:
 ```
 
 Using both together is safe and covers all runner states.
+
+## Azure Pipelines (EXPERIMENTAL)
+
+Azure DevOps support is experimental. No first-party Azure Pipelines
+task is provided — use the Releasaurus Docker image directly in your
+pipeline. Note that the `release` command only pushes the git tag
+(the changelog commit lands when the release PR is merged); Azure
+DevOps Git has no native release object, so no release notes page is
+created.
+
+Provide a PAT via the `AZURE_DEVOPS_TOKEN` pipeline secret variable.
+The PAT needs `Code: Read & Write` and `Pull Request Threads: Read &
+Write` scopes.
+
+```yaml
+trigger:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+container: rgonnella/releasaurus:vX.X.X
+
+steps:
+  - checkout: self
+    fetchDepth: 0  # required if you also pass --local-path
+
+  - script: |
+      releasaurus release-pr \
+        --forge azure-devops \
+        --repo "$(Build.Repository.Uri)"
+    env:
+      AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+
+  - script: |
+      releasaurus release \
+        --forge azure-devops \
+        --repo "$(Build.Repository.Uri)"
+    env:
+      AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+```

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -342,6 +342,9 @@ URL:
 # Forgejo
 --forge forgejo --repo "https://forgejo.example.com/owner/repo"
 
+# Azure DevOps (EXPERIMENTAL)
+--forge azure-devops --repo "https://dev.azure.com/org/project/_git/repo"
+
 # Local repository (for testing)
 --forge local --repo "."
 ```
@@ -352,6 +355,12 @@ URL:
 - `gitlab` - For gitlab.com and self-hosted GitLab instances
 - `gitea` - For gitea.com and self-hosted Gitea instances
 - `forgejo` - For codeberg.org and self-hosted Forgejo instances
+- `azure-devops` - **EXPERIMENTAL.** For Azure DevOps Services
+  (`dev.azure.com`). Azure DevOps Git has no native release object,
+  so the `release` step only pushes the git tag — the changelog
+  commit lands when the release PR is merged, and no release notes
+  are published to a release page. Azure DevOps Server (on-prem) is
+  not supported.
 - `local` - For testing against local repositories
 
 ### Known Limitations

--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -135,6 +135,15 @@ The following environment variables are used when running integration tests.
 - `GITEA_TEST_TOKEN`
 - `GITEA_RESET_SHA`
 
+- `FORGEJO_TEST_REPO`
+- `FORGEJO_TEST_TOKEN`
+- `FORGEJO_RESET_SHA`
+
+- `AZURE_DEVOPS_TEST_REPO` (form: `https://dev.azure.com/{org}/{project}/_git/{repo}`)
+- `AZURE_DEVOPS_TEST_TOKEN` (PAT with `Code: Read & Write` and
+  `Pull Request Threads: Read & Write` scopes)
+- `AZURE_DEVOPS_RESET_SHA`
+
 ⚠️ Whatever you configure for these repositories WILL have their histories
 overwritten. All PRs, tags, releases, and branches will be deleted and the
 repository will be hard reset back to the configured reset sha at the start
@@ -153,6 +162,10 @@ export GITLAB_RESET_SHA="abc123"
 export GITEA_TEST_REPO="https://gitea.com/your/test/repo"
 export GITEA_TEST_TOKEN="gt_test_token"
 export GITEA_RESET_SHA="abc123"
+
+export AZURE_DEVOPS_TEST_REPO="https://dev.azure.com/your-org/your-project/_git/test-repo"
+export AZURE_DEVOPS_TEST_TOKEN="azdo_test_pat"
+export AZURE_DEVOPS_RESET_SHA="abc123"
 
 # Or you can add these to a .env file and mise will automatically load them
 # .env
@@ -176,7 +189,18 @@ just test-github-integration
 just test-gitlab-integration
 # target just gitea integration tests
 just test-gitea-integration
+# target just forgejo integration tests
+just test-forgejo-integration
+# target just azure devops integration tests
+just test-azure-devops-integration
 ```
+
+> **Azure DevOps test setup**: the test repo must not have any branch
+> policies on its default branch — the reset routine force-resets
+> history via a temporary branch swap and would fail against a
+> policy-protected branch. Create a dedicated empty project and grant
+> the test PAT `Code: Read & Write` and `Pull Request Threads: Read &
+> Write` scopes.
 
 ## Code Contribution Guidelines
 

--- a/book/src/environment-variables.md
+++ b/book/src/environment-variables.md
@@ -143,6 +143,36 @@ releasaurus release-pr \
   --repo "https://forgejo.example.com/user/project"
 ```
 
+#### `AZURE_DEVOPS_TOKEN`
+
+**Purpose**: Authentication token (Personal Access Token) for Azure
+DevOps API access. **EXPERIMENTAL** — Azure DevOps has no native
+release object, so the `release` step only pushes the git tag (the
+changelog commit lands when the release PR is merged).
+
+**Required PAT Scopes**:
+
+- `Code` — Read & Write (read repo, push commits, create tags and
+  branches)
+- `Pull Request Threads` — Read & Write (create / update release PRs
+  and manage labels)
+
+**Example**:
+
+```bash
+export AZURE_DEVOPS_TOKEN="xxxxxxxxxxxxxxxxxx"
+```
+
+**Usage**:
+
+```bash
+# Azure DevOps Services (dev.azure.com only — on-prem Azure DevOps
+# Server is not supported)
+releasaurus release-pr \
+  --forge azure-devops \
+  --repo "https://dev.azure.com/org/project/_git/repo"
+```
+
 **Token Selection**: Releasaurus automatically selects the appropriate
 environment variable based on the `--forge` flag. Use `--token` to override
 or when the environment variable is not set.

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -10,6 +10,7 @@ use releasaurus_core::{
         resolved::{CommitModifiers, GlobalOverrides, PackageOverrides},
     },
     forge::{
+        azure_devops::{AzureDevops, url_parse::azure_git_url_to_repo_url},
         config::{RepoUrl, Scheme, TokenVar, resolve_token},
         forgejo::Forgejo,
         gitea::Gitea,
@@ -53,7 +54,8 @@ pub struct Cli {
 
 #[derive(Debug, Clone, Args)]
 pub struct ForgeArgs {
-    /// Targets a specific forge: github, gitlab, gitea, or local
+    /// Targets a specific forge: github, gitlab, gitea, forgejo,
+    /// azure-devops, or local
     #[arg(short, long, value_enum, global = true)]
     pub forge: Option<ForgeType>,
 
@@ -68,7 +70,8 @@ pub struct ForgeArgs {
     pub local_path: Option<PathBuf>,
 
     /// Authentication token. Falls back to env vars:
-    /// GITHUB_TOKEN, GITLAB_TOKEN, GITEA_TOKEN
+    /// GITHUB_TOKEN, GITLAB_TOKEN, GITEA_TOKEN, FORGEJO_TOKEN,
+    /// AZURE_DEVOPS_TOKEN
     #[arg(short, long, global = true)]
     pub token: Option<SecretString>,
 }
@@ -138,6 +141,22 @@ impl ForgeArgs {
                         )?
                     } else {
                         Box::new(forgejo)
+                    }
+                }
+                ForgeType::AzureDevops => {
+                    let repo = azure_git_url_to_repo_url(git_url)?;
+                    let azure =
+                        AzureDevops::new(repo.clone(), self.token.clone())
+                            .await?;
+                    if let Some(local_path) = self.local_path.as_ref() {
+                        self.resolve_hybrid_forge(
+                            Arc::new(azure),
+                            local_path,
+                            &repo,
+                            TokenVar::AzureDevops,
+                        )?
+                    } else {
+                        Box::new(azure)
                     }
                 }
                 ForgeType::Local => {
@@ -232,6 +251,10 @@ pub enum ForgeType {
     Gitea,
     /// Targets Forgejo as the remote forge
     Forgejo,
+    /// Targets Azure DevOps as the remote forge (EXPERIMENTAL —
+    /// release step only pushes the git tag; Azure DevOps has no
+    /// native release object)
+    AzureDevops,
     /// Targets a local repo for testing / debugging
     Local,
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -47,7 +47,7 @@ tl = "0.7.8"
 tokio.workspace = true
 toml = "1.1.2"
 toml_edit = "0.25.11"
-url = "2.5.8"
+url.workspace = true
 
 [dev-dependencies]
 mockall = "0.14.0"

--- a/crates/core/src/forge.rs
+++ b/crates/core/src/forge.rs
@@ -1,10 +1,12 @@
 //! Forge platform abstractions and implementations.
 //!
 //! The [`traits::Forge`] trait defines the common interface.
-//! Implementations: [`github`], [`gitlab`], [`gitea`], [`forgejo`], [`local`].
+//! Implementations: [`github`], [`gitlab`], [`gitea`], [`forgejo`],
+//! [`azure_devops`], [`local`].
 //! [`manager::ForgeManager`] wraps any `Forge` with caching,
 //! logging, and dry-run support.
 
+pub mod azure_devops;
 pub mod config;
 pub mod forgejo;
 pub mod gitea;

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -1,0 +1,936 @@
+//! Implements the Forge trait for Azure DevOps Git repositories.
+//!
+//! Azure DevOps Git has no native "release object" concept (its
+//! "Releases" feature is part of Azure Pipelines CD, not git). The
+//! `create_release` method below is a deliberate no-op that logs at
+//! info level; tags and the changelog commit are pushed normally.
+use async_trait::async_trait;
+use base64::{Engine, prelude::BASE64_STANDARD};
+use chrono::DateTime;
+use color_eyre::eyre::ContextCompat;
+use log::{info, warn};
+use regex::Regex;
+use reqwest::{
+    Client, StatusCode,
+    header::{HeaderMap, HeaderValue},
+};
+use secrecy::{ExposeSecret, SecretString};
+use std::cmp;
+use std::sync::{LazyLock, Once};
+use url::Url;
+
+use crate::{
+    config::{
+        Config, DEFAULT_COMMIT_SEARCH_DEPTH, DEFAULT_CONFIG_FILE,
+        DEFAULT_TAG_SEARCH_DEPTH,
+    },
+    forge::{
+        azure_devops::types::{
+            AzureCommit, AzureCommitChanges, AzureList, AzurePullRequest,
+            AzureRef, AzureRepo, Change, ChangeItem, CreateLabel,
+            CreatePullRequest, NewContent, Push, PushCommit, PushResponse,
+            RefUpdate, UpdatePullRequest,
+        },
+        config::{
+            DEFAULT_PAGE_SIZE, LEGACY_PENDING_LABEL, PENDING_LABEL, RepoUrl,
+            TokenVar, resolve_token,
+        },
+        request::{
+            Commit, CreateCommitRequest, CreatePrRequest,
+            CreateReleaseBranchRequest, FileUpdateType, ForgeCommit,
+            GetFileContentRequest, GetPrRequest, PrLabelsRequest,
+            PrMetadataBlock, PullRequest, ReleaseByTagResponse, Tag,
+            UpdatePrRequest,
+        },
+        traits::Forge,
+    },
+    result::{ReleasaurusError, Result},
+};
+
+mod types;
+pub mod url_parse;
+
+const API_VERSION: &str = "7.1";
+const LABELS_API_VERSION: &str = "7.1-preview.1";
+const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+
+static EXPERIMENTAL_WARNING: Once = Once::new();
+
+/// Strips the `Merged PR NNN: ` prefix that Azure DevOps prepends to
+/// squash-merge commit messages, recovering the original commit subject.
+static AZURE_MERGED_PR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(Merged PR \d+:)\s+").unwrap());
+
+/// Azure DevOps forge implementation using reqwest against the
+/// Azure DevOps Git REST API.
+///
+/// `repo_url.owner` is expected to hold `"{org}/{project}"`.
+pub struct AzureDevops {
+    url: RepoUrl,
+    commit_search_depth: usize,
+    tag_search_depth: usize,
+    /// API base: `https://dev.azure.com/{org}/{project}/_apis/git/repositories/{repo}/`
+    base_url: Url,
+    client: Client,
+    default_branch: String,
+    release_link_base_url: Url,
+    compare_link_base_url: Url,
+}
+
+impl AzureDevops {
+    pub async fn new(
+        url: RepoUrl,
+        token: Option<SecretString>,
+    ) -> Result<Self> {
+        EXPERIMENTAL_WARNING.call_once(|| {
+            warn!(
+                "azure devops forge support is EXPERIMENTAL; \
+                 expect rough edges. the release step only pushes the \
+                 git tag — azure devops has no native release object \
+                 to publish notes against."
+            );
+        });
+
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
+
+        let token =
+            resolve_token(token, url.token.as_ref(), TokenVar::AzureDevops)?;
+
+        let link_base_url = url.link_base_url();
+
+        // Web URL prefix: https://dev.azure.com/{org}/{project}/_git/{repo}
+        let web_repo_url = format!("{}{}", link_base_url, url.path);
+
+        // Azure DevOps has no Releases page; link tags to the tag listing.
+        let release_link_base_url =
+            Url::parse(&format!("{}?path=/&version=GT", web_repo_url))?;
+        let compare_link_base_url = Url::parse(&format!(
+            "{}/branchCompare?baseVersion=GT",
+            web_repo_url
+        ))?;
+
+        let mut headers = HeaderMap::new();
+
+        // Azure DevOps PAT auth: Basic base64(":{PAT}") with an empty username.
+        let basic = BASE64_STANDARD
+            .encode(format!(":{}", token.expose_secret()).as_bytes());
+        let token_value =
+            HeaderValue::from_str(format!("Basic {}", basic).as_str())?;
+        headers.append("Authorization", token_value);
+        headers.append("Accept", HeaderValue::from_static("application/json"));
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()?;
+
+        // API base: https://dev.azure.com/{org}/{project}/_apis/git/repositories/{repo}/
+        let base_url = format!(
+            "{}/{}/_apis/git/repositories/{}/",
+            link_base_url, url.owner, url.name
+        );
+        let base_url = Url::parse(&base_url)?;
+
+        // Fetch repo metadata for the default branch.
+        let mut repo_url = base_url.clone();
+        repo_url
+            .query_pairs_mut()
+            .append_pair("api-version", API_VERSION);
+        let response = client.get(repo_url).send().await?;
+        let result = response.error_for_status()?;
+        let repo: AzureRepo = result.json().await?;
+        let default_branch = repo
+            .default_branch
+            .as_deref()
+            .map(strip_refs_heads)
+            .map(str::to_string)
+            .wrap_err("failed to get default branch")?;
+
+        Ok(Self {
+            url,
+            commit_search_depth: DEFAULT_COMMIT_SEARCH_DEPTH,
+            tag_search_depth: DEFAULT_TAG_SEARCH_DEPTH,
+            client,
+            base_url,
+            release_link_base_url,
+            compare_link_base_url,
+            default_branch,
+        })
+    }
+
+    fn endpoint(&self, path: &str) -> Result<Url> {
+        let mut url = self.base_url.join(path)?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION);
+        Ok(url)
+    }
+
+    /// Returns true if `commit_sha` is reachable from `branch`'s head
+    /// (i.e. the commit is an ancestor of the branch). Uses the Azure
+    /// DevOps diffs API: if `commonCommit == baseCommit`, the base
+    /// (commit) is fully contained in the target (branch).
+    async fn is_ancestor_of_branch(
+        &self,
+        commit_sha: &str,
+        branch: &str,
+    ) -> Result<bool> {
+        let mut url = self.base_url.join("diffs/commits")?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("baseVersion", commit_sha)
+            .append_pair("baseVersionType", "commit")
+            .append_pair("targetVersion", branch)
+            .append_pair("targetVersionType", "branch");
+        let response = self.client.get(url).send().await?;
+        if !response.status().is_success() {
+            return Ok(false);
+        }
+        let body: serde_json::Value = response.json().await?;
+        let base = body.get("baseCommit").and_then(|v| v.as_str());
+        let common = body.get("commonCommit").and_then(|v| v.as_str());
+        match (base, common) {
+            (Some(b), Some(c)) => Ok(b == c),
+            _ => Ok(false),
+        }
+    }
+
+    async fn get_branch_head_sha(&self, branch: &str) -> Result<String> {
+        let mut refs_url = self.base_url.join("refs")?;
+        refs_url
+            .query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("filter", &format!("heads/{branch}"));
+        let response = self.client.get(refs_url).send().await?;
+        let result = response.error_for_status()?;
+        let refs: AzureList<AzureRef> = result.json().await?;
+        let want = format!("refs/heads/{branch}");
+        refs.value
+            .into_iter()
+            .find(|r| r.name == want)
+            .map(|r| r.object_id)
+            .ok_or_else(|| {
+                ReleasaurusError::forge(format!("branch not found: {branch}"))
+            })
+    }
+
+    async fn build_push_changes(
+        &self,
+        branch: &str,
+        changes: &[crate::forge::request::FileChange],
+    ) -> Result<Vec<Change>> {
+        let mut out = vec![];
+        for change in changes.iter() {
+            let existing = self
+                .get_file_content(GetFileContentRequest {
+                    branch: Some(branch.to_string()),
+                    path: change.path.clone(),
+                })
+                .await?;
+
+            let mut content = change.content.clone();
+            let (change_type, existed) = match existing.as_deref() {
+                Some(prev) => {
+                    if matches!(change.update_type, FileUpdateType::Prepend) {
+                        content = format!("{content}{prev}");
+                    }
+                    ("edit", Some(prev.to_string()))
+                }
+                None => ("add", None),
+            };
+
+            if let Some(prev) = existed.as_ref()
+                && content == *prev
+            {
+                warn!(
+                    "skipping file update content matches existing state: {}",
+                    change.path
+                );
+                continue;
+            }
+
+            out.push(Change {
+                change_type: change_type.to_string(),
+                item: ChangeItem {
+                    path: normalize_path(&change.path),
+                },
+                new_content: Some(NewContent {
+                    content,
+                    content_type: "rawtext".into(),
+                }),
+            });
+        }
+        Ok(out)
+    }
+
+    async fn push_to_branch(
+        &self,
+        branch: &str,
+        old_sha: &str,
+        message: &str,
+        changes: Vec<Change>,
+    ) -> Result<String> {
+        let url = self.endpoint("pushes")?;
+        let body = Push {
+            ref_updates: vec![RefUpdate {
+                name: format!("refs/heads/{branch}"),
+                old_object_id: old_sha.to_string(),
+                new_object_id: None,
+            }],
+            commits: vec![PushCommit {
+                comment: message.to_string(),
+                changes,
+            }],
+        };
+        let response = self.client.post(url).json(&body).send().await?;
+        let result = response.error_for_status()?;
+        let push: PushResponse = result.json().await?;
+        push.commits
+            .into_iter()
+            .next()
+            .map(|c| c.commit_id)
+            .ok_or_else(|| {
+                ReleasaurusError::forge("push returned no commits".to_string())
+            })
+    }
+
+    /// Fetches a single PR by ID, returning its full description (the list
+    /// endpoint truncates `description` at ~400 chars).
+    async fn get_pr_by_id(&self, pr_id: u64) -> Result<AzurePullRequest> {
+        let url = self.endpoint(&format!("pullrequests/{pr_id}"))?;
+        let response = self.client.get(url).send().await?;
+        let pr: AzurePullRequest = response.error_for_status()?.json().await?;
+        Ok(pr)
+    }
+
+    async fn find_pr_by_branch(
+        &self,
+        status: &str,
+        head_branch: &str,
+    ) -> Result<Vec<AzurePullRequest>> {
+        let mut found = vec![];
+        let mut skip: u64 = 0;
+        let page_size = u64::from(DEFAULT_PAGE_SIZE);
+        loop {
+            let mut url = self.base_url.join("pullrequests")?;
+            url.query_pairs_mut()
+                .append_pair("api-version", API_VERSION)
+                .append_pair("searchCriteria.status", status)
+                .append_pair(
+                    "searchCriteria.sourceRefName",
+                    &format!("refs/heads/{head_branch}"),
+                )
+                .append_pair("$top", &page_size.to_string())
+                .append_pair("$skip", &skip.to_string());
+            let response = self.client.get(url).send().await?;
+            let result = response.error_for_status()?;
+            let list: AzureList<AzurePullRequest> = result.json().await?;
+            let count = list.value.len() as u64;
+            found.extend(list.value);
+            if count < page_size {
+                break;
+            }
+            skip += page_size;
+        }
+        Ok(found)
+    }
+
+    async fn pr_has_label(&self, pr_number: u64, label: &str) -> Result<bool> {
+        let labels = self.get_pr_labels(pr_number).await?;
+        Ok(labels.iter().any(|l| l.name == label && l.active))
+    }
+
+    async fn get_pr_labels(
+        &self,
+        pr_number: u64,
+    ) -> Result<Vec<crate::forge::azure_devops::types::AzureLabel>> {
+        let mut url = self
+            .base_url
+            .join(&format!("pullrequests/{pr_number}/labels"))?;
+        url.query_pairs_mut()
+            .append_pair("api-version", LABELS_API_VERSION);
+        let response = self.client.get(url).send().await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(vec![]);
+        }
+        let result = response.error_for_status()?;
+        let list: AzureList<crate::forge::azure_devops::types::AzureLabel> =
+            result.json().await?;
+        Ok(list.value)
+    }
+
+    async fn delete_pr_label(
+        &self,
+        pr_number: u64,
+        label_id_or_name: &str,
+    ) -> Result<()> {
+        let mut url = self.base_url.join(&format!(
+            "pullrequests/{pr_number}/labels/{label_id_or_name}"
+        ))?;
+        url.query_pairs_mut()
+            .append_pair("api-version", LABELS_API_VERSION);
+        let response = self.client.delete(url).send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
+
+    async fn add_pr_label(&self, pr_number: u64, name: &str) -> Result<()> {
+        let mut url = self
+            .base_url
+            .join(&format!("pullrequests/{pr_number}/labels"))?;
+        url.query_pairs_mut()
+            .append_pair("api-version", LABELS_API_VERSION);
+        let body = CreateLabel {
+            name: name.to_string(),
+        };
+        let response = self.client.post(url).json(&body).send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
+
+    async fn get_commit_timestamp(&self, commit_id: &str) -> Result<i64> {
+        let mut url = self.base_url.join(&format!("commits/{commit_id}"))?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION);
+        let response = self.client.get(url).send().await?;
+        let commit: AzureCommit = response.error_for_status()?.json().await?;
+        Ok(DateTime::parse_from_rfc3339(&commit.author.date)
+            .map(|t| t.timestamp())
+            .unwrap_or(0))
+    }
+
+    async fn get_commit_files(&self, commit_id: &str) -> Result<Vec<String>> {
+        let mut url = self
+            .base_url
+            .join(&format!("commits/{commit_id}/changes"))?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION);
+        let response = self.client.get(url).send().await?;
+        if !response.status().is_success() {
+            return Ok(vec![]);
+        }
+        let changes: AzureCommitChanges = response.json().await?;
+        Ok(changes
+            .changes
+            .into_iter()
+            .filter_map(|c| {
+                let p = c.item.path;
+                if p.is_empty() {
+                    None
+                } else {
+                    Some(p.trim_start_matches('/').to_string())
+                }
+            })
+            .collect())
+    }
+}
+
+fn strip_refs_heads(name: &str) -> &str {
+    name.strip_prefix("refs/heads/").unwrap_or(name)
+}
+
+fn strip_refs_tags(name: &str) -> &str {
+    name.strip_prefix("refs/tags/").unwrap_or(name)
+}
+
+fn normalize_path(path: &str) -> String {
+    let trimmed = path.strip_prefix("./").unwrap_or(path);
+    if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+#[async_trait]
+impl Forge for AzureDevops {
+    fn repo_name(&self) -> String {
+        self.url.name.clone()
+    }
+
+    fn release_link_base_url(&self) -> Url {
+        self.release_link_base_url.clone()
+    }
+
+    fn compare_link_base_url(&self) -> Url {
+        self.compare_link_base_url.clone()
+    }
+
+    fn default_branch(&self) -> String {
+        self.default_branch.clone()
+    }
+
+    fn set_commit_search_depth(&mut self, depth: usize) {
+        self.commit_search_depth = if depth == 0 { usize::MAX } else { depth }
+    }
+
+    fn set_tag_search_depth(&mut self, depth: usize) {
+        self.tag_search_depth = if depth == 0 { usize::MAX } else { depth }
+    }
+
+    async fn get_file_content(
+        &self,
+        req: GetFileContentRequest,
+    ) -> Result<Option<String>> {
+        let mut url = self.base_url.join("items")?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("path", &normalize_path(&req.path))
+            .append_pair("includeContent", "true")
+            .append_pair("$format", "text");
+        if let Some(branch) = req.branch.as_ref() {
+            url.query_pairs_mut()
+                .append_pair("versionDescriptor.version", branch)
+                .append_pair("versionDescriptor.versionType", "branch");
+        }
+        let response = self
+            .client
+            .get(url)
+            .header("Accept", "text/plain")
+            .send()
+            .await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let result = response.error_for_status()?;
+        let content = result.text().await?;
+        Ok(Some(content))
+    }
+
+    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
+        if let Some(content) = self
+            .get_file_content(GetFileContentRequest {
+                branch,
+                path: DEFAULT_CONFIG_FILE.into(),
+            })
+            .await?
+        {
+            let config: Config = toml::from_str(&content)?;
+            Ok(config)
+        } else {
+            Ok(Config::default())
+        }
+    }
+
+    async fn get_release_by_tag(
+        &self,
+        tag: &str,
+    ) -> Result<ReleaseByTagResponse> {
+        // Azure DevOps has no native release object. Resolve the tag's
+        // commit SHA via the refs endpoint and return empty notes —
+        // callers that need notes should source them from the
+        // release-PR body.
+        let mut url = self.base_url.join("refs")?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("filter", &format!("tags/{tag}"));
+        let response = self.client.get(url).send().await?;
+        let result = response.error_for_status()?;
+        let refs: AzureList<AzureRef> = result.json().await?;
+        let want = format!("refs/tags/{tag}");
+        let r = refs.value.into_iter().find(|r| r.name == want).ok_or_else(
+            || ReleasaurusError::forge(format!("tag not found: {tag}")),
+        )?;
+        Ok(ReleaseByTagResponse {
+            tag: tag.to_string(),
+            sha: r.object_id,
+            notes: String::new(),
+        })
+    }
+
+    async fn get_latest_tags_for_prefix(
+        &self,
+        prefix: &str,
+        branch: &str,
+    ) -> Result<Vec<Tag>> {
+        let re = Regex::new(format!(r"^{prefix}").as_str())?;
+        let mut url = self.base_url.join("refs")?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("filter", "tags/");
+        let response = self.client.get(url).send().await?;
+        let result = response.error_for_status()?;
+        let refs: AzureList<AzureRef> = result.json().await?;
+        let mut tags = vec![];
+        for (count, r) in refs.value.into_iter().enumerate() {
+            if count >= self.tag_search_depth {
+                break;
+            }
+            let name = strip_refs_tags(&r.name).to_string();
+            if !re.is_match(&name) {
+                continue;
+            }
+            let stripped = re.replace_all(&name, "").to_string();
+            let Ok(sver) = semver::Version::parse(&stripped) else {
+                continue;
+            };
+            // Only return tags reachable from the target branch.
+            if !self.is_ancestor_of_branch(&r.object_id, branch).await? {
+                continue;
+            }
+            let timestamp = self.get_commit_timestamp(&r.object_id).await.ok();
+            tags.push(Tag {
+                name,
+                semver: sver,
+                sha: r.object_id,
+                timestamp,
+            });
+        }
+        Ok(tags)
+    }
+
+    async fn get_commits(
+        &self,
+        branch: Option<String>,
+        sha: Option<String>,
+    ) -> Result<Vec<ForgeCommit>> {
+        let mut skip: u64 = 0;
+        let page_size = cmp::min(
+            u64::from(DEFAULT_PAGE_SIZE),
+            self.commit_search_depth as u64,
+        );
+        let mut commits: Vec<ForgeCommit> = vec![];
+        let mut count = 0usize;
+
+        loop {
+            let mut url = self.base_url.join("commits")?;
+            url.query_pairs_mut()
+                .append_pair("api-version", API_VERSION)
+                .append_pair("$top", &page_size.to_string())
+                .append_pair("$skip", &skip.to_string())
+                .append_pair("searchCriteria.includeWorkItems", "false");
+            // Azure DevOps commits API without a branch filter returns commits
+            // from all refs, not just the default branch. Always filter.
+            let effective_branch =
+                branch.as_deref().unwrap_or(&self.default_branch);
+            url.query_pairs_mut()
+                .append_pair(
+                    "searchCriteria.itemVersion.version",
+                    effective_branch,
+                )
+                .append_pair(
+                    "searchCriteria.itemVersion.versionType",
+                    "branch",
+                );
+
+            let response = self.client.get(url).send().await?;
+            let result = response.error_for_status()?;
+            let list: AzureList<AzureCommit> = result.json().await?;
+            let returned = list.value.len() as u64;
+
+            for c in list.value.into_iter() {
+                if sha.is_none() && count >= self.commit_search_depth {
+                    return Ok(commits);
+                }
+                if let Some(target) = sha.as_ref()
+                    && *target == c.commit_id
+                {
+                    return Ok(commits);
+                }
+
+                // Fetch file list for this commit (best effort).
+                let files = self
+                    .get_commit_files(&c.commit_id)
+                    .await
+                    .unwrap_or_default();
+
+                let timestamp = DateTime::parse_from_rfc3339(&c.author.date)
+                    .map(|t| t.timestamp())
+                    .unwrap_or(0);
+
+                commits.push(ForgeCommit {
+                    author_email: c.author.email,
+                    author_name: c.author.name,
+                    id: c.commit_id.clone(),
+                    short_id: c.commit_id.chars().take(8).collect(),
+                    link: c.remote_url,
+                    merge_commit: c.parents.len() > 1,
+                    message: AZURE_MERGED_PR_RE
+                        .replace(c.comment.trim_end(), "")
+                        .into_owned(),
+                    timestamp,
+                    files,
+                });
+                count += 1;
+            }
+
+            if returned < page_size {
+                break;
+            }
+            skip += page_size;
+        }
+
+        Ok(commits)
+    }
+
+    async fn create_release_branch(
+        &self,
+        req: CreateReleaseBranchRequest,
+    ) -> Result<Commit> {
+        let base_sha = self.get_branch_head_sha(&req.base_branch).await?;
+        let existing_sha =
+            self.get_branch_head_sha(&req.release_branch).await.ok();
+        let old_object_id =
+            existing_sha.as_deref().unwrap_or(ZERO_SHA).to_string();
+        let url = self.endpoint("refs")?;
+        let body = vec![RefUpdate {
+            name: format!("refs/heads/{}", req.release_branch),
+            old_object_id,
+            new_object_id: Some(base_sha.clone()),
+        }];
+        self.client
+            .post(url)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?;
+        let changes = self
+            .build_push_changes(&req.base_branch, &req.file_changes)
+            .await?;
+        if changes.is_empty() {
+            return Ok(Commit { sha: base_sha });
+        }
+        let new_sha = self
+            .push_to_branch(
+                &req.release_branch,
+                &base_sha,
+                &req.message,
+                changes,
+            )
+            .await?;
+        Ok(Commit { sha: new_sha })
+    }
+
+    async fn create_commit(&self, req: CreateCommitRequest) -> Result<Commit> {
+        let head_sha = self.get_branch_head_sha(&req.target_branch).await?;
+        let changes = self
+            .build_push_changes(&req.target_branch, &req.file_changes)
+            .await?;
+        if changes.is_empty() {
+            warn!(
+                "commit would result in no changes: target_branch: {}, message: {}",
+                req.target_branch, req.message,
+            );
+            return Ok(Commit { sha: "None".into() });
+        }
+        let new_sha = self
+            .push_to_branch(
+                &req.target_branch,
+                &head_sha,
+                &req.message,
+                changes,
+            )
+            .await?;
+        Ok(Commit { sha: new_sha })
+    }
+
+    async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()> {
+        let url = self.endpoint("refs")?;
+        let body = vec![RefUpdate {
+            name: format!("refs/tags/{tag_name}"),
+            old_object_id: ZERO_SHA.to_string(),
+            new_object_id: Some(sha.to_string()),
+        }];
+        let response = self.client.post(url).json(&body).send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
+
+    async fn get_open_release_pr(
+        &self,
+        req: GetPrRequest,
+    ) -> Result<Option<PullRequest>> {
+        let candidates =
+            self.find_pr_by_branch("active", &req.head_branch).await?;
+        let target = format!("refs/heads/{}", req.base_branch);
+        let mut matches = vec![];
+        for pr in candidates.into_iter() {
+            if pr.target_ref_name != target {
+                continue;
+            }
+            // Match by either current or legacy pending label.
+            let pending =
+                self.pr_has_label(pr.pull_request_id, PENDING_LABEL).await?
+                    || self
+                        .pr_has_label(pr.pull_request_id, LEGACY_PENDING_LABEL)
+                        .await?;
+            if !pending {
+                continue;
+            }
+            matches.push(pr);
+        }
+        if matches.len() > 1 {
+            return Err(ReleasaurusError::forge(format!(
+                "Found more than one open release PR with pending label for branch {}",
+                req.head_branch
+            )));
+        }
+        let Some(pr) = matches.pop() else {
+            return Ok(None);
+        };
+        let full = self.get_pr_by_id(pr.pull_request_id).await?;
+        Ok(Some(PullRequest {
+            number: pr.pull_request_id,
+            sha: pr
+                .last_merge_source_commit
+                .map(|c| c.commit_id)
+                .unwrap_or_default(),
+            body: full.description.unwrap_or_default(),
+        }))
+    }
+
+    async fn get_merged_release_pr(
+        &self,
+        req: GetPrRequest,
+    ) -> Result<Option<PullRequest>> {
+        let candidates = self
+            .find_pr_by_branch("completed", &req.head_branch)
+            .await?;
+        let target = format!("refs/heads/{}", req.base_branch);
+        let mut matches = vec![];
+        for pr in candidates.into_iter() {
+            if pr.target_ref_name != target {
+                continue;
+            }
+            let pending =
+                self.pr_has_label(pr.pull_request_id, PENDING_LABEL).await?
+                    || self
+                        .pr_has_label(pr.pull_request_id, LEGACY_PENDING_LABEL)
+                        .await?;
+            if !pending {
+                continue;
+            }
+            matches.push(pr);
+        }
+        if matches.len() > 1 {
+            return Err(ReleasaurusError::forge(format!(
+                "Found more than one closed release PR with pending label for branch {}. \
+              You must remove the {PENDING_LABEL} label from all closed release PRs except for the most recent.",
+                req.head_branch
+            )));
+        }
+        let Some(pr) = matches.pop() else {
+            return Ok(None);
+        };
+        let sha = pr
+            .last_merge_commit
+            .as_ref()
+            .map(|c| c.commit_id.clone())
+            .ok_or_else(|| {
+                ReleasaurusError::forge(format!(
+                    "no merge commit found for pr {}",
+                    pr.pull_request_id
+                ))
+            })?;
+        let full = self.get_pr_by_id(pr.pull_request_id).await?;
+        Ok(Some(PullRequest {
+            number: pr.pull_request_id,
+            sha,
+            body: full.description.unwrap_or_default(),
+        }))
+    }
+
+    async fn create_pr(&self, req: CreatePrRequest) -> Result<PullRequest> {
+        let body = CreatePullRequest {
+            source_ref_name: format!("refs/heads/{}", req.head_branch),
+            target_ref_name: format!("refs/heads/{}", req.base_branch),
+            title: req.title,
+            description: req.body,
+        };
+        let url = self.endpoint("pullrequests")?;
+        let response = self.client.post(url).json(&body).send().await?;
+        let result = response.error_for_status()?;
+        let pr: AzurePullRequest = result.json().await?;
+        Ok(PullRequest {
+            number: pr.pull_request_id,
+            sha: pr
+                .last_merge_source_commit
+                .map(|c| c.commit_id)
+                .unwrap_or_default(),
+            body: pr.description.unwrap_or_default(),
+        })
+    }
+
+    async fn update_pr(&self, req: UpdatePrRequest) -> Result<()> {
+        let body = UpdatePullRequest {
+            title: req.title,
+            description: req.body,
+        };
+        let url = self.endpoint(&format!("pullrequests/{}", req.pr_number))?;
+        let response = self.client.patch(url).json(&body).send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
+
+    async fn replace_pr_labels(&self, req: PrLabelsRequest) -> Result<()> {
+        let existing = self.get_pr_labels(req.pr_number).await?;
+        let desired: std::collections::HashSet<&str> =
+            req.labels.iter().map(|s| s.as_str()).collect();
+
+        for label in existing.iter() {
+            if !desired.contains(label.name.as_str()) {
+                self.delete_pr_label(req.pr_number, &label.id).await?;
+            }
+        }
+
+        let existing_names: std::collections::HashSet<&str> =
+            existing.iter().map(|l| l.name.as_str()).collect();
+
+        for name in req.labels.iter() {
+            if !existing_names.contains(name.as_str()) {
+                self.add_pr_label(req.pr_number, name).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn create_release(
+        &self,
+        tag: &str,
+        _sha: &str,
+        _notes: &str,
+    ) -> Result<()> {
+        info!(
+            "azure devops has no native release object — skipping release publish for tag {tag}; \
+             changelog commit and tag have already been pushed"
+        );
+        Ok(())
+    }
+
+    fn encode_pr_metadata(&self, json: &str) -> PrMetadataBlock {
+        let b64 = BASE64_STANDARD.encode(json.as_bytes());
+        PrMetadataBlock {
+            inline_content: String::new(),
+            div_attribute: format!(r#"data-meta="{b64}""#),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_adds_leading_slash() {
+        assert_eq!(normalize_path("Cargo.toml"), "/Cargo.toml");
+        assert_eq!(normalize_path("/Cargo.toml"), "/Cargo.toml");
+        assert_eq!(normalize_path("./Cargo.toml"), "/Cargo.toml");
+        assert_eq!(
+            normalize_path("crates/foo/Cargo.toml"),
+            "/crates/foo/Cargo.toml"
+        );
+    }
+
+    #[test]
+    fn strip_refs_heads_removes_prefix() {
+        assert_eq!(strip_refs_heads("refs/heads/main"), "main");
+        assert_eq!(strip_refs_heads("main"), "main");
+    }
+
+    #[test]
+    fn strip_refs_tags_removes_prefix() {
+        assert_eq!(strip_refs_tags("refs/tags/v1.0.0"), "v1.0.0");
+        assert_eq!(strip_refs_tags("v1.0.0"), "v1.0.0");
+    }
+}

--- a/crates/core/src/forge/azure_devops/types.rs
+++ b/crates/core/src/forge/azure_devops/types.rs
@@ -1,0 +1,235 @@
+use serde::{Deserialize, Serialize};
+
+/// Top-level response wrapper used by most Azure DevOps list endpoints.
+#[derive(Debug, Deserialize)]
+pub struct AzureList<T> {
+    /// Deserialized items returned by the endpoint.
+    #[serde(default = "Vec::new")]
+    pub value: Vec<T>,
+}
+
+/// Metadata for an Azure DevOps Git repository.
+#[derive(Debug, Deserialize)]
+pub struct AzureRepo {
+    /// Fully-qualified ref name of the repository's default branch (e.g. `refs/heads/main`).
+    #[serde(rename = "defaultBranch")]
+    pub default_branch: Option<String>,
+}
+
+/// A Git ref (branch or tag) as returned by the Azure DevOps Refs API.
+#[derive(Debug, Deserialize)]
+pub struct AzureRef {
+    /// Fully-qualified ref name (e.g. `refs/heads/main`).
+    pub name: String,
+    /// SHA-1 commit ID that this ref currently points to.
+    #[serde(rename = "objectId")]
+    pub object_id: String,
+}
+
+/// Describes a ref update to include in a push or Refs API request.
+#[derive(Debug, Serialize)]
+pub struct RefUpdate {
+    /// Fully-qualified ref name to update (e.g. `refs/heads/main`).
+    pub name: String,
+    /// Current commit ID the ref points to; used for optimistic concurrency.
+    #[serde(rename = "oldObjectId")]
+    pub old_object_id: String,
+    /// Required for the Refs API (create/update/delete refs).
+    /// Omit for the Push API — Azure DevOps computes it from the commits.
+    #[serde(rename = "newObjectId", skip_serializing_if = "Option::is_none")]
+    pub new_object_id: Option<String>,
+}
+
+/// Author or committer information attached to an Azure DevOps commit.
+#[derive(Debug, Default, Deserialize)]
+pub struct AzureUser {
+    /// Display name of the user.
+    #[serde(default)]
+    pub name: String,
+    /// Email address of the user.
+    #[serde(default)]
+    pub email: String,
+    /// ISO-8601 timestamp for the author or committer.
+    #[serde(default)]
+    pub date: String,
+}
+
+/// A Git commit as returned by the Azure DevOps Git Commits API.
+#[derive(Debug, Deserialize)]
+pub struct AzureCommit {
+    /// SHA-1 identifier of the commit.
+    #[serde(rename = "commitId")]
+    pub commit_id: String,
+    /// Commit author metadata.
+    #[serde(default)]
+    pub author: AzureUser,
+    /// First line of the commit message.
+    #[serde(default)]
+    pub comment: String,
+    /// SHA-1 identifiers of parent commits.
+    #[serde(default)]
+    pub parents: Vec<String>,
+    /// Web URL to view the commit in Azure DevOps.
+    #[serde(rename = "remoteUrl", default)]
+    pub remote_url: String,
+}
+
+/// Path metadata for a single file affected by a commit change.
+#[derive(Debug, Default, Deserialize)]
+pub struct AzureChangeItem {
+    /// Repository-relative path of the file (e.g. `/src/main.rs`).
+    #[serde(default)]
+    pub path: String,
+}
+
+/// A single file change entry within an [`AzureCommitChanges`] response.
+#[derive(Debug, Deserialize)]
+pub struct AzureChange {
+    /// File path metadata for this change.
+    #[serde(default)]
+    pub item: AzureChangeItem,
+}
+
+/// Collection of file changes associated with a single commit.
+#[derive(Debug, Deserialize)]
+pub struct AzureCommitChanges {
+    /// Individual file changes introduced by the commit.
+    #[serde(default)]
+    pub changes: Vec<AzureChange>,
+}
+
+/// File path descriptor used in push request bodies.
+#[derive(Debug, Serialize)]
+pub struct ChangeItem {
+    /// Repository-relative path of the file (e.g. `/src/main.rs`).
+    pub path: String,
+}
+
+/// New file content to be written as part of a push change.
+#[derive(Debug, Serialize)]
+pub struct NewContent {
+    /// Raw file content (base64-encoded or plain-text depending on `content_type`).
+    pub content: String,
+    /// Encoding of `content`; typically `"rawtext"` or `"base64Encoded"`.
+    #[serde(rename = "contentType")]
+    pub content_type: String,
+}
+
+/// A single file operation to include in a push commit.
+#[derive(Debug, Serialize)]
+pub struct Change {
+    /// Type of change: `"add"`, `"edit"`, or `"delete"`.
+    #[serde(rename = "changeType")]
+    pub change_type: String,
+    /// Target file path for this change.
+    pub item: ChangeItem,
+    /// New file content; omitted for `"delete"` changes.
+    #[serde(rename = "newContent", skip_serializing_if = "Option::is_none")]
+    pub new_content: Option<NewContent>,
+}
+
+/// A commit to be created as part of a push operation.
+#[derive(Debug, Serialize)]
+pub struct PushCommit {
+    /// Commit message.
+    pub comment: String,
+    /// File changes included in this commit.
+    pub changes: Vec<Change>,
+}
+
+/// Request body for the Azure DevOps Git Push API.
+#[derive(Debug, Serialize)]
+pub struct Push {
+    /// Refs to advance as a result of the push.
+    #[serde(rename = "refUpdates")]
+    pub ref_updates: Vec<RefUpdate>,
+    /// Commits to create in the push, in order.
+    pub commits: Vec<PushCommit>,
+}
+
+/// Abbreviated commit descriptor returned inside a push response.
+#[derive(Debug, Deserialize)]
+pub struct PushResponseCommit {
+    /// SHA-1 identifier of the newly created commit.
+    #[serde(rename = "commitId")]
+    pub commit_id: String,
+}
+
+/// Response body returned by the Azure DevOps Git Push API.
+#[derive(Debug, Deserialize)]
+pub struct PushResponse {
+    /// Commits created by the push.
+    #[serde(default)]
+    pub commits: Vec<PushResponseCommit>,
+}
+
+/// Request body for creating a new pull request.
+#[derive(Debug, Serialize)]
+pub struct CreatePullRequest {
+    /// Fully-qualified source ref name (e.g. `refs/heads/feature-branch`).
+    #[serde(rename = "sourceRefName")]
+    pub source_ref_name: String,
+    /// Fully-qualified target ref name (e.g. `refs/heads/main`).
+    #[serde(rename = "targetRefName")]
+    pub target_ref_name: String,
+    /// Pull request title.
+    pub title: String,
+    /// Pull request description (supports Markdown).
+    pub description: String,
+}
+
+/// Request body for updating an existing pull request's title or description.
+#[derive(Debug, Serialize)]
+pub struct UpdatePullRequest {
+    /// New pull request title.
+    pub title: String,
+    /// New pull request description (supports Markdown).
+    pub description: String,
+}
+
+/// A pull request as returned by the Azure DevOps Pull Requests API.
+#[derive(Debug, Deserialize)]
+pub struct AzurePullRequest {
+    /// Numeric identifier of the pull request within the repository.
+    #[serde(rename = "pullRequestId")]
+    pub pull_request_id: u64,
+    /// Fully-qualified target ref name (e.g. `refs/heads/main`).
+    #[serde(rename = "targetRefName")]
+    pub target_ref_name: String,
+    /// Tip commit of the source branch at the time of the last merge attempt.
+    #[serde(rename = "lastMergeSourceCommit", default)]
+    pub last_merge_source_commit: Option<AzureCommitRef>,
+    /// Merge commit produced by the last merge attempt.
+    #[serde(rename = "lastMergeCommit", default)]
+    pub last_merge_commit: Option<AzureCommitRef>,
+    /// Pull request description (supports Markdown).
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+/// A lightweight commit reference (ID only) embedded in pull request responses.
+#[derive(Debug, Deserialize, Clone)]
+pub struct AzureCommitRef {
+    /// SHA-1 identifier of the referenced commit.
+    #[serde(rename = "commitId")]
+    pub commit_id: String,
+}
+
+/// A label attached to an Azure DevOps pull request.
+#[derive(Debug, Deserialize, Clone)]
+pub struct AzureLabel {
+    /// Unique identifier of the label.
+    pub id: String,
+    /// Display name of the label.
+    pub name: String,
+    /// Whether the label is currently active on the pull request.
+    #[serde(default)]
+    pub active: bool,
+}
+
+/// Request body for adding a label to a pull request.
+#[derive(Debug, Serialize)]
+pub struct CreateLabel {
+    /// Name of the label to create or attach.
+    pub name: String,
+}

--- a/crates/core/src/forge/azure_devops/url_parse.rs
+++ b/crates/core/src/forge/azure_devops/url_parse.rs
@@ -1,0 +1,197 @@
+//! URL parsing for Azure DevOps repository URLs.
+use secrecy::SecretString;
+use url::Url;
+
+use crate::{
+    forge::config::{RepoUrl, Scheme},
+    result::{ReleasaurusError, Result},
+};
+
+/// Parse an Azure DevOps Git URL of the form
+/// `https://dev.azure.com/{org}/{project}/_git/{repo}` into a
+/// [`RepoUrl`]. The `owner` field carries `"{org}/{project}"`.
+/// Hosts other than `dev.azure.com` are rejected; on-prem Azure
+/// DevOps Server is out of scope.
+pub fn azure_git_url_to_repo_url(input: &str) -> Result<RepoUrl> {
+    let url = Url::parse(input).map_err(|e| {
+        ReleasaurusError::InvalidArgs(format!(
+            "failed to parse azure devops repo url: {e}"
+        ))
+    })?;
+
+    let scheme = match url.scheme() {
+        "https" => Scheme::Https,
+        "http" => Scheme::Http,
+        s => {
+            return Err(ReleasaurusError::InvalidArgs(format!(
+                "azure devops repo url must start with http:// or https://, got: {s}"
+            )));
+        }
+    };
+
+    // Prefer the password component as the PAT; fall back to the
+    // username for `https://{PAT}@dev.azure.com/...` style URLs.
+    let token = match url.password() {
+        Some(pat) if !pat.is_empty() => {
+            Some(SecretString::from(pat.to_string()))
+        }
+        _ => {
+            let user = url.username();
+            if user.is_empty() {
+                None
+            } else {
+                Some(SecretString::from(user.to_string()))
+            }
+        }
+    };
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| {
+            ReleasaurusError::InvalidArgs(
+                "azure devops repo url is missing a host".into(),
+            )
+        })?
+        .to_string();
+
+    if host != "dev.azure.com" {
+        return Err(ReleasaurusError::InvalidArgs(format!(
+            "only dev.azure.com is supported for azure devops urls \
+             (on-prem Azure DevOps Server is not supported), got: {host}"
+        )));
+    }
+
+    let segments: Vec<&str> =
+        url.path_segments().map(|s| s.collect()).unwrap_or_default();
+
+    let git_idx =
+        segments.iter().position(|s| *s == "_git").ok_or_else(|| {
+            ReleasaurusError::InvalidArgs(
+                "azure devops repo url is missing the _git segment; \
+                 expected https://dev.azure.com/{org}/{project}/_git/{repo}"
+                    .into(),
+            )
+        })?;
+
+    if git_idx < 2 || git_idx + 1 >= segments.len() {
+        return Err(ReleasaurusError::InvalidArgs(
+            "azure devops repo url must be of the form \
+             https://dev.azure.com/{org}/{project}/_git/{repo}"
+                .into(),
+        ));
+    }
+
+    let org_project = segments[..git_idx].join("/");
+    let name = segments[git_idx + 1].trim_end_matches(".git").to_string();
+    let path = url.path().trim_end_matches(".git").to_string();
+    let port = url.port();
+
+    Ok(RepoUrl {
+        host,
+        owner: org_project,
+        name,
+        path,
+        port,
+        scheme,
+        token,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    fn parses_basic_form() {
+        let repo = azure_git_url_to_repo_url(
+            "https://dev.azure.com/myorg/myproject/_git/myrepo",
+        )
+        .unwrap();
+        assert_eq!(repo.host, "dev.azure.com");
+        assert_eq!(repo.owner, "myorg/myproject");
+        assert_eq!(repo.name, "myrepo");
+        assert_eq!(repo.path, "/myorg/myproject/_git/myrepo");
+        assert!(repo.token.is_none());
+    }
+
+    #[test]
+    fn parses_nested_project_path() {
+        let repo = azure_git_url_to_repo_url(
+            "https://dev.azure.com/myorg/group/myproject/_git/myrepo",
+        )
+        .unwrap();
+        assert_eq!(repo.owner, "myorg/group/myproject");
+        assert_eq!(repo.name, "myrepo");
+        assert_eq!(repo.path, "/myorg/group/myproject/_git/myrepo");
+    }
+
+    #[test]
+    fn extracts_embedded_pat() {
+        let repo = azure_git_url_to_repo_url(
+            "https://user:mypat@dev.azure.com/myorg/myproject/_git/myrepo",
+        )
+        .unwrap();
+        assert_eq!(repo.token.unwrap().expose_secret(), "mypat");
+    }
+
+    #[test]
+    fn extracts_pat_as_username() {
+        let repo = azure_git_url_to_repo_url(
+            "https://mypat@dev.azure.com/myorg/myproject/_git/myrepo",
+        )
+        .unwrap();
+        assert_eq!(repo.token.unwrap().expose_secret(), "mypat");
+    }
+
+    #[test]
+    fn rejects_non_dev_azure_host() {
+        let result = azure_git_url_to_repo_url(
+            "https://myorg.visualstudio.com/myproject/_git/myrepo",
+        );
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ReleasaurusError::InvalidArgs(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_missing_git_segment() {
+        let result = azure_git_url_to_repo_url(
+            "https://dev.azure.com/myorg/myproject/myrepo",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_scheme() {
+        let result = azure_git_url_to_repo_url(
+            "ssh://git@dev.azure.com/myorg/myproject/_git/myrepo",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn strips_dot_git_suffix() {
+        let repo = azure_git_url_to_repo_url(
+            "https://dev.azure.com/myorg/myproject/_git/myrepo.git",
+        )
+        .unwrap();
+        assert_eq!(repo.name, "myrepo");
+        assert_eq!(repo.path, "/myorg/myproject/_git/myrepo");
+    }
+
+    #[test]
+    fn path_has_leading_slash() {
+        let repo = azure_git_url_to_repo_url(
+            "https://dev.azure.com/myorg/myproject/_git/myrepo",
+        )
+        .unwrap();
+        assert!(
+            repo.path.starts_with('/'),
+            "azure path should start with '/' for consistency with other RepoUrl instances, got: {}",
+            repo.path
+        );
+    }
+}

--- a/crates/core/src/forge/config.rs
+++ b/crates/core/src/forge/config.rs
@@ -104,6 +104,8 @@ pub enum TokenVar {
     Gitea,
     #[strum(to_string = "FORGEJO_TOKEN")]
     Forgejo,
+    #[strum(to_string = "AZURE_DEVOPS_TOKEN")]
+    AzureDevops,
 }
 
 /// Resolve authentication token from multiple sources in priority order:

--- a/crates/core/src/forge/manager.rs
+++ b/crates/core/src/forge/manager.rs
@@ -9,8 +9,8 @@ use crate::{
         request::{
             Commit, CreateCommitRequest, CreatePrRequest,
             CreateReleaseBranchRequest, ForgeCommit, GetFileContentRequest,
-            GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
-            Tag, UpdatePrRequest,
+            GetPrRequest, PrLabelsRequest, PrMetadataBlock, PullRequest,
+            ReleaseByTagResponse, Tag, UpdatePrRequest,
         },
         traits::{FileLoader, Forge},
     },
@@ -386,6 +386,10 @@ impl ForgeManager {
         }
 
         result
+    }
+
+    pub fn encode_pr_metadata(&self, json: &str) -> PrMetadataBlock {
+        self.forge.encode_pr_metadata(json)
     }
 }
 

--- a/crates/core/src/forge/request.rs
+++ b/crates/core/src/forge/request.rs
@@ -2,6 +2,18 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize, ser::SerializeStruct};
 use std::{fmt::Display, hash::Hash};
 
+/// Forge-specific encoding of PR metadata: content to embed inside the div
+/// and an optional extra HTML attribute on the div tag.
+#[derive(Debug)]
+pub struct PrMetadataBlock {
+    /// Content to embed inside the metadata div (e.g. an HTML comment).
+    /// Empty when the forge strips HTML comments.
+    pub inline_content: String,
+    /// Extra HTML attribute to add to the div tag (e.g. `data-meta="..."`).
+    /// Empty for forges that preserve inline HTML.
+    pub div_attribute: String,
+}
+
 /// Release pull request information with PR number, sha, and body
 #[allow(unused)]
 #[derive(Debug)]

--- a/crates/core/src/forge/tests.rs
+++ b/crates/core/src/forge/tests.rs
@@ -1,3 +1,4 @@
+mod azure_devops;
 mod common;
 mod forgejo;
 mod gitea;

--- a/crates/core/src/forge/tests/azure_devops.rs
+++ b/crates/core/src/forge/tests/azure_devops.rs
@@ -1,0 +1,42 @@
+use secrecy::SecretString;
+use std::env;
+
+use crate::forge::{
+    azure_devops::{AzureDevops, url_parse::azure_git_url_to_repo_url},
+    manager::{ForgeManager, ForgeOptions},
+    tests::common::{
+        azure_devops::AzureDevopsForgeTestHelper, run::run_forge_test,
+    },
+};
+
+#[tokio::test]
+#[test_log::test]
+async fn test_azure_devops_forge() {
+    let repo = azure_git_url_to_repo_url(
+        &env::var("AZURE_DEVOPS_TEST_REPO")
+            .expect("AZURE_DEVOPS_TEST_REPO env var must be set"),
+    )
+    .expect("AZURE_DEVOPS_TEST_REPO must be a valid azure devops url");
+
+    let token_str = env::var("AZURE_DEVOPS_TEST_TOKEN")
+        .expect("AZURE_DEVOPS_TEST_TOKEN env var must be set");
+
+    let token_secret = SecretString::from(token_str.clone());
+
+    let reset_sha = env::var("AZURE_DEVOPS_RESET_SHA")
+        .expect("AZURE_DEVOPS_RESET_SHA env var must be set");
+
+    let helper =
+        AzureDevopsForgeTestHelper::new(&repo, &token_str, &reset_sha).await;
+
+    let azure_forge = AzureDevops::new(repo, Some(token_secret))
+        .await
+        .expect("failed to create AzureDevops forge");
+
+    let manager = ForgeManager::new(
+        Box::new(azure_forge),
+        ForgeOptions { dry_run: false },
+    );
+
+    run_forge_test(&manager, &helper).await;
+}

--- a/crates/core/src/forge/tests/common.rs
+++ b/crates/core/src/forge/tests/common.rs
@@ -1,3 +1,4 @@
+pub mod azure_devops;
 pub mod forgejo;
 pub mod gitea;
 pub mod github;

--- a/crates/core/src/forge/tests/common/azure_devops.rs
+++ b/crates/core/src/forge/tests/common/azure_devops.rs
@@ -1,0 +1,338 @@
+use async_trait::async_trait;
+use base64::{Engine, prelude::BASE64_STANDARD};
+use color_eyre::eyre::Result;
+use reqwest::{
+    Client,
+    header::{HeaderMap, HeaderValue},
+};
+use serde::Deserialize;
+use serde_json::json;
+use url::Url;
+
+use crate::forge::{config::RepoUrl, tests::common::traits::ForgeTestHelper};
+
+const API_VERSION: &str = "7.1";
+const LABELS_API_VERSION: &str = "7.1-preview.1";
+const ZERO_SHA: &str = "0000000000000000000000000000000000000000";
+const PENDING_LABELS: &[&str] =
+    &["releasaurus:pending", "releasaurus::pending"];
+
+#[derive(Debug, Deserialize)]
+struct AzureRepo {
+    #[serde(rename = "defaultBranch")]
+    default_branch: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureRef {
+    name: String,
+    #[serde(rename = "objectId")]
+    object_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureList<T> {
+    #[serde(default = "Vec::new")]
+    value: Vec<T>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzurePr {
+    #[serde(rename = "pullRequestId")]
+    pull_request_id: u64,
+    #[serde(rename = "lastMergeSourceCommit", default)]
+    last_merge_source_commit: Option<AzureCommitRef>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct AzureCommitRef {
+    #[serde(rename = "commitId")]
+    commit_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AzureLabel {
+    id: String,
+    name: String,
+}
+
+pub struct AzureDevopsForgeTestHelper {
+    client: Client,
+    base_url: Url,
+    default_branch: String,
+    reset_sha: String,
+}
+
+impl AzureDevopsForgeTestHelper {
+    pub async fn new(repo: &RepoUrl, token: &str, reset_sha: &str) -> Self {
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
+
+        let basic = BASE64_STANDARD.encode(format!(":{}", token).as_bytes());
+        let mut headers = HeaderMap::new();
+        headers.append(
+            "Authorization",
+            HeaderValue::from_str(&format!("Basic {}", basic)).unwrap(),
+        );
+        headers.append("Accept", HeaderValue::from_static("application/json"));
+
+        let client =
+            Client::builder().default_headers(headers).build().unwrap();
+
+        let link_base_url = match repo.port {
+            Some(port) => {
+                format!("{}://{}:{}", repo.scheme, repo.host, port)
+            }
+            None => format!("{}://{}", repo.scheme, repo.host),
+        };
+
+        let base_url = Url::parse(&format!(
+            "{}/{}/_apis/git/repositories/{}/",
+            link_base_url, repo.owner, repo.name
+        ))
+        .unwrap();
+
+        let mut metadata_url = base_url.clone();
+        metadata_url
+            .query_pairs_mut()
+            .append_pair("api-version", API_VERSION);
+        let response = client.get(metadata_url).send().await.unwrap();
+        let result = response.error_for_status().unwrap();
+        let meta: AzureRepo = result.json().await.unwrap();
+        let default_branch = meta
+            .default_branch
+            .as_deref()
+            .map(|s| s.strip_prefix("refs/heads/").unwrap_or(s).to_string())
+            .expect("repository must have a default branch");
+
+        Self {
+            client,
+            base_url,
+            default_branch,
+            reset_sha: reset_sha.into(),
+        }
+    }
+
+    fn endpoint(&self, path: &str) -> Url {
+        let mut url = self.base_url.join(path).unwrap();
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION);
+        url
+    }
+
+    async fn list_refs(&self, filter: &str) -> Result<Vec<AzureRef>> {
+        let mut url = self.base_url.join("refs")?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("filter", filter);
+        let response = self.client.get(url).send().await?;
+        let result = response.error_for_status()?;
+        let list: AzureList<AzureRef> = result.json().await?;
+        Ok(list.value)
+    }
+
+    async fn delete_refs(&self, refs: &[AzureRef]) -> Result<()> {
+        if refs.is_empty() {
+            return Ok(());
+        }
+        let body: Vec<_> = refs
+            .iter()
+            .map(|r| {
+                json!({
+                    "name": r.name,
+                    "oldObjectId": r.object_id,
+                    "newObjectId": ZERO_SHA,
+                })
+            })
+            .collect();
+        let url = self.endpoint("refs");
+        let response = self.client.post(url).json(&body).send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
+
+    async fn remove_pending_labels_from_completed_prs(&self) -> Result<()> {
+        log::info!("removing pending labels from completed prs");
+        let mut url = self.base_url.join("pullrequests")?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("searchCriteria.status", "completed")
+            .append_pair("$top", "200");
+        let response = self.client.get(url).send().await?;
+        let result = response.error_for_status()?;
+        let list: AzureList<AzurePr> = result.json().await?;
+
+        for pr in list.value.iter() {
+            let mut labels_url = self
+                .base_url
+                .join(&format!("pullrequests/{}/labels", pr.pull_request_id))?;
+            labels_url
+                .query_pairs_mut()
+                .append_pair("api-version", LABELS_API_VERSION);
+            let resp = self.client.get(labels_url).send().await?;
+            if !resp.status().is_success() {
+                continue;
+            }
+            let label_list: AzureList<AzureLabel> = resp.json().await?;
+            for label in label_list.value.iter() {
+                if PENDING_LABELS.contains(&label.name.as_str()) {
+                    let mut del_url = self.base_url.join(&format!(
+                        "pullrequests/{}/labels/{}",
+                        pr.pull_request_id, label.id
+                    ))?;
+                    del_url
+                        .query_pairs_mut()
+                        .append_pair("api-version", LABELS_API_VERSION);
+                    let _ = self.client.delete(del_url).send().await;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn abandon_all_active_prs(&self) -> Result<()> {
+        log::info!("abandoning all active prs");
+        let mut url = self.base_url.join("pullrequests")?;
+        url.query_pairs_mut()
+            .append_pair("api-version", API_VERSION)
+            .append_pair("searchCriteria.status", "active")
+            .append_pair("$top", "200");
+        let response = self.client.get(url).send().await?;
+        let result = response.error_for_status()?;
+        let list: AzureList<AzurePr> = result.json().await?;
+
+        for pr in list.value.iter() {
+            let pr_url =
+                self.endpoint(&format!("pullrequests/{}", pr.pull_request_id));
+            let body = json!({ "status": "abandoned" });
+            let response = self.client.patch(pr_url).json(&body).send().await?;
+            response.error_for_status()?;
+        }
+        Ok(())
+    }
+
+    async fn delete_all_tags(&self) -> Result<()> {
+        log::info!("deleting all tags");
+        let refs = self.list_refs("tags/").await?;
+        self.delete_refs(&refs).await
+    }
+
+    async fn delete_all_branches(&self) -> Result<()> {
+        log::info!("deleting all branches except default");
+        let refs = self.list_refs("heads/").await?;
+        let default_ref = format!("refs/heads/{}", self.default_branch);
+        let to_delete: Vec<AzureRef> =
+            refs.into_iter().filter(|r| r.name != default_ref).collect();
+        self.delete_refs(&to_delete).await
+    }
+
+    async fn force_reset_history(&self) -> Result<()> {
+        log::info!("force resetting history");
+        let default_ref = format!("refs/heads/{}", self.default_branch);
+
+        let heads = self
+            .list_refs(&format!("heads/{}", self.default_branch))
+            .await?;
+        let current_head = heads
+            .iter()
+            .find(|r| r.name == default_ref)
+            .map(|r| r.object_id.clone())
+            .ok_or_else(|| {
+                color_eyre::eyre::eyre!("default branch ref not found")
+            })?;
+
+        if current_head == self.reset_sha {
+            log::info!("already at reset SHA, nothing to do");
+            return Ok(());
+        }
+
+        // Direct non-fast-forward ref update — requires the repository
+        // to have "Allow rewriting history (force push)" enabled.
+        let body = vec![json!({
+            "name": default_ref,
+            "oldObjectId": current_head,
+            "newObjectId": self.reset_sha,
+        })];
+        let url = self.endpoint("refs");
+        let response = self.client.post(url).json(&body).send().await?;
+        let status = response.status();
+        let body_text = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(color_eyre::eyre::eyre!(
+                "force reset refs POST failed: {status} — {body_text}"
+            ));
+        }
+        let result: AzureList<serde_json::Value> =
+            serde_json::from_str(&body_text).map_err(|e| {
+                color_eyre::eyre::eyre!(
+                    "failed to parse refs update response: {e} — {body_text}"
+                )
+            })?;
+        for item in result.value.iter() {
+            let success = item
+                .get("success")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            if !success {
+                let update_status = item
+                    .get("updateStatus")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                return Err(color_eyre::eyre::eyre!(
+                    "force reset rejected ({update_status}): enable \
+                     'Allow rewriting history' on the default branch in \
+                     Azure DevOps repo settings"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl ForgeTestHelper for AzureDevopsForgeTestHelper {
+    fn supports_native_releases(&self) -> bool {
+        false
+    }
+
+    async fn reset(&self) -> Result<()> {
+        self.remove_pending_labels_from_completed_prs().await?;
+        self.abandon_all_active_prs().await?;
+        self.delete_all_tags().await?;
+        self.delete_all_branches().await?;
+        self.force_reset_history().await
+    }
+
+    async fn merge_pr(&self, pr_number: u64) -> Result<()> {
+        // Azure requires the caller to assert which source-tip it
+        // intends to complete the merge against. Fetch the PR first
+        // to grab `lastMergeSourceCommit.commitId`.
+        let pr_url = self.endpoint(&format!("pullrequests/{pr_number}"));
+        let response = self.client.get(pr_url.clone()).send().await?;
+        let result = response.error_for_status()?;
+        let pr: AzurePr = result.json().await?;
+        let commit_id = pr
+            .last_merge_source_commit
+            .as_ref()
+            .map(|c| c.commit_id.clone())
+            .ok_or_else(|| {
+                color_eyre::eyre::eyre!(
+                    "pr {} has no lastMergeSourceCommit yet — try again",
+                    pr_number
+                )
+            })?;
+
+        let body = json!({
+            "status": "completed",
+            "lastMergeSourceCommit": {"commitId": commit_id},
+            "completionOptions": {
+                "mergeStrategy": "noFastForward",
+                "deleteSourceBranch": false,
+            }
+        });
+        let response = self.client.patch(pr_url).json(&body).send().await?;
+        response.error_for_status()?;
+        Ok(())
+    }
+}

--- a/crates/core/src/forge/tests/common/run.rs
+++ b/crates/core/src/forge/tests/common/run.rs
@@ -154,6 +154,25 @@ pub async fn run_forge_test(
     sleep(SHORT_WAIT).await;
 
     ////////////////////////////////////////////////////////////////////////////
+    // create_release_branch on existing branch -> force-resets, succeeds
+    ////////////////////////////////////////////////////////////////////////////
+    log::info!("re-creating release-branch (force-reset scenario)");
+    let re_create_req = CreateReleaseBranchRequest {
+        base_branch: default_branch.to_string(),
+        message: "chore(main): release (re-run)".into(),
+        release_branch: release_branch.to_string(),
+        file_changes: vec![FileChange {
+            content: format!("# Changelog - {} (updated)", created_commit.sha),
+            path: "CHANGELOG.md".into(),
+            update_type: FileUpdateType::Prepend,
+        }],
+    };
+    let re_create_commit =
+        forge.create_release_branch(re_create_req).await.unwrap();
+    assert!(!re_create_commit.sha.is_empty());
+    sleep(SHORT_WAIT).await;
+
+    ////////////////////////////////////////////////////////////////////////////
     // get_open_release_pr: expect -> None
     ////////////////////////////////////////////////////////////////////////////
     log::info!("getting non-existent open PR");
@@ -308,6 +327,10 @@ pub async fn run_forge_test(
     assert_eq!(current_tag.name, tag);
     assert_eq!(current_tag.semver, Version::parse(semver).unwrap());
     assert_eq!(current_tag.sha, merged_pr.sha);
+    assert!(
+        current_tag.timestamp.is_some(),
+        "tag must carry a timestamp so multi-package repos filter commits correctly"
+    );
 
     ////////////////////////////////////////////////////////////////////////////
     // get_latest_tag_for_prefix on pre-tag-branch -> None
@@ -326,15 +349,17 @@ pub async fn run_forge_test(
          was created"
     );
 
-    ////////////////////////////////////////////////////////////////////////////
-    // get_release_by_tag -> Err Not Found
-    ////////////////////////////////////////////////////////////////////////////
-    log::info!("getting non-existent release by tag name");
-    let err = forge
-        .get_release_by_tag(&current_tag.name)
-        .await
-        .unwrap_err();
-    assert!(matches!(err, ReleasaurusError::ForgeError(_)));
+    if helper.supports_native_releases() {
+        ////////////////////////////////////////////////////////////////////////////
+        // get_release_by_tag -> Err Not Found
+        ////////////////////////////////////////////////////////////////////////////
+        log::info!("getting non-existent release by tag name");
+        let err = forge
+            .get_release_by_tag(&current_tag.name)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ReleasaurusError::ForgeError(_)));
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     // create_release -> succeeds
@@ -346,12 +371,15 @@ pub async fn run_forge_test(
         .unwrap();
     sleep(SHORT_WAIT).await;
 
-    ////////////////////////////////////////////////////////////////////////////
-    // get_release_by_tag -> Found
-    ////////////////////////////////////////////////////////////////////////////
-    log::info!("getting newly created release by tag name");
-    let release = forge.get_release_by_tag(&current_tag.name).await.unwrap();
-    assert_eq!(release.tag, current_tag.name);
+    if helper.supports_native_releases() {
+        ////////////////////////////////////////////////////////////////////////////
+        // get_release_by_tag -> Found
+        ////////////////////////////////////////////////////////////////////////////
+        log::info!("getting newly created release by tag name");
+        let release =
+            forge.get_release_by_tag(&current_tag.name).await.unwrap();
+        assert_eq!(release.tag, current_tag.name);
+    }
 
     ////////////////////////////////////////////////////////////////////////////
     // load_config -> Default::default()
@@ -398,4 +426,25 @@ pub async fn run_forge_test(
     assert_eq!(config.packages[0].name, "test-package");
     assert_eq!(config.packages[0].workspace_root, "packages");
     assert_eq!(config.packages[0].path, "test-package");
+
+    ////////////////////////////////////////////////////////////////////////////
+    // get_commits(sha) -> exactly the one commit made after the tag
+    //
+    // This exercises the SHA-based history walk used by the orchestrator.
+    // The releasaurus.toml commit above is the only commit on the default
+    // branch that post-dates the release tag.
+    ////////////////////////////////////////////////////////////////////////////
+    log::info!("getting commits since release tag");
+    let commits_since_tag = forge
+        .get_commits(
+            Some(default_branch.to_string()),
+            Some(current_tag.sha.clone()),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        commits_since_tag.len(),
+        1,
+        "expected exactly one commit after the release tag"
+    );
 }

--- a/crates/core/src/forge/tests/common/traits.rs
+++ b/crates/core/src/forge/tests/common/traits.rs
@@ -5,4 +5,7 @@ use color_eyre::eyre::Result;
 pub trait ForgeTestHelper {
     async fn reset(&self) -> Result<()>;
     async fn merge_pr(&self, pr_number: u64) -> Result<()>;
+    fn supports_native_releases(&self) -> bool {
+        true
+    }
 }

--- a/crates/core/src/forge/traits.rs
+++ b/crates/core/src/forge/traits.rs
@@ -11,8 +11,8 @@ use crate::{
     forge::request::{
         Commit, CreateCommitRequest, CreatePrRequest,
         CreateReleaseBranchRequest, ForgeCommit, GetFileContentRequest,
-        GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse, Tag,
-        UpdatePrRequest,
+        GetPrRequest, PrLabelsRequest, PrMetadataBlock, PullRequest,
+        ReleaseByTagResponse, Tag, UpdatePrRequest,
     },
     result::Result,
 };
@@ -96,6 +96,17 @@ pub trait Forge: Any + Send + Sync {
         sha: &str,
         notes: &str,
     ) -> Result<()>;
+    /// Encode metadata JSON for embedding in the PR body.
+    ///
+    /// The default writes metadata as an HTML comment inside the div. Forges
+    /// that strip HTML comments should override this to use an attribute
+    /// instead (e.g. `data-meta` with a base64-encoded payload).
+    fn encode_pr_metadata(&self, json: &str) -> PrMetadataBlock {
+        PrMetadataBlock {
+            inline_content: format!("<!--{json}-->"),
+            div_attribute: String::new(),
+        }
+    }
 }
 
 /// Abstraction for loading file content from a source.

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -394,7 +394,15 @@ impl Orchestrator {
         )? {
             (tag, notes)
         } else {
-            parse_pr_body(&package.name, merged_pr.number, &merged_pr.body)?
+            parse_pr_body(&package.name, merged_pr.number, &merged_pr.body)
+                .inspect_err(|_e| {
+                    log::debug!(
+                        "parse_pr_body failed for PR #{} ({} chars body): {:?}",
+                        merged_pr.number,
+                        merged_pr.body.len(),
+                        merged_pr.body
+                    );
+                })?
         };
 
         log::info!("tagging commit: tag: {}, sha: {}", tag, merged_pr.sha);

--- a/crates/core/src/orchestrator/commit_fetcher.rs
+++ b/crates/core/src/orchestrator/commit_fetcher.rs
@@ -247,7 +247,7 @@ impl CommitFetcher {
         }
 
         let mut commits = cache.iter().cloned().collect::<Vec<ForgeCommit>>();
-        commits.sort_by(|c1, c2| c1.timestamp.cmp(&c2.timestamp));
+        commits.sort_by_key(|c| c.timestamp);
         Ok(commits)
     }
 

--- a/crates/core/src/orchestrator/package_processor.rs
+++ b/crates/core/src/orchestrator/package_processor.rs
@@ -439,7 +439,18 @@ impl PackageProcessor {
             };
 
             let json = serde_json::to_string(&metadata)?;
-            let metadata_str = format!(r#"<!--{json}-->"#);
+            let block = self.forge.encode_pr_metadata(&json);
+
+            let div_attr = if block.div_attribute.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", block.div_attribute)
+            };
+            let inline_section = if block.inline_content.is_empty() {
+                "\n".to_string()
+            } else {
+                format!("{}\n\n", block.inline_content)
+            };
 
             // in the PR body link to the comparison with sha instead
             // of tag since the tag doesn't exist yet
@@ -458,10 +469,8 @@ impl PackageProcessor {
                 r#"{start_details}
 <summary>{}</summary>
 <div id="{html_id}-header">{header}</div>
-<div id="{html_id}" data-tag="{}">
-{metadata_str}
-
-{notes}
+<div id="{html_id}" data-tag="{}"{div_attr}>
+{inline_section}{notes}
 </div>
 <div id="{html_id}-footer">{footer}</div>
 </details>"#,

--- a/crates/core/src/orchestrator/package_processor/tests/pr_requests.rs
+++ b/crates/core/src/orchestrator/package_processor/tests/pr_requests.rs
@@ -13,12 +13,23 @@ use super::common::*;
 use crate::{
     config::{Config, package::PackageConfigBuilder},
     forge::{
-        request::{Commit, CreateReleaseBranchRequest, PullRequest, Tag},
+        request::{
+            Commit, CreateReleaseBranchRequest, PrMetadataBlock, PullRequest,
+            Tag,
+        },
         traits::MockForge,
     },
     orchestrator::tests::common::{PrBodyInput, make_pr_body},
     packages::releasable::ReleasablePackage,
 };
+
+fn expect_html_comment_encoding(mock: &mut MockForge) {
+    mock.expect_encode_pr_metadata()
+        .returning(|json| PrMetadataBlock {
+            inline_content: format!("<!--{json}-->"),
+            div_attribute: String::new(),
+        });
+}
 
 #[tokio::test]
 async fn create_pr_branches_creates_branch_before_pr_request() {
@@ -47,6 +58,8 @@ async fn create_pr_branches_creates_branch_before_pr_request() {
                 sha: "abc123".to_string(),
             })
         });
+
+    expect_html_comment_encoding(&mut mock_forge);
 
     let processor = create_package_processor(mock_forge, None, None);
 
@@ -96,6 +109,8 @@ async fn create_pr_branches_includes_metadata_in_body() {
                 sha: "abc123".to_string(),
             })
         });
+
+    expect_html_comment_encoding(&mut mock_forge);
 
     let processor = create_package_processor(mock_forge, None, None);
 
@@ -150,6 +165,8 @@ async fn create_pr_branches_uses_sha_compare_link() {
                 sha: "abc123".to_string(),
             })
         });
+
+    expect_html_comment_encoding(&mut mock_forge);
 
     let processor = create_package_processor(mock_forge, None, None);
 
@@ -239,6 +256,8 @@ async fn create_pr_branches_handles_multiple_packages_on_same_branch() {
         separate_pull_requests: false,
         ..Default::default()
     };
+
+    expect_html_comment_encoding(&mut mock_forge);
 
     let processor =
         create_package_processor(mock_forge, Some(pkg_configs), Some(config));
@@ -331,6 +350,8 @@ async fn create_pr_branches_handles_separate_branches() {
         ..Default::default()
     };
 
+    expect_html_comment_encoding(&mut mock_forge);
+
     let processor =
         create_package_processor(mock_forge, Some(pkg_configs), Some(config));
 
@@ -400,6 +421,8 @@ async fn create_pr_branches_includes_file_changes() {
             })
         });
 
+    expect_html_comment_encoding(&mut mock_forge);
+
     let processor = create_package_processor(mock_forge, None, None);
 
     let releasable = ReleasablePackage {
@@ -443,6 +466,8 @@ async fn create_pr_branches_uses_correct_title_format() {
                 sha: "abc123".to_string(),
             })
         });
+
+    expect_html_comment_encoding(&mut mock_forge);
 
     let processor = create_package_processor(mock_forge, None, None);
 
@@ -507,6 +532,8 @@ async fn create_pr_branches_handles_existing_pr_body_sections() {
                 sha: "abc123".to_string(),
             })
         });
+
+    expect_html_comment_encoding(&mut mock_forge);
 
     let processor = create_package_processor(mock_forge, None, None);
 

--- a/crates/core/src/orchestrator/pr_body.rs
+++ b/crates/core/src/orchestrator/pr_body.rs
@@ -1,3 +1,4 @@
+use base64::{Engine, prelude::BASE64_STANDARD};
 use color_eyre::eyre::eyre;
 use regex::Regex;
 use std::sync::LazyLock;
@@ -130,27 +131,49 @@ pub fn parse_pr_body(
 
     let notes = div.inner_html(parser);
 
-    let cap =
-        METADATA_REGEX
-            .captures(&notes)
-            .ok_or(ReleasaurusError::Other(eyre!(
-                "failed to find metadata for package: pkg={} pr={}",
+    // Try data-meta attribute first (base64 JSON); fall back to the inline HTML comment
+    let json: PRMetadata = if let Some(b64) = div_tag
+        .attributes()
+        .get("data-meta")
+        .flatten()
+        .map(|b| b.as_utf8_str().to_string())
+    {
+        let decoded = BASE64_STANDARD.decode(b64.as_bytes()).map_err(|e| {
+            ReleasaurusError::Other(eyre!(
+                "failed to decode data-meta for package: pkg={} pr={} - {e}",
                 package_name,
                 pr_number
-            )))?;
-
-    let metadata_str = cap
-        .name("metadata")
-        .ok_or(ReleasaurusError::Other(eyre!(
-            "failed to parse metadata from PR body: pkg={} pr={}",
-            package_name,
-            pr_number,
-        )))?
-        .as_str();
-
-    log::debug!("parsing metadata string: {:#?}", metadata_str);
-
-    let json: PRMetadata = serde_json::from_str(metadata_str)?;
+            ))
+        })?;
+        let s = String::from_utf8(decoded).map_err(|e| {
+            ReleasaurusError::Other(eyre!(
+                "data-meta is not valid UTF-8: pkg={} pr={} - {e}",
+                package_name,
+                pr_number
+            ))
+        })?;
+        log::debug!("parsing metadata from data-meta attribute: {s:?}");
+        serde_json::from_str(&s)?
+    } else {
+        let cap =
+            METADATA_REGEX
+                .captures(&notes)
+                .ok_or(ReleasaurusError::Other(eyre!(
+                    "failed to find metadata for package: pkg={} pr={}",
+                    package_name,
+                    pr_number
+                )))?;
+        let metadata_str = cap
+            .name("metadata")
+            .ok_or(ReleasaurusError::Other(eyre!(
+                "failed to parse metadata from PR body: pkg={} pr={}",
+                package_name,
+                pr_number,
+            )))?
+            .as_str();
+        log::debug!("parsing metadata from HTML comment: {metadata_str:?}");
+        serde_json::from_str(metadata_str)?
+    };
 
     let tag_compare_link =
         json.metadata

--- a/crates/core/src/orchestrator/tests/pr_workflow.rs
+++ b/crates/core/src/orchestrator/tests/pr_workflow.rs
@@ -10,7 +10,9 @@ use crate::{
     config::{Config, package::PackageConfigBuilder},
     forge::{
         config::PENDING_LABEL,
-        request::{Commit, ForgeCommitBuilder, PullRequest, Tag},
+        request::{
+            Commit, ForgeCommitBuilder, PrMetadataBlock, PullRequest, Tag,
+        },
         traits::MockForge,
     },
     result::ReleasaurusError,
@@ -137,6 +139,14 @@ async fn create_release_prs_creates_new_prs() {
         .times(2);
 
     mock_forge
+        .expect_encode_pr_metadata()
+        .times(2)
+        .returning(|json| PrMetadataBlock {
+            inline_content: format!("<!--{json}-->"),
+            div_attribute: String::new(),
+        });
+
+    mock_forge
         .expect_create_pr()
         .returning(|req| {
             let mut pr_number = 1;
@@ -226,6 +236,14 @@ async fn create_release_prs_targets_specific_package() {
             })
         })
         .times(1);
+
+    mock_forge
+        .expect_encode_pr_metadata()
+        .times(1)
+        .returning(|json| PrMetadataBlock {
+            inline_content: format!("<!--{json}-->"),
+            div_attribute: String::new(),
+        });
 
     mock_forge
         .expect_create_pr()
@@ -357,6 +375,14 @@ async fn create_release_prs_updates_existing_prs() {
         .times(1);
 
     mock_forge.expect_create_pr().times(0);
+
+    mock_forge
+        .expect_encode_pr_metadata()
+        .times(1)
+        .returning(|json| PrMetadataBlock {
+            inline_content: format!("<!--{json}-->"),
+            div_attribute: String::new(),
+        });
 
     mock_forge.expect_update_pr().returning(|_| Ok(())).times(1);
 


### PR DESCRIPTION
## Description

This PR adds an `AzureDevops` forge implementation backed by `reqwest` against the Azure DevOps REST API 7.1.

Note that while it works, Azure DevOps has no first-class release object. Its so-called Release is actually a deployment pipeline concept and is not usable for this case. Due to that, the `create_release` step is a deliberate no-op — only the changelog commit and the git tag are pushed. A one-time `warn!` flags support as experimental on every invocation.

**Notable implementation details:**

- **URL scope**: Only `https://dev.azure.com/{org}/{project}/_git/{repo}` is accepted. On-prem Azure DevOps Server and legacy `*.visualstudio.com` URLs are explicitly out of scope.
- **Auth**: PAT via HTTP Basic with the new `AZURE_DEVOPS_TOKEN` env var. Required scopes: `Code: Read & Write` and `Pull Request Threads: Read & Write`.
- **PR metadata encoding**: Azure DevOps strips HTML comments from PR descriptions, so metadata is written as a base64-encoded `data-meta` attribute on the metadata `div` in addition to the inline HTML comment. The reader tries the attribute first and falls back to the comment for forges that preserve it. This required a new `PrMetadataBlock` abstraction in `forge/request.rs`.
- **Squash-merge prefix stripping**: Azure DevOps prepends `Merged PR NNN:` to squash-merge commit subjects. This prefix is stripped when scanning commit history so the original subject is recovered.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

Integration tests are wired up in `crates/core/src/forge/tests/azure_devops.rs` using the shared `run_forge_test` harness. They require three env vars pointing at a live Azure DevOps repo: `AZURE_DEVOPS_TEST_REPO`, `AZURE_DEVOPS_TEST_TOKEN`, and `AZURE_DEVOPS_RESET_SHA`. A dedicated `AzureDevopsForgeTestHelper` in `tests/common/azure_devops.rs` handles repo setup and teardown against the API.

The book (`ci-cd-integration.md`, `environment-variables.md`, `commands.md`, `contributing.md`) is updated with usage instructions, required PAT scopes, and an Azure Pipelines Docker example.