### PR TITLE
fix: fixes issue with creating release branch in forgejo

### DIFF
--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -354,6 +354,23 @@ URL:
 - `forgejo` - For codeberg.org and self-hosted Forgejo instances
 - `local` - For testing against local repositories
 
+### Known Limitations
+
+#### Forgejo: Closed Release PRs on Repeated Runs
+
+Forgejo currently does not support force-pushing a branch via
+the API. As a workaround, releasaurus deletes the release branch and
+re-creates it on each run. Forgejo automatically closes any open pull request
+targeting a deleted branch, so each run produces a new PR and leaves a
+closed one behind.
+
+**Workaround**: Use `--local-path` (hybrid mode) to perform git operations
+locally. This bypasses the branch-deletion workaround and avoids accumulating
+closed PRs. See the [Using `--local-path`](#using---local-path-hybrid-mode)
+example below, substituting `--forge gitea` and your Forgejo repository URL.
+
+We are working on submitting a patch to Forgejo to remove this limitation.
+
 ### Dry Run Mode
 
 Test your release workflow without making any actual changes to your

--- a/crates/core/src/forge/forgejo.rs
+++ b/crates/core/src/forge/forgejo.rs
@@ -6,6 +6,8 @@ use reqwest::{
     header::{HeaderMap, HeaderValue},
 };
 use secrecy::{ExposeSecret, SecretString};
+use std::time::Duration;
+use tokio::time::sleep;
 use url::Url;
 
 use crate::{
@@ -82,6 +84,18 @@ impl Forgejo {
             base_url,
             gitea,
         })
+    }
+
+    // TODO: Right now forgejo does not support force updating a branch
+    async fn delete_branch_if_exists(&self, branch: &str) -> Result<()> {
+        let url = self.base_url.join(&format!("branches/{branch}"))?;
+        let request = self.client.delete(url).build()?;
+        let response = self.client.execute(request).await?;
+        let status = response.status();
+        if !status.is_success() && status != reqwest::StatusCode::NOT_FOUND {
+            response.error_for_status()?;
+        }
+        Ok(())
     }
 
     async fn get_file_sha(&self, path: &str) -> Result<String> {
@@ -162,6 +176,13 @@ impl Forge for Forgejo {
         &self,
         req: CreateReleaseBranchRequest,
     ) -> Result<Commit> {
+        // TODO: When forgejo supports force pushing on /contents
+        // delete this call
+        self.delete_branch_if_exists(&req.release_branch).await?;
+        // pause execution to wait for any PRs that might have been closed as
+        // a result to fully register as closed
+        sleep(Duration::from_millis(3000)).await;
+
         let mut file_changes: Vec<ForgejoFileChange> = vec![];
 
         for change in req.file_changes.iter() {
@@ -182,11 +203,15 @@ impl Forge for Forgejo {
             } else {
                 op = ForgejoFileChangeOperation::Create;
             }
+
             file_changes.push(ForgejoFileChange {
                 path: change.path.clone(),
                 content: BASE64_STANDARD.encode(&content),
                 operation: op,
                 sha,
+                // TODO: Currently forgejo does not support the force option,
+                // when it does we'll add the below line
+                // force_push: true,
             })
         }
 
@@ -241,6 +266,9 @@ impl Forge for Forgejo {
                 content: BASE64_STANDARD.encode(&content),
                 operation: op,
                 sha,
+                // TODO: below line will be needed when forgejo supports
+                // force pushing on /contents
+                // force_push: false
             })
         }
 

--- a/crates/core/src/forge/forgejo/types.rs
+++ b/crates/core/src/forge/forgejo/types.rs
@@ -23,6 +23,8 @@ pub struct ForgejoModifyFiles {
     pub new_branch: Option<String>,
     pub message: String,
     pub files: Vec<ForgejoFileChange>,
+    // TODO: add this once forgejo supports force pushing on /contents route
+    // pub force_push: bool,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Description

Since forgejo doesn't support force pushing on /contents route yet we need to resort to our old gitea trick of deleting the and recreating the branch each time

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)
