### PR TITLE
fix: fixes issue in gitea is_ancestor_of_branch check

### DIFF
--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -231,6 +231,10 @@ impl Gitea {
         ))?;
         let request = self.client.get(compare_url).build()?;
         let response = self.client.execute(request).await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            // dangling commit
+            return Ok(false);
+        }
         let result: serde_json::Value =
             response.error_for_status()?.json().await?;
         Ok(result["total_commits"].as_u64() == Some(0))


### PR DESCRIPTION
## Description

Ensures that 404 responses are interpretted as NOT ancestor of branch and properly returns "false". This handles the cases when the commit has been deleted or overwritten - dangling commit

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)
