### PR TITLE
fix: only filter Gitea release PRs by labels that exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +576,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -1208,6 +1236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,6 +1299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humansize"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1327,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1915,6 +1956,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2606,6 +2657,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -4243,6 +4295,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -54,6 +54,7 @@ mockall = "0.14.0"
 temp-env = "0.3.6"
 tempfile = "3.27.0"
 test-log = "0.2.20"
+wiremock = "0.6"
 
 [features]
 default = []

--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -190,6 +190,30 @@ impl Gitea {
         Ok(label)
     }
 
+    /// Returns the list of pending labels safe to filter on when
+    /// searching for release PRs.
+    ///
+    /// Gitea's issues endpoint silently discards non-existent label
+    /// names from the `labels` query parameter, which causes the
+    /// filter to match every issue. To prevent that, only return
+    /// labels that already exist in the repository. Missing labels
+    /// are created on demand by the PR-management code paths, so
+    /// there is nothing to filter on until they exist.
+    ///
+    /// Callers MUST skip the API query entirely when this returns an
+    /// empty list — issuing a request without any label filter would
+    /// match all issues.
+    async fn pending_labels_to_query(&self) -> Result<Vec<&'static str>> {
+        let all_labels = self.get_all_labels().await?;
+        let mut labels = vec![];
+        for candidate in [PENDING_LABEL, LEGACY_PENDING_LABEL] {
+            if all_labels.iter().any(|l| l.name == candidate) {
+                labels.push(candidate);
+            }
+        }
+        Ok(labels)
+    }
+
     /// Returns true if `tag_sha` is an ancestor of `branch`. Uses the
     /// Gitea compare API: `total_commits == 0` when base=branch, head=tag
     /// means the tag has no commits that the branch doesn't, so the tag
@@ -612,7 +636,7 @@ impl Forge for Gitea {
         // Try the current label first, then fall back to the
         // legacy single-colon label for users upgrading from an
         // older version of releasaurus.
-        for pending_label in [PENDING_LABEL, LEGACY_PENDING_LABEL] {
+        for pending_label in self.pending_labels_to_query().await? {
             if !found_prs.is_empty() {
                 break;
             }
@@ -693,7 +717,7 @@ impl Forge for Gitea {
         // Try the current label first, then fall back to the
         // legacy single-colon label for users upgrading from an
         // older version of releasaurus.
-        for pending_label in [PENDING_LABEL, LEGACY_PENDING_LABEL] {
+        for pending_label in self.pending_labels_to_query().await? {
             if !found_prs.is_empty() {
                 break;
             }
@@ -869,5 +893,166 @@ impl Forge for Gitea {
         response.error_for_status()?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::SecretString;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::forge::config::{RepoUrl, Scheme};
+    use crate::forge::traits::Forge;
+
+    use super::Gitea;
+    use crate::forge::request::GetPrRequest;
+
+    /// Build a [`RepoUrl`] pointing at `server` with the given owner/name.
+    fn make_repo_url(server: &MockServer, owner: &str, name: &str) -> RepoUrl {
+        let uri = server.uri();
+        let parsed = url::Url::parse(&uri).expect("mock server uri is valid");
+        let host = parsed.host_str().unwrap_or("127.0.0.1").to_string();
+        let port = parsed.port();
+        RepoUrl {
+            scheme: Scheme::Http,
+            host,
+            owner: owner.to_string(),
+            name: name.to_string(),
+            path: format!("/{owner}/{name}"),
+            port,
+            token: None,
+        }
+    }
+
+    /// Construct a `Gitea` instance pointed at `server`.
+    ///
+    /// Mounts the repo-metadata mock (required by `Gitea::new`) before
+    /// calling the constructor. The caller is responsible for mounting
+    /// any additional mocks.
+    async fn make_gitea(server: &MockServer, owner: &str, name: &str) -> Gitea {
+        let repo_path = format!("/api/v1/repos/{owner}/{name}/");
+        Mock::given(method("GET"))
+            .and(path(&repo_path))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(
+                    serde_json::json!({"default_branch": "main"}),
+                ),
+            )
+            .mount(server)
+            .await;
+
+        let url = make_repo_url(server, owner, name);
+        Gitea::new(url, Some(SecretString::from("dummy-token")), None)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn pending_labels_to_query_returns_empty_when_no_pending_labels_exist()
+     {
+        let server = MockServer::start().await;
+        let gitea = make_gitea(&server, "foo", "bar").await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repos/foo/bar/labels"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!([
+                    {
+                        "id": 1,
+                        "name": "releasaurus::tagged",
+                        "color": "a47dab",
+                        "description": "",
+                        "exclusive": false,
+                        "is_archived": false
+                    }
+                ]),
+            ))
+            .mount(&server)
+            .await;
+
+        let labels = gitea.pending_labels_to_query().await.unwrap();
+
+        assert!(
+            labels.is_empty(),
+            "expected empty vec when no pending labels exist, got: {labels:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_merged_release_pr_skips_query_when_no_pending_labels_exist() {
+        let server = MockServer::start().await;
+        let gitea = make_gitea(&server, "foo", "bar").await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repos/foo/bar/labels"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!([
+                    {
+                        "id": 1,
+                        "name": "releasaurus::tagged",
+                        "color": "a47dab",
+                        "description": "",
+                        "exclusive": false,
+                        "is_archived": false
+                    }
+                ]),
+            ))
+            .mount(&server)
+            .await;
+
+        // The /issues endpoint must never be called when there are no
+        // pending labels to filter on.
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repos/foo/bar/issues"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!([])),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let req = GetPrRequest {
+            head_branch: "release-branch".to_string(),
+            base_branch: "main".to_string(),
+        };
+
+        let result = gitea.get_merged_release_pr(req).await.unwrap();
+
+        assert!(
+            result.is_none(),
+            "expected None when no pending labels exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_labels_to_query_includes_legacy_when_present() {
+        let server = MockServer::start().await;
+        let gitea = make_gitea(&server, "foo", "bar").await;
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/repos/foo/bar/labels"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!([
+                    {
+                        "id": 2,
+                        "name": "releasaurus:pending",
+                        "color": "a47dab",
+                        "description": "",
+                        "exclusive": false,
+                        "is_archived": false
+                    }
+                ]),
+            ))
+            .mount(&server)
+            .await;
+
+        let labels = gitea.pending_labels_to_query().await.unwrap();
+
+        assert_eq!(
+            labels,
+            vec!["releasaurus:pending"],
+            "expected only the legacy label to be returned"
+        );
     }
 }


### PR DESCRIPTION
Gitea's `/repos/{owner}/{repo}/issues` endpoint silently discards
non-existent label names from the `labels` query parameter. When the
expected pending label is missing from a repository, the filter is
dropped entirely and every closed PR is returned — releasaurus then
re-processes already-tagged release PRs and fails with HTTP 409 on
tag creation.

This restricts the pending-label filter in `get_open_release_pr` and
`get_merged_release_pr` to labels that actually exist in the
repository. If no candidate label exists, the API query is skipped
entirely so an unfiltered request is never issued. Missing labels
continue to be created on demand by the existing PR-management code
paths.

Adds three `wiremock`-based unit tests covering: empty result when no
pending labels exist, the issues endpoint not being called in that
case, and legacy single-colon label inclusion when present.