### PR TITLE
feat(cli): env-var fallbacks + auto-infer forge for cloud hosts

### DIFF
--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -363,6 +363,36 @@ URL:
   not supported.
 - `local` - For testing against local repositories
 
+#### Automatic forge inference
+
+When `--repo` points at a recognized cloud host, `--forge` can be
+omitted — Releasaurus infers it from the URL host:
+
+| Host             | Inferred forge |
+| ---------------- | -------------- |
+| `github.com`     | `github`       |
+| `gitlab.com`     | `gitlab`       |
+| `gitea.com`      | `gitea`        |
+| `codeberg.org`   | `forgejo`      |
+| `dev.azure.com`  | `azure-devops` |
+
+```bash
+# --forge omitted — inferred as github
+releasaurus release-pr --repo "https://github.com/owner/repo"
+```
+
+Self-hosted instances (e.g. `https://gitlab.company.com/...`) still
+require `--forge` explicitly, since the host alone can't identify the
+forge software. `--forge local` also still requires the flag.
+
+#### Environment-variable defaults
+
+`--forge`, `--repo`, and `--local-path` each fall back to an
+environment variable when the flag is omitted: `RELEASAURUS_FORGE`,
+`RELEASAURUS_REPO`, and `RELEASAURUS_LOCAL_PATH`. See
+[Environment Variables](./environment-variables.md#forge-selection)
+for details.
+
 ### Known Limitations
 
 #### Forgejo: Closed Release PRs on Repeated Runs

--- a/book/src/environment-variables.md
+++ b/book/src/environment-variables.md
@@ -268,6 +268,41 @@ numbers, file changes, and release notes.
 `RELEASAURUS_DEBUG` setting. This ensures you have maximum visibility into
 what would happen during the release process.
 
+## Forge Selection
+
+The following variables act as fallbacks for their matching CLI flags.
+Command-line flags always win when both are provided.
+
+### `RELEASAURUS_FORGE`
+
+**Purpose**: Default value for `--forge`. Accepts the same values as the
+flag: `github`, `gitlab`, `gitea`, `forgejo`, `azure-devops`, or `local`.
+
+```bash
+export RELEASAURUS_FORGE=github
+releasaurus release-pr --repo "https://github.com/owner/repo"
+```
+
+### `RELEASAURUS_REPO`
+
+**Purpose**: Default value for `--repo`. The repository URL releasaurus
+should operate against.
+
+```bash
+export RELEASAURUS_REPO="https://github.com/owner/repo"
+releasaurus release-pr --forge github
+```
+
+### `RELEASAURUS_LOCAL_PATH`
+
+**Purpose**: Default value for `--local-path`. Path to a local clone used
+in hybrid mode (local git operations + remote PR/release creation).
+
+```bash
+export RELEASAURUS_LOCAL_PATH=.
+releasaurus release-pr --forge github --repo "https://github.com/owner/repo"
+```
+
 ## Next Steps
 
 - **[Commands](./commands.md)** - Command-line options and usage patterns

--- a/book/src/environment-variables.md
+++ b/book/src/environment-variables.md
@@ -283,6 +283,13 @@ export RELEASAURUS_FORGE=github
 releasaurus release-pr --repo "https://github.com/owner/repo"
 ```
 
+**Note**: When `--repo` (or `RELEASAURUS_REPO`) points at a recognized
+cloud host — `github.com`, `gitlab.com`, `gitea.com`, `codeberg.org`,
+or `dev.azure.com` — the forge is inferred from the URL and neither
+the flag nor the variable is required. Self-hosted instances still
+need an explicit forge. See
+[Automatic forge inference](./commands.md#automatic-forge-inference).
+
 ### `RELEASAURUS_REPO`
 
 **Purpose**: Default value for `--repo`. The repository URL releasaurus

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ name = "releasaurus"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive", "env"] }
 color-eyre.workspace = true
 git-url-parse = "0.6.0"
 log.workspace = true

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -79,7 +79,10 @@ pub struct ForgeArgs {
 
 impl ForgeArgs {
     pub async fn forge(&self) -> Result<Box<dyn Forge>> {
-        if let Some(forge_type) = self.forge.as_ref()
+        let inferred_forge = self
+            .forge
+            .or_else(|| self.repo.as_deref().and_then(infer_forge_from_url));
+        if let Some(forge_type) = inferred_forge.as_ref()
             && let Some(git_url) = self.repo.as_ref()
         {
             let forge: Box<dyn Forge> = match forge_type {
@@ -166,9 +169,15 @@ impl ForgeArgs {
             };
 
             Ok(forge)
+        } else if self.repo.is_none() {
+            Err(ReleasaurusError::InvalidArgs(
+                "--repo is required (or set RELEASAURUS_REPO)".into(),
+            ))
         } else {
             Err(ReleasaurusError::InvalidArgs(
-                "both --forge and --repo are required".into(),
+                "could not infer --forge from repo URL; \
+                 pass --forge explicitly (or set RELEASAURUS_FORGE)."
+                    .into(),
             ))
         }
     }
@@ -191,6 +200,21 @@ impl ForgeArgs {
                 url: repo.clone(),
             }),
         )?))
+    }
+}
+
+/// Infer the forge type from a cloud-hosted repository URL. Returns
+/// `None` for self-hosted instances or unparseable URLs — those require
+/// `--forge` to be passed explicitly.
+fn infer_forge_from_url(url: &str) -> Option<ForgeType> {
+    let host = GitUrl::parse(url).ok()?.host()?.to_lowercase();
+    match host.as_str() {
+        "github.com" => Some(ForgeType::Github),
+        "gitlab.com" => Some(ForgeType::Gitlab),
+        "gitea.com" => Some(ForgeType::Gitea),
+        "codeberg.org" => Some(ForgeType::Forgejo),
+        "dev.azure.com" => Some(ForgeType::AzureDevops),
+        _ => None,
     }
 }
 
@@ -635,10 +659,11 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn forge_args_errors_if_missing_forge_type() {
-        let repo = "https://github.com/github_owner/github_repo";
+    async fn forge_args_errors_if_missing_forge_type_and_url_unrecognized() {
+        // Self-hosted URLs can't be auto-detected; --forge must be explicit.
+        let repo = "https://git.self-hosted.example/owner/repo";
 
-        let token = SecretString::from("github_token");
+        let token = SecretString::from("token");
 
         let forge_args = ForgeArgs {
             forge: None,
@@ -657,6 +682,39 @@ mod tests {
                 assert!(matches!(err, ReleasaurusError::InvalidArgs(_)))
             }
         }
+    }
+
+    #[test]
+    fn infer_forge_recognizes_cloud_hosts() {
+        assert_eq!(
+            infer_forge_from_url("https://github.com/o/r"),
+            Some(ForgeType::Github),
+        );
+        assert_eq!(
+            infer_forge_from_url("https://gitlab.com/o/r"),
+            Some(ForgeType::Gitlab),
+        );
+        assert_eq!(
+            infer_forge_from_url("https://gitea.com/o/r"),
+            Some(ForgeType::Gitea),
+        );
+        assert_eq!(
+            infer_forge_from_url("https://codeberg.org/o/r"),
+            Some(ForgeType::Forgejo),
+        );
+        assert_eq!(
+            infer_forge_from_url("https://dev.azure.com/org/proj/_git/r"),
+            Some(ForgeType::AzureDevops),
+        );
+    }
+
+    #[test]
+    fn infer_forge_returns_none_for_self_hosted() {
+        assert_eq!(infer_forge_from_url("https://git.example.com/o/r"), None,);
+        assert_eq!(
+            infer_forge_from_url("https://gitlab.self-hosted.io/o/r"),
+            None,
+        );
     }
 
     #[tokio::test]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -55,18 +55,19 @@ pub struct Cli {
 #[derive(Debug, Clone, Args)]
 pub struct ForgeArgs {
     /// Targets a specific forge: github, gitlab, gitea, forgejo,
-    /// azure-devops, or local
-    #[arg(short, long, value_enum, global = true)]
+    /// azure-devops, or local. Falls back to env var: RELEASAURUS_FORGE
+    #[arg(short, long, value_enum, global = true, env = "RELEASAURUS_FORGE")]
     pub forge: Option<ForgeType>,
 
-    /// Repository URL
-    #[arg(short, long, global = true)]
+    /// Repository URL. Falls back to env var: RELEASAURUS_REPO
+    #[arg(short, long, global = true, env = "RELEASAURUS_REPO")]
     pub repo: Option<String>,
 
     /// Optional path to local repository. Performs local git operations for
     /// commit analysis, file updates, commits, tagging, pushing, and only uses
-    /// remote forge for PR and release creation
-    #[arg(long, global = true)]
+    /// remote forge for PR and release creation.
+    /// Falls back to env var: RELEASAURUS_LOCAL_PATH
+    #[arg(long, global = true, env = "RELEASAURUS_LOCAL_PATH")]
     pub local_path: Option<PathBuf>,
 
     /// Authentication token. Falls back to env vars:


### PR DESCRIPTION
## Summary

Cuts boilerplate from the CLI in two complementary ways:

- **Env-var fallbacks** for `--forge`, `--repo`, and `--local-path` via
  `RELEASAURUS_FORGE`, `RELEASAURUS_REPO`, and `RELEASAURUS_LOCAL_PATH`
  — matches the existing `RELEASAURUS_DEBUG` / `RELEASAURUS_DRY_RUN`
  convention so users can set defaults once per environment.
- **Auto-inferred `--forge`** when `--repo` points at a recognized
  cloud host (`github.com`, `gitlab.com`, `gitea.com`, `codeberg.org`,
  `dev.azure.com`). Self-hosted instances still require `--forge`
  explicitly; the error message now spells out which hosts are
  auto-detected.

Together these let a typical cloud-host invocation shrink to:

    releasaurus release-pr --repo "https://github.com/owner/repo"

…or, with `RELEASAURUS_REPO` exported, just:

    releasaurus release-pr

## Changes

- `crates/cli/src/cli.rs` — add `env =` attributes to the three flags;
  add `infer_forge_from_url` helper and wire it into `ForgeArgs::forge`;
  update the "missing forge" error to mention auto-detection.
- `book/src/environment-variables.md` — document the three new
  variables under a new *Forge Selection* section; note that inference
  makes the forge variable optional for cloud hosts.
- `book/src/commands.md` — add *Automatic forge inference* subsection
  (cloud-host table + self-hosted caveat) and an env-var pointer under
  Platform Selection.

## Tests

- `infer_forge_recognizes_cloud_hosts` — covers all five supported hosts.
- `infer_forge_returns_none_for_self_hosted` — confirms unrecognized
  hosts fall through to the explicit-`--forge` error path.
- Renamed `forge_args_errors_if_missing_forge_type` →
  `..._and_url_unrecognized` to make the self-hosted intent explicit.
