### PR TITLE
feat(azure): OAuth bearer auth + clearer non-JSON error

### DIFF
--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -5,7 +5,10 @@
 //! `create_release` method below is a deliberate no-op that logs at
 //! info level; tags and the changelog commit are pushed normally.
 use async_trait::async_trait;
-use base64::{Engine, prelude::BASE64_STANDARD};
+use base64::{
+    Engine,
+    prelude::{BASE64_STANDARD, BASE64_URL_SAFE_NO_PAD},
+};
 use chrono::DateTime;
 use color_eyre::eyre::ContextCompat;
 use log::{info, warn};
@@ -113,11 +116,16 @@ impl AzureDevops {
 
         let mut headers = HeaderMap::new();
 
-        // Azure DevOps PAT auth: Basic base64(":{PAT}") with an empty username.
-        let basic = BASE64_STANDARD
-            .encode(format!(":{}", token.expose_secret()).as_bytes());
-        let token_value =
-            HeaderValue::from_str(format!("Basic {}", basic).as_str())?;
+        // Azure DevOps accepts either a PAT (Basic base64(":{PAT}")) or an
+        // OAuth bearer (typically a pipeline System.AccessToken, which is a
+        // signed JWT). Detect the JWT shape to pick the scheme.
+        let token_value = if looks_like_jwt(token.expose_secret()) {
+            HeaderValue::from_str(&format!("Bearer {}", token.expose_secret()))?
+        } else {
+            let basic = BASE64_STANDARD
+                .encode(format!(":{}", token.expose_secret()).as_bytes());
+            HeaderValue::from_str(&format!("Basic {}", basic))?
+        };
         headers.append("Authorization", token_value);
         headers.append("Accept", HeaderValue::from_static("application/json"));
 
@@ -449,6 +457,34 @@ fn normalize_path(path: &str) -> String {
     } else {
         format!("/{trimmed}")
     }
+}
+
+/// Returns `true` if `token` has the structural shape of a JWT (RFC 7519):
+/// three base64url segments separated by dots, where the first segment
+/// decodes to a JSON object containing an `alg` field. Used to distinguish
+/// an Azure DevOps OAuth bearer (e.g. pipeline `System.AccessToken`) from a
+/// PAT, which is an opaque base32-style string.
+fn looks_like_jwt(token: &str) -> bool {
+    // Fast path: every JWT header begins with `{"`, which base64url-encodes
+    // to `eyJ`. Skip the parse work for anything that can't be one.
+    if !token.starts_with("eyJ") {
+        return false;
+    }
+    let mut parts = token.split('.');
+    let (Some(header), Some(_), Some(_), None) =
+        (parts.next(), parts.next(), parts.next(), parts.next())
+    else {
+        return false;
+    };
+    let Ok(header_bytes) = BASE64_URL_SAFE_NO_PAD.decode(header) else {
+        return false;
+    };
+    let Ok(header_json) =
+        serde_json::from_slice::<serde_json::Value>(&header_bytes)
+    else {
+        return false;
+    };
+    header_json.get("alg").is_some()
 }
 
 #[async_trait]
@@ -947,5 +983,53 @@ mod tests {
     fn strip_refs_tags_removes_prefix() {
         assert_eq!(strip_refs_tags("refs/tags/v1.0.0"), "v1.0.0");
         assert_eq!(strip_refs_tags("v1.0.0"), "v1.0.0");
+    }
+
+    fn make_jwt(header_json: &str, payload_json: &str) -> String {
+        let h = BASE64_URL_SAFE_NO_PAD.encode(header_json.as_bytes());
+        let p = BASE64_URL_SAFE_NO_PAD.encode(payload_json.as_bytes());
+        format!("{h}.{p}.signature")
+    }
+
+    #[test]
+    fn looks_like_jwt_accepts_signed_token() {
+        let token =
+            make_jwt(r#"{"alg":"RS256","typ":"JWT"}"#, r#"{"sub":"x"}"#);
+        assert!(looks_like_jwt(&token));
+    }
+
+    #[test]
+    fn looks_like_jwt_rejects_pat() {
+        // Azure DevOps PATs are ~52 alphanumeric chars, no dots.
+        assert!(!looks_like_jwt(
+            "abcdefghijklmnopqrstuvwxyz234567abcdefghijklmnopqrst"
+        ));
+    }
+
+    #[test]
+    fn looks_like_jwt_rejects_wrong_segment_count() {
+        let two_parts = "eyJhbGciOiJIUzI1NiJ9.payload";
+        assert!(!looks_like_jwt(two_parts));
+        let four_parts = "eyJhbGciOiJIUzI1NiJ9.a.b.c";
+        assert!(!looks_like_jwt(four_parts));
+    }
+
+    #[test]
+    fn looks_like_jwt_rejects_header_without_alg() {
+        let token = make_jwt(r#"{"typ":"JWT"}"#, r#"{}"#);
+        assert!(!looks_like_jwt(&token));
+    }
+
+    #[test]
+    fn looks_like_jwt_rejects_non_eyj_prefix() {
+        // Three dot-separated parts but header doesn't base64url-decode to
+        // a JSON object — fast-path rejection.
+        assert!(!looks_like_jwt("foo.bar.baz"));
+    }
+
+    #[test]
+    fn looks_like_jwt_rejects_invalid_base64_header() {
+        // Starts with "eyJ" but contains an illegal base64url character.
+        assert!(!looks_like_jwt("eyJ!!!.payload.sig"));
     }
 }

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -146,8 +146,7 @@ impl AzureDevops {
             .query_pairs_mut()
             .append_pair("api-version", API_VERSION);
         let response = client.get(repo_url).send().await?;
-        let result = response.error_for_status()?;
-        let repo: AzureRepo = result.json().await?;
+        let repo: AzureRepo = read_json(response).await?;
         let default_branch = repo
             .default_branch
             .as_deref()
@@ -198,8 +197,7 @@ impl AzureDevops {
         if response.status() == StatusCode::NOT_FOUND {
             return Ok(false);
         }
-        let body: serde_json::Value =
-            response.error_for_status()?.json().await?;
+        let body: serde_json::Value = read_json(response).await?;
         let base = body.get("baseCommit").and_then(|v| v.as_str());
         let common = body.get("commonCommit").and_then(|v| v.as_str());
         match (base, common) {
@@ -215,8 +213,7 @@ impl AzureDevops {
             .append_pair("api-version", API_VERSION)
             .append_pair("filter", &format!("heads/{branch}"));
         let response = self.client.get(refs_url).send().await?;
-        let result = response.error_for_status()?;
-        let refs: AzureList<AzureRef> = result.json().await?;
+        let refs: AzureList<AzureRef> = read_json(response).await?;
         let want = format!("refs/heads/{branch}");
         refs.value
             .into_iter()
@@ -296,8 +293,7 @@ impl AzureDevops {
             }],
         };
         let response = self.client.post(url).json(&body).send().await?;
-        let result = response.error_for_status()?;
-        let push: PushResponse = result.json().await?;
+        let push: PushResponse = read_json(response).await?;
         push.commits
             .into_iter()
             .next()
@@ -312,7 +308,7 @@ impl AzureDevops {
     async fn get_pr_by_id(&self, pr_id: u64) -> Result<AzurePullRequest> {
         let url = self.endpoint(&format!("pullrequests/{pr_id}"))?;
         let response = self.client.get(url).send().await?;
-        let pr: AzurePullRequest = response.error_for_status()?.json().await?;
+        let pr: AzurePullRequest = read_json(response).await?;
         Ok(pr)
     }
 
@@ -336,8 +332,7 @@ impl AzureDevops {
                 .append_pair("$top", &page_size.to_string())
                 .append_pair("$skip", &skip.to_string());
             let response = self.client.get(url).send().await?;
-            let result = response.error_for_status()?;
-            let list: AzureList<AzurePullRequest> = result.json().await?;
+            let list: AzureList<AzurePullRequest> = read_json(response).await?;
             let count = list.value.len() as u64;
             found.extend(list.value);
             if count < page_size {
@@ -366,9 +361,8 @@ impl AzureDevops {
         if response.status() == StatusCode::NOT_FOUND {
             return Ok(vec![]);
         }
-        let result = response.error_for_status()?;
         let list: AzureList<crate::forge::azure_devops::types::AzureLabel> =
-            result.json().await?;
+            read_json(response).await?;
         Ok(list.value)
     }
 
@@ -406,7 +400,7 @@ impl AzureDevops {
         url.query_pairs_mut()
             .append_pair("api-version", API_VERSION);
         let response = self.client.get(url).send().await?;
-        let commit: AzureCommit = response.error_for_status()?.json().await?;
+        let commit: AzureCommit = read_json(response).await?;
         Ok(DateTime::parse_from_rfc3339(&commit.author.date)
             .map(|t| t.timestamp())
             .unwrap_or(0))
@@ -425,8 +419,7 @@ impl AzureDevops {
         if response.status() == StatusCode::NOT_FOUND {
             return Ok(vec![]);
         }
-        let changes: AzureCommitChanges =
-            response.error_for_status()?.json().await?;
+        let changes: AzureCommitChanges = read_json(response).await?;
         Ok(changes
             .changes
             .into_iter()
@@ -457,6 +450,26 @@ fn normalize_path(path: &str) -> String {
     } else {
         format!("/{trimmed}")
     }
+}
+
+/// Parses a JSON body from `response`, wrapping parse failures with an
+/// actionable hint. Azure DevOps responds to invalid or under-privileged
+/// tokens with an HTML sign-in page (HTTP 203 + `text/html`), which slips
+/// past `error_for_status` and then fails JSON parsing — the hint points
+/// users at the likely auth issue rather than a bare serde error.
+async fn read_json<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T> {
+    let response = response.error_for_status()?;
+    let status = response.status();
+    let url = response.url().clone();
+    response.json::<T>().await.map_err(|err| {
+        ReleasaurusError::forge(format!(
+            "failed to parse Azure DevOps response from {url} \
+             (HTTP {status}): {err} — the configured token might be \
+             invalid or lack access to this repository"
+        ))
+    })
 }
 
 /// Returns `true` if `token` has the structural shape of a JWT (RFC 7519):
@@ -570,8 +583,7 @@ impl Forge for AzureDevops {
             .append_pair("api-version", API_VERSION)
             .append_pair("filter", &format!("tags/{tag}"));
         let response = self.client.get(url).send().await?;
-        let result = response.error_for_status()?;
-        let refs: AzureList<AzureRef> = result.json().await?;
+        let refs: AzureList<AzureRef> = read_json(response).await?;
         let want = format!("refs/tags/{tag}");
         let r = refs.value.into_iter().find(|r| r.name == want).ok_or_else(
             || ReleasaurusError::forge(format!("tag not found: {tag}")),
@@ -594,8 +606,7 @@ impl Forge for AzureDevops {
             .append_pair("api-version", API_VERSION)
             .append_pair("filter", "tags/");
         let response = self.client.get(url).send().await?;
-        let result = response.error_for_status()?;
-        let refs: AzureList<AzureRef> = result.json().await?;
+        let refs: AzureList<AzureRef> = read_json(response).await?;
         let mut tags = vec![];
         for (count, r) in refs.value.into_iter().enumerate() {
             if count >= self.tag_search_depth {
@@ -659,8 +670,7 @@ impl Forge for AzureDevops {
                 );
 
             let response = self.client.get(url).send().await?;
-            let result = response.error_for_status()?;
-            let list: AzureList<AzureCommit> = result.json().await?;
+            let list: AzureList<AzureCommit> = read_json(response).await?;
             let returned = list.value.len() as u64;
 
             for c in list.value.into_iter() {
@@ -890,8 +900,7 @@ impl Forge for AzureDevops {
         };
         let url = self.endpoint("pullrequests")?;
         let response = self.client.post(url).json(&body).send().await?;
-        let result = response.error_for_status()?;
-        let pr: AzurePullRequest = result.json().await?;
+        let pr: AzurePullRequest = read_json(response).await?;
         Ok(PullRequest {
             number: pr.pull_request_id,
             sha: pr


### PR DESCRIPTION
## Summary
- Detect JWT-shaped tokens at construction time and use `Authorization: Bearer <token>` instead of Basic auth. This lets Azure Pipelines use `System.AccessToken` (an OAuth JWT) directly, without minting a PAT. PAT users see no change — detection is a fast-path `starts_with("eyJ")` plus a strict RFC 7519 header/`alg` validation, and falls through to Basic for anything else.
- Route every JSON read through a `read_json` helper that checks `Content-Type` and returns a `ForgeError` naming the URL, status, content-type, body preview, and an HTML-specific hint. Azure DevOps serves an HTML sign-in page (sometimes with a 2xx status) on auth failure, which previously surfaced as the cryptic `error decoding response body`.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] `cargo test -p releasaurus-core --lib forge::azure_devops` — 18 tests pass (including 6 new ones for `looks_like_jwt`)