### PR TITLE
fix: fixes forgejo implementations

### DIFF
--- a/crates/core/src/forge/forgejo.rs
+++ b/crates/core/src/forge/forgejo.rs
@@ -1,25 +1,39 @@
 use async_trait::async_trait;
-use secrecy::SecretString;
+use base64::{Engine, prelude::BASE64_STANDARD};
+use color_eyre::eyre::ContextCompat;
+use reqwest::{
+    Client,
+    header::{HeaderMap, HeaderValue},
+};
+use secrecy::{ExposeSecret, SecretString};
 use url::Url;
 
 use crate::{
     config::Config,
     forge::{
-        config::{RepoUrl, TokenVar},
+        config::{RepoUrl, TokenVar, resolve_token},
+        forgejo::types::{
+            ForgejoCreatedCommit, ForgejoFileChange,
+            ForgejoFileChangeOperation, ForgejoModifyFiles,
+        },
         gitea::Gitea,
         request::{
             Commit, CreateCommitRequest, CreatePrRequest,
-            CreateReleaseBranchRequest, ForgeCommit, GetFileContentRequest,
-            GetPrRequest, PrLabelsRequest, PullRequest, ReleaseByTagResponse,
-            Tag, UpdatePrRequest,
+            CreateReleaseBranchRequest, FileUpdateType, ForgeCommit,
+            GetFileContentRequest, GetPrRequest, PrLabelsRequest, PullRequest,
+            ReleaseByTagResponse, Tag, UpdatePrRequest,
         },
         traits::Forge,
     },
     result::Result,
 };
 
+mod types;
+
 pub struct Forgejo {
     gitea: Gitea,
+    base_url: Url,
+    client: Client,
 }
 
 impl Forgejo {
@@ -27,9 +41,58 @@ impl Forgejo {
         url: RepoUrl,
         token: Option<SecretString>,
     ) -> Result<Self> {
-        let gitea = Gitea::new(url, token, Some(TokenVar::Forgejo)).await?;
+        rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .ok();
 
-        Ok(Self { gitea })
+        let token =
+            resolve_token(token, url.token.as_ref(), TokenVar::Forgejo)?;
+
+        let mut headers = HeaderMap::new();
+
+        let token_value = HeaderValue::from_str(
+            format!("token {}", token.expose_secret()).as_str(),
+        )?;
+
+        headers.append("Authorization", token_value);
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()?;
+
+        let base_url = match url.port {
+            Some(port) => format!(
+                "{}://{}:{}/api/v1/repos/{}/{}/",
+                url.scheme, url.host, port, url.owner, url.name
+            ),
+            None => format!(
+                "{}://{}/api/v1/repos/{}/{}/",
+                url.scheme, url.host, url.owner, url.name
+            ),
+        };
+
+        let base_url = Url::parse(&base_url)?;
+
+        let gitea =
+            Gitea::new(url.clone(), Some(token), Some(TokenVar::Forgejo))
+                .await?;
+
+        Ok(Self {
+            client,
+            base_url,
+            gitea,
+        })
+    }
+
+    async fn get_file_sha(&self, path: &str) -> Result<String> {
+        let path = path.strip_prefix("./").unwrap_or(path);
+        let file_url = self.base_url.join(&format!("contents/{path}"))?;
+        let request = self.client.get(file_url).build()?;
+        let response = self.client.execute(request).await?;
+        let result = response.error_for_status()?;
+        let file: serde_json::Value = result.json().await?;
+        let sha = file["sha"].as_str().wrap_err("failed to get file sha")?;
+        Ok(sha.into())
     }
 }
 
@@ -99,11 +162,111 @@ impl Forge for Forgejo {
         &self,
         req: CreateReleaseBranchRequest,
     ) -> Result<Commit> {
-        self.gitea.create_release_branch(req).await
+        let mut file_changes: Vec<ForgejoFileChange> = vec![];
+
+        for change in req.file_changes.iter() {
+            let mut op = ForgejoFileChangeOperation::Update;
+            let mut sha = None;
+            let mut content = change.content.clone();
+            let existing_content = self
+                .get_file_content(GetFileContentRequest {
+                    branch: Some(req.base_branch.clone()),
+                    path: change.path.to_string(),
+                })
+                .await?;
+            if let Some(existing_content) = existing_content {
+                sha = Some(self.get_file_sha(&change.path).await?);
+                if matches!(change.update_type, FileUpdateType::Prepend) {
+                    content = format!("{content}{existing_content}");
+                }
+            } else {
+                op = ForgejoFileChangeOperation::Create;
+            }
+            file_changes.push(ForgejoFileChange {
+                path: change.path.clone(),
+                content: BASE64_STANDARD.encode(&content),
+                operation: op,
+                sha,
+            })
+        }
+
+        let body = ForgejoModifyFiles {
+            branch: req.base_branch,
+            new_branch: Some(req.release_branch),
+            message: req.message,
+            files: file_changes,
+        };
+
+        let contents_url = self.base_url.join("contents")?;
+        let request = self.client.post(contents_url).json(&body).build()?;
+        let response = self.client.execute(request).await?;
+        let result = response.error_for_status()?;
+        let created: ForgejoCreatedCommit = result.json().await?;
+
+        Ok(created.commit)
     }
 
     async fn create_commit(&self, req: CreateCommitRequest) -> Result<Commit> {
-        self.gitea.create_commit(req).await
+        let mut file_changes: Vec<ForgejoFileChange> = vec![];
+
+        for change in req.file_changes.iter() {
+            let mut op = ForgejoFileChangeOperation::Update;
+            let mut sha = None;
+            let mut content = change.content.clone();
+            let existing_content = self
+                .get_file_content(GetFileContentRequest {
+                    branch: Some(req.target_branch.clone()),
+                    path: change.path.to_string(),
+                })
+                .await?;
+            if let Some(existing_content) = existing_content.clone() {
+                sha = Some(self.get_file_sha(&change.path).await?);
+                if matches!(change.update_type, FileUpdateType::Prepend) {
+                    content = format!("{content}{existing_content}");
+                }
+            } else {
+                op = ForgejoFileChangeOperation::Create;
+            }
+
+            if content == existing_content.unwrap_or_default() {
+                log::warn!(
+                    "skipping file update content matches existing state: {}",
+                    change.path
+                );
+                continue;
+            }
+
+            file_changes.push(ForgejoFileChange {
+                path: change.path.clone(),
+                content: BASE64_STANDARD.encode(&content),
+                operation: op,
+                sha,
+            })
+        }
+
+        if file_changes.is_empty() {
+            log::warn!(
+                "commit would result in no changes: target_branch: {}, message: {}",
+                req.target_branch,
+                req.message,
+            );
+            return Ok(Commit { sha: "None".into() });
+        }
+
+        let body = ForgejoModifyFiles {
+            new_branch: None,
+            branch: req.target_branch,
+            message: req.message,
+            files: file_changes,
+        };
+
+        let contents_url = self.base_url.join("contents")?;
+        let request = self.client.post(contents_url).json(&body).build()?;
+        let response = self.client.execute(request).await?;
+        let result = response.error_for_status()?;
+        let created: ForgejoCreatedCommit = result.json().await?;
+
+        Ok(created.commit)
     }
 
     async fn tag_commit(&self, tag_name: &str, sha: &str) -> Result<()> {

--- a/crates/core/src/forge/forgejo/types.rs
+++ b/crates/core/src/forge/forgejo/types.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+use crate::forge::request::Commit;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ForgejoFileChangeOperation {
+    Create,
+    Update,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ForgejoFileChange {
+    pub path: String,
+    pub content: String,
+    pub operation: ForgejoFileChangeOperation,
+    pub sha: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ForgejoModifyFiles {
+    pub branch: String,
+    pub new_branch: Option<String>,
+    pub message: String,
+    pub files: Vec<ForgejoFileChange>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ForgejoCreatedCommit {
+    pub commit: Commit,
+}


### PR DESCRIPTION
## Description

Forgejo doesn't support force pushingo on the /contents routes yet. So this commit addresses that issue by diverging from the gitea implementation for the create_release_branch and create_commit methods

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)