### PR TITLE
fix(azure): surface API errors and document release branch permission

### DIFF
--- a/book/src/ci-cd-integration.md
+++ b/book/src/ci-cd-integration.md
@@ -92,6 +92,14 @@ Provide a PAT via the `AZURE_DEVOPS_TOKEN` pipeline secret variable.
 The PAT needs `Code: Read & Write` and `Pull Request Threads: Read &
 Write` scopes.
 
+The release branch (typically `releasaurus-release-*`) must have 
+**Allow rewriting history** 
+enabled for the build service identity — releasaurus performs
+a non-fast-forward reset to the base branch when updating an existing
+release PR. See the [Azure DevOps known
+limitation](./commands.md#azure-devops-release-branch-requires-allow-rewriting-history)
+for the exact setting.
+
 ```yaml
 trigger:
   branches:

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -380,6 +380,18 @@ example below, substituting `--forge gitea` and your Forgejo repository URL.
 
 We are working on submitting a patch to Forgejo to remove this limitation.
 
+#### Azure DevOps: Release Branch Requires "Allow rewriting history"
+
+When a release PR is updated, releasaurus resets the release branch to the
+tip of the base branch and replays the changelog commit on top. If the
+existing release branch has diverged from the base, this is a non-fast-forward
+update and Azure DevOps will reject it unless the **Allow rewriting history**
+permission is granted on the release branch (typically `releasaurus-release-*`).
+
+In Azure DevOps: **Project Settings → Repositories → {repo} → Security → Branches
+→ {release branch}**, set **Allow rewriting history** to *Allow* for the build
+service account (or whichever identity holds the PAT releasaurus uses).
+
 ### Dry Run Mode
 
 Test your release workflow without making any actual changes to your

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -183,10 +183,15 @@ impl AzureDevops {
             .append_pair("targetVersion", branch)
             .append_pair("targetVersionType", "branch");
         let response = self.client.get(url).send().await?;
-        if !response.status().is_success() {
+        // 404 means the base commit isn't reachable from the target branch
+        // (or doesn't exist) — a legitimate "not an ancestor". Any other
+        // non-2xx (401, 429, 5xx) would silently drop reachable tags if
+        // coerced to false, so propagate it.
+        if response.status() == StatusCode::NOT_FOUND {
             return Ok(false);
         }
-        let body: serde_json::Value = response.json().await?;
+        let body: serde_json::Value =
+            response.error_for_status()?.json().await?;
         let base = body.get("baseCommit").and_then(|v| v.as_str());
         let common = body.get("commonCommit").and_then(|v| v.as_str());
         match (base, common) {
@@ -406,10 +411,14 @@ impl AzureDevops {
         url.query_pairs_mut()
             .append_pair("api-version", API_VERSION);
         let response = self.client.get(url).send().await?;
-        if !response.status().is_success() {
+        // 404 is legitimate (commit has no recorded change list); other
+        // non-2xx codes (401/429/5xx) would silently produce empty file
+        // lists and mask auth or transport problems, so propagate.
+        if response.status() == StatusCode::NOT_FOUND {
             return Ok(vec![]);
         }
-        let changes: AzureCommitChanges = response.json().await?;
+        let changes: AzureCommitChanges =
+            response.error_for_status()?.json().await?;
         Ok(changes
             .changes
             .into_iter()
@@ -628,7 +637,13 @@ impl Forge for AzureDevops {
                     return Ok(commits);
                 }
 
-                // Fetch file list for this commit (best effort).
+                // Fetch file list for this commit (best effort). Azure
+                // DevOps' commits list endpoint doesn't include change
+                // info, so this is one extra request per commit.
+                log::debug!(
+                    "backfilling file list for commit: {}",
+                    c.commit_id
+                );
                 let files = self
                     .get_commit_files(&c.commit_id)
                     .await


### PR DESCRIPTION
Small improvement based on AI review:

- is_ancestor_of_branch and get_commit_files now treat 404 as the legitimate absent case but propagate other non-2xx (401, 429, 5xx) instead of silently coercing them to empty results, matching the 404-distinction pattern already used by get_pr_labels and get_file_content. log::warn! at the boundary surfaces what happened.

- Add log::debug! before per-commit file backfill in get_commits to match the github/gitlab idiom (azure devops' commits list endpoint doesn't include change info, so the N+1 is unavoidable until we add bounded concurrency across all forges).

- Document the "Allow rewriting history" permission requirement on the release branch in commands.md as a known limitation, with a cross reference from the azure pipelines section of ci-cd-integration.md.

Relates to #289