### PR TITLE
fix: remove trailing blank line from generated CHANGELOG

### DIFF
--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -224,7 +224,7 @@ impl LocalRepo {
                         full_path.display(),
                         existing_content.len()
                     );
-                    content = format!("{content}{existing_content}");
+                    content = format!("{content}\n{existing_content}");
                 } else {
                     log::debug!(
                         "local_commit: no existing file at {}, creating new",

--- a/crates/core/src/orchestrator/package_processor.rs
+++ b/crates/core/src/orchestrator/package_processor.rs
@@ -580,7 +580,7 @@ impl PackageProcessor {
                 .join("CHANGELOG.md")
                 .to_string_lossy()
                 .to_string(),
-            content: format!("{}\n\n", target.notes),
+            content: format!("{}\n", target.notes),
             update_type: FileUpdateType::Prepend,
         }
     }


### PR DESCRIPTION
## Problem

When releasaurus generates or updates a `CHANGELOG.md`, it produces a trailing blank line at the end of the file. This happens because `changelog_file_change` formats the content as `format!("{}\n\n", notes)` — two trailing newlines. On the very first release (no existing file), this becomes the entire file and leaves a trailing blank line. Subsequent releases prepend new content in front of that blank line, so it persists forever.

This conflicts with linters (e.g. `pre-commit`'s `end-of-file-fixer`) that enforce a single trailing newline on Markdown files. Every time releasaurus updates `CHANGELOG.md` in CI, the linter will want to strip the blank line on the developer's next local commit, causing an unnecessary fight between the two tools.

## Fix

Two minimal changes:

1. **`package_processor.rs`** — `changelog_file_change` now appends a single `\n` instead of `\n\n`.
2. **`local.rs`** — the `Prepend` logic in `local_commit` now inserts a `\n` between the new content and the existing file content.

Together these preserve the blank-line separator between consecutive release sections while eliminating the trailing blank line at the end of the file.

### Before
```
- last commit entry (Blair, Nicholas)
                                       ← trailing blank line
```

### After
```
- last commit entry (Blair, Nicholas)
                                       ← file ends here (single \n, no blank line)
```