### PR TITLE
fix: removes option to skip release commits

### DIFF
--- a/book/src/configuration-changelog.md
+++ b/book/src/configuration-changelog.md
@@ -131,15 +131,6 @@ Exclude merge commits:
 skip_merge_commits = false  # Include "Merge pull request #123"
 ```
 
-### `skip_release_commits` (default: true)
-
-Exclude release commits created by Releasaurus:
-
-```toml
-[changelog]
-skip_release_commits = false  # Include "chore(main): release v1.0.0"
-```
-
 ### `include_author` (default: false)
 
 Include commit author names in changelog entries:
@@ -308,7 +299,6 @@ skip_ci = true
 skip_chore = true
 skip_miscellaneous = true
 skip_merge_commits = true
-skip_release_commits = true
 
 [[package]]
 path = "."

--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -343,19 +343,6 @@ Exclude merge commits from changelog.
 skip_merge_commits = false
 ```
 
-#### `skip_release_commits`
-
-**Type**: Boolean (optional)
-
-**Default**: true
-
-Exclude release commits created by Releasaurus.
-
-```toml
-[changelog]
-skip_release_commits = false
-```
-
 #### `include_author`
 
 **Type**: Boolean (optional)

--- a/crates/core/src/analyzer/commit.rs
+++ b/crates/core/src/analyzer/commit.rs
@@ -122,9 +122,7 @@ impl Commit {
                     );
                     return None;
                 }
-                if config.skip_release_commits
-                    && let Some(matcher) =
-                        config.release_commit_matcher.as_ref()
+                if let Some(matcher) = config.release_commit_matcher.as_ref()
                     && matcher.is_match(&commit.raw_title)
                 {
                     log::debug!(
@@ -466,7 +464,6 @@ mod tests {
     fn test_parses_and_omits_release_commit() {
         let analyzer_config = AnalyzerConfig {
             skip_chore: false,
-            skip_release_commits: true,
             release_commit_matcher: Some(
                 Regex::new(r#"^chore\(main\):\srelease.+"#).unwrap(),
             ),
@@ -491,36 +488,6 @@ mod tests {
         );
 
         assert!(commit.is_none());
-    }
-
-    #[test]
-    fn test_parses_and_includes_release_commit() {
-        let analyzer_config = AnalyzerConfig {
-            skip_release_commits: false,
-            ..AnalyzerConfig::default()
-        };
-        let group_parser = GroupParser::default();
-        let forge_commit = ForgeCommitBuilder::default()
-            .id("vwx234")
-            .message("chore(main): release test-package test-package-v1.0.0")
-            .author_name("GitHub")
-            .author_email("noreply@github.com")
-            .timestamp(1640995900)
-            .merge_commit(false)
-            .build()
-            .unwrap();
-        let commit = Commit::parse_forge_commit(
-            &group_parser,
-            &forge_commit,
-            &analyzer_config,
-        )
-        .unwrap();
-
-        assert_eq!(commit.group, Group::Chore);
-        assert!(!commit.merge_commit);
-        assert_eq!(commit.title, "release test-package test-package-v1.0.0");
-        assert_eq!(commit.author_name, "GitHub");
-        assert_eq!(commit.author_email, "noreply@github.com");
     }
 
     #[test]
@@ -1398,7 +1365,6 @@ mod tests {
             skip_miscellaneous: true,
             skip_perf: true,
             skip_refactor: true,
-            skip_release_commits: true,
             skip_revert: true,
             skip_style: true,
             skip_test: true,

--- a/crates/core/src/analyzer/config.rs
+++ b/crates/core/src/analyzer/config.rs
@@ -32,8 +32,6 @@ pub struct AnalyzerConfig {
     pub skip_miscellaneous: bool,
     /// Skips including merge commits in changelog (default: true)
     pub skip_merge_commits: bool,
-    /// Skips including release commits in changelog (default: true)
-    pub skip_release_commits: bool,
     /// Includes commit author in default body template (default: false)
     pub include_author: bool,
     /// Optional prefix for package tags.
@@ -73,7 +71,6 @@ impl Default for AnalyzerConfig {
             skip_revert: false,
             skip_miscellaneous: false,
             skip_merge_commits: true,
-            skip_release_commits: true,
             include_author: false,
             tag_prefix: None,
             release_link_base_url: None,

--- a/crates/core/src/config/changelog.rs
+++ b/crates/core/src/config/changelog.rs
@@ -62,8 +62,6 @@ pub struct ChangelogConfig {
     pub skip_miscellaneous: bool,
     /// Skips including merge commits in changelog
     pub skip_merge_commits: bool,
-    /// Skips including release commits in changelog
-    pub skip_release_commits: bool,
     /// Skips targeted commit shas (or prefixes) when generating next version
     /// and changelog. Each value matches any commit whose SHA starts with the
     /// provided value
@@ -92,7 +90,6 @@ impl Default for ChangelogConfig {
             skip_revert: false,
             skip_miscellaneous: false,
             skip_merge_commits: true,
-            skip_release_commits: true,
             skip_shas: None,
             reword: None,
             include_author: false,

--- a/crates/core/src/forge/github.rs
+++ b/crates/core/src/forge/github.rs
@@ -489,6 +489,13 @@ impl Forge for Github {
                 return Ok(commits);
             }
 
+            // stop if we've reached target sha
+            if let Some(target_sha) = sha.as_deref()
+                && thin_commit.sha == target_sha
+            {
+                return Ok(commits);
+            }
+
             count += 1;
 
             log::debug!(

--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -415,6 +415,13 @@ impl Forge for Gitlab {
         let mut forge_commits = vec![];
 
         for commit in result.iter() {
+            // stop if we've reached target sha
+            if let Some(target_sha) = sha.as_deref()
+                && commit.id == target_sha
+            {
+                break;
+            }
+
             log::debug!("backfilling file list for commit: {}", commit.id);
 
             let vars = CommitDiffQueryVars {

--- a/crates/core/src/orchestrator/commit_fetcher.rs
+++ b/crates/core/src/orchestrator/commit_fetcher.rs
@@ -79,12 +79,18 @@ impl CommitFetcher {
         let mut package_commits: Vec<ForgeCommit> = vec![];
 
         for commit in commits.iter() {
-            if let Some(tag) = tag
-                && let Some(tag_timestamp) = tag.timestamp
-                && commit.timestamp < tag_timestamp
-            {
-                // commit is older than package's previous release starting point
-                continue;
+            if let Some(tag) = tag {
+                if let Some(tag_timestamp) = tag.timestamp
+                    && commit.timestamp < tag_timestamp
+                {
+                    // omit: commit is older than last release tag
+                    continue;
+                }
+
+                if commit.id == tag.sha {
+                    // omit: commit is previous release tag
+                    continue;
+                }
             }
             'file_loop: for file in commit.files.iter() {
                 let file_path = Path::new(file);
@@ -415,6 +421,44 @@ mod tests {
             core.filter_commits_for_package(&package, Some(&tag), &commits);
 
         // Should only include commits newer than tag timestamp
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "new-commit");
+    }
+
+    #[test]
+    fn omits_commit_matching_tag_sha() {
+        let commits = vec![
+            ForgeCommitBuilder::default()
+                .id("release-sha")
+                .short_id("rel")
+                .message("chore(main): release v1.0.0")
+                .timestamp(200)
+                .files(vec!["packages/pkg-a/src/lib.rs".to_string()])
+                .build()
+                .unwrap(),
+            ForgeCommitBuilder::default()
+                .id("new-commit")
+                .short_id("new")
+                .message("feat: new feature")
+                .timestamp(300)
+                .files(vec!["packages/pkg-a/src/main.rs".to_string()])
+                .build()
+                .unwrap(),
+        ];
+
+        let package = create_test_package("pkg-a", "packages/pkg-a");
+        let tag = Tag {
+            name: "v1.0.0".to_string(),
+            sha: "release-sha".to_string(),
+            timestamp: Some(100),
+            ..Default::default()
+        };
+
+        let core = create_test_commit_fetcher();
+
+        let filtered =
+            core.filter_commits_for_package(&package, Some(&tag), &commits);
+
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].id, "new-commit");
     }

--- a/crates/core/src/orchestrator/tests/pr_workflow.rs
+++ b/crates/core/src/orchestrator/tests/pr_workflow.rs
@@ -324,7 +324,7 @@ async fn create_release_prs_updates_existing_prs() {
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
             ForgeCommitBuilder::default()
-                .id("abc123")
+                .id("def456")
                 .files(vec!["dummy.txt".into()])
                 .timestamp(200)
                 .build()

--- a/crates/core/src/resolver/resolvers/analyzer.rs
+++ b/crates/core/src/resolver/resolvers/analyzer.rs
@@ -62,7 +62,6 @@ pub fn build_analyzer_config(params: AnalyzerParams) -> AnalyzerConfig {
         skip_style: params.config.changelog.skip_style,
         skip_merge_commits: params.config.changelog.skip_merge_commits,
         skip_miscellaneous: params.config.changelog.skip_miscellaneous,
-        skip_release_commits: params.config.changelog.skip_release_commits,
         tag_prefix: Some(params.tag_prefix),
         commit_modifiers: params.config.commit_modifiers.clone(),
     }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -88,7 +88,6 @@
         "skip_revert": false,
         "skip_miscellaneous": false,
         "skip_merge_commits": true,
-        "skip_release_commits": true,
         "skip_shas": null,
         "reword": null,
         "include_author": false,
@@ -212,11 +211,6 @@
         },
         "skip_merge_commits": {
           "description": "Skips including merge commits in changelog",
-          "type": "boolean",
-          "default": true
-        },
-        "skip_release_commits": {
-          "description": "Skips including release commits in changelog",
           "type": "boolean",
           "default": true
         },


### PR DESCRIPTION
## Description

We now always skip release commits as we ensure each forge omits them when fetching commits. The setting only ever made sense in monorepos as that is the only time we might fetch more commits than what is needed for a particular package. Since the setting only made sense in that one case it makes more sense to remove the setting entirely and just have uniform behavior where release commits are always omitted

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [x] Documentation tested (if applicable)
