### PR TITLE
docs: run gitlab release then release-pr in one sequential job

### DIFF
--- a/book/src/ci-cd-integration.md
+++ b/book/src/ci-cd-integration.md
@@ -32,27 +32,33 @@ option with a reference to your defined variable, e.g.
 - `api` (full API access)
 - `write_repository` (repository write access)
 
+Run both commands in a **single job** so they execute sequentially:
+`release` first (it tags any merged release PR), then `release-pr` (it
+opens or updates the next one). This matches the order used by the
+GitHub, Gitea, and Forgejo action. Defining them as two separate jobs
+with the same `rules:` lets GitLab schedule them in the same stage
+concurrently, which races: `release-pr` may observe a merged but
+not-yet-tagged release PR and abort with
+`must finish previous release first`.
+
 ### Example
 
 ```yaml
-publish-release:
+releasaurus:
   image:
     name: rgonnella/releasaurus:vX.X.X
     entrypoint: [""]
   script:
-    # Assumes use of $GITLAB_TOKEN var for token authentication
+    # Assumes a CI/CD variable named $GITLAB_TOKEN for authentication.
+    # Alternatively, pass `--token $RELEASE_TOKEN` to each command.
+    #
+    # Run `release` BEFORE `release-pr`: `release` tags any merged
+    # release PR, then `release-pr` opens/updates the next one. The
+    # reverse order (or two parallel jobs) lets `release-pr` see a
+    # merged-but-untagged release PR and abort with
+    # "must finish previous release first".
     - releasaurus release --forge gitlab --repo $CI_PROJECT_URL
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-
-release-pr:
-  image:
-    name: rgonnella/releasaurus:vX.X.X
-    entrypoint: [""]
-  script:
-    # Uses custom var for token authentication
-    - releasaurus release-pr --forge gitlab \
-        --repo $CI_PROJECT_URL --token $RELEASE_TOKEN
+    - releasaurus release-pr --forge gitlab --repo $CI_PROJECT_URL
   rules:
     - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
 ```


### PR DESCRIPTION
## Problem

The GitLab CI example defines `publish-release` and `release-pr` as **two separate jobs** with identical `rules:` and no `stage:`/`needs:`. GitLab therefore places them in the same stage and runs them **concurrently**.

On the push that merges a release PR, this races:

- `release` (publish) starts tagging the merged release PR;
- `release-pr`, running in parallel, observes the merged-but-untagged release PR first and aborts:

```
Error: Found pending release (PR #NN) on branch 'releasaurus-release-main'
that has not been tagged yet: cannot continue, must finish previous release first
```

The release itself succeeds (tag + release object get created), but the `release-pr` job fails the pipeline every release cycle. I hit this on a real GitLab project; the publish job and the failing `release-pr` job were timestamped within the same second of the same pipeline.

## Fix

Collapse the two jobs into a single job that runs `release` then `release-pr` **sequentially**. This is the same order used by:

- the official action entrypoint (`releasaurus release` → `releasaurus release-pr`, under `set -eo pipefail`), and
- releasaurus's own dogfooded `.github/workflows/release.yml` (step `release` → step `release-pr`).

Running `release` first means any merged release PR is tagged before `release-pr` runs, so `release-pr` never sees an untagged merged PR. A GitLab `script:` aborts on the first non-zero command, giving the same fail-fast behavior as the action's `set -e`. `release` is a no-op (exit 0) on non-release commits, so a single job is safe to run on every push to the default branch.

Only the GitLab section changes; prose + an inline comment explain why the ordering and single job matter.

## Note (not changed here)

The **Azure Pipelines** example runs `release-pr` *before* `release` within one job. By the same reasoning that's the risky order — on a release-PR merge, `release-pr` would run before the merged PR is tagged. I left it alone to keep this PR scoped to GitLab, but flagging it in case you'd like it reordered too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)