### PR TITLE
fix: fixes issue with sha_compare_links and release timestamps

### DIFF
--- a/crates/core/src/analyzer.rs
+++ b/crates/core/src/analyzer.rs
@@ -145,7 +145,15 @@ impl<'a> Analyzer<'a> {
             release.include_author = true;
         }
 
-        // loop commits in reverse oldest -> newest
+        // commits are ordered newest-first; the release sha and timestamp
+        // come from the newest commit in the range regardless of any
+        // conventional-commit filtering below, so compare links span the
+        // entire range
+        if let Some(newest) = commits.first() {
+            release.sha = newest.id.clone();
+            release.timestamp = newest.timestamp;
+        }
+
         for forge_commit in commits.iter() {
             if self
                 .config

--- a/crates/core/src/analyzer/helpers.rs
+++ b/crates/core/src/analyzer/helpers.rs
@@ -16,8 +16,8 @@ use crate::{
 static EXTRA_NEW_LINES_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
 
-/// Add a parsed commit to the release and update the release SHA and
-/// timestamp to reflect the latest commit.
+/// Parse a forge commit and, if it passes the configured filters, add it
+/// to the release's commit list.
 pub fn update_release_with_commit(
     group_parser: &GroupParser,
     release: &mut Release,
@@ -28,8 +28,6 @@ pub fn update_release_with_commit(
     if let Some(commit) =
         Commit::parse_forge_commit(group_parser, forge_commit, config)
     {
-        let commit_id = commit.id.to_string();
-
         log::info!(
             "processing commit: {} : {}",
             commit.short_id,
@@ -38,10 +36,6 @@ pub fn update_release_with_commit(
 
         // add commit to release
         release.commits.push(commit);
-        // set release commit - this will keep getting updated until we
-        // get to the last commit in the release, which will be a tag
-        release.sha = commit_id;
-        release.timestamp = forge_commit.timestamp;
     }
 }
 
@@ -131,12 +125,7 @@ mod tests {
 
         // Should have 1 commit (merge commit 2 is filtered by default skip_merge_commits: true)
         assert_eq!(release.commits.len(), 1);
-
-        // SHA should be from the last commit
-        assert_eq!(release.sha, "commit1");
-
-        // Timestamp should be from the last commit
-        assert_eq!(release.timestamp, 1640995200);
+        assert_eq!(release.commits[0].id, "commit1");
     }
 
     #[test]

--- a/crates/core/src/analyzer/tests/basic_versioning.rs
+++ b/crates/core/src/analyzer/tests/basic_versioning.rs
@@ -9,6 +9,7 @@
 //! - Multiple commits
 
 use semver::Version as SemVer;
+use url::Url;
 
 use crate::{
     analyzer::{Analyzer, config::AnalyzerConfig},
@@ -210,6 +211,103 @@ fn test_analyze_multiple_commits() {
     assert_eq!(release.commits.len(), 3);
     // Should bump minor due to features
     assert_eq!(release.tag.semver, SemVer::parse("1.1.0").unwrap());
+}
+
+#[test]
+fn test_sha_compare_link_uses_newest_commit() {
+    let config = AnalyzerConfig {
+        compare_link_base_url: Some(
+            Url::parse("https://example.com/compare/").unwrap(),
+        ),
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let current_tag = Tag {
+        sha: "old123".to_string(),
+        name: "1.0.0".to_string(),
+        semver: SemVer::parse("1.0.0").unwrap(),
+        ..Tag::default()
+    };
+
+    // commits arrive newest-first, matching the Forge::get_commits contract
+    let commits = vec![
+        ForgeCommit {
+            id: "newest999".to_string(),
+            message: "fix: latest fix".to_string(),
+            timestamp: 3000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "middle555".to_string(),
+            message: "fix: another fix".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "oldest111".to_string(),
+            message: "fix: first fix after release".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
+
+    let release = result.unwrap();
+    assert_eq!(release.sha, "newest999");
+    assert_eq!(release.timestamp, 3000);
+    assert_eq!(
+        release.sha_compare_link,
+        "https://example.com/compare/1.0.0...newest999"
+    );
+}
+
+#[test]
+fn test_sha_compare_link_spans_filtered_newest_commit() {
+    let config = AnalyzerConfig {
+        compare_link_base_url: Some(
+            Url::parse("https://example.com/compare/").unwrap(),
+        ),
+        ..AnalyzerConfig::default()
+    };
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let current_tag = Tag {
+        sha: "old123".to_string(),
+        name: "1.0.0".to_string(),
+        semver: SemVer::parse("1.0.0").unwrap(),
+        ..Tag::default()
+    };
+
+    // newest commit is a merge commit, filtered from the changelog by
+    // default, but the compare link should still span the whole range
+    let commits = vec![
+        ForgeCommit {
+            id: "merge999".to_string(),
+            message: "Merge pull request #42".to_string(),
+            merge_commit: true,
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "fix111".to_string(),
+            message: "fix: a bug fix".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let result = analyzer.analyze(commits, Some(current_tag)).unwrap();
+
+    let release = result.unwrap();
+    assert_eq!(release.commits.len(), 1);
+    assert_eq!(release.sha, "merge999");
+    assert_eq!(release.timestamp, 2000);
+    assert_eq!(
+        release.sha_compare_link,
+        "https://example.com/compare/1.0.0...merge999"
+    );
 }
 
 #[test]

--- a/crates/core/src/forge/traits.rs
+++ b/crates/core/src/forge/traits.rs
@@ -67,7 +67,8 @@ pub trait Forge: Any + Send + Sync {
         branch: &str,
     ) -> Result<Vec<Tag>>;
     /// Fetch commits for a package path, optionally starting from a specific
-    /// SHA.
+    /// SHA. Commits are returned newest-first; callers (e.g. the analyzer)
+    /// rely on this ordering.
     async fn get_commits(
         &self,
         branch: Option<String>,

--- a/crates/core/src/orchestrator/commit_fetcher.rs
+++ b/crates/core/src/orchestrator/commit_fetcher.rs
@@ -247,7 +247,8 @@ impl CommitFetcher {
         }
 
         let mut commits = cache.iter().cloned().collect::<Vec<ForgeCommit>>();
-        commits.sort_by_key(|c| c.timestamp);
+        // restore the newest-first order guaranteed by Forge::get_commits
+        commits.sort_by_key(|c| std::cmp::Reverse(c.timestamp));
         Ok(commits)
     }
 

--- a/crates/core/src/orchestrator/package_processor.rs
+++ b/crates/core/src/orchestrator/package_processor.rs
@@ -191,7 +191,9 @@ impl PackageProcessor {
                         .into_iter()
                         .filter(|c| !commit_hash_set.contains(c)),
                 );
-                commits.sort_by_key(|c| c.timestamp);
+                // restore the newest-first order guaranteed by
+                // Forge::get_commits
+                commits.sort_by_key(|c| std::cmp::Reverse(c.timestamp));
             }
 
             prepared_packages.push(PreparedPackage {

--- a/crates/core/src/orchestrator/package_processor/tests/prepare.rs
+++ b/crates/core/src/orchestrator/package_processor/tests/prepare.rs
@@ -226,9 +226,9 @@ async fn aggregate_prereleases_enabled_and_graduating_merges_commits() {
     assert_eq!(prepared.len(), 1);
     // historical (500) and current (2000); current already in window
     assert_eq!(prepared[0].commits.len(), 2);
-    // sorted by timestamp: historical first
-    assert_eq!(prepared[0].commits[0].id, "historical");
-    assert_eq!(prepared[0].commits[1].id, "current");
+    // sorted newest-first: current first
+    assert_eq!(prepared[0].commits[0].id, "current");
+    assert_eq!(prepared[0].commits[1].id, "historical");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Description

Previously release.sha and release.timestamp were incorrectly set to the oldest commit in the set of release commits. This commit correctly sets them to the newest commit in the release commits set. This fixes the sha_compare_link used in PRs and the release timestamp displayed in changelogs, releases, and PRs

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)

