### PR TITLE
doc: updates documentation for gitea/forgejo action issue

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -17,6 +17,25 @@ Actions and Gitea Actions workflows.
 | **GitHub** (classic)      | `repo`                                                                                                                                    |
 | **GitHub** (fine-grained) | Contents, Issues, Pull requests — all read & write. Add Actions/Workflows read & write only if using the Action to modify workflow files. |
 
+## Authentication on Gitea / Forgejo Actions
+
+> ⚠️ **Pass your token with `--token`, not `env: FORGEJO_TOKEN` /
+> `env: GITEA_TOKEN`, on Gitea and Forgejo runners (including
+> Codeberg).**
+>
+> These runners automatically inject an ephemeral, limited per-job
+> token into the environment under `GITHUB_TOKEN`, `GITEA_TOKEN`, and
+> `FORGEJO_TOKEN`. A token you set via step `env:` under one of those
+> names can be shadowed by the runner's value, so Releasaurus ends up
+> using the limited token. It can read the repo (so the run starts
+> fine) but cannot open a pull request on a **private** repo —
+> Gitea/Forgejo return a `404 Not Found` on `.../pulls`. Public repos
+> hide the issue.
+>
+> Passing `--token ${{ secrets.RELEASE_TOKEN }}` takes precedence over
+> any `*_TOKEN` environment variable and avoids the collision. See the
+> [example below](#gitea--forgejo-actions).
+
 ## Examples
 
 ### Basic Release Workflow
@@ -83,6 +102,38 @@ jobs:
             --local-path ${{ github.workspace }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Gitea / Forgejo Actions
+
+On Gitea and Forgejo runners (including Codeberg), pass the token with
+`--token` rather than `env: FORGEJO_TOKEN` / `env: GITEA_TOKEN` — see
+[the authentication note above][auth-note] for why.
+
+[auth-note]: #authentication-on-gitea--forgejo-actions
+
+```yaml
+name: Release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # required for --local-path
+      - name: Create Release PR
+        uses: robgonnella/releasaurus/action@vX.X.X
+        with:
+          command: release-pr
+          command_args: >-
+            --forge forgejo
+            --repo ${{ github.server_url }}/${{ github.repository }}
+            --token ${{ secrets.RELEASE_TOKEN }}
+            --local-path ${{ github.workspace }}
 ```
 
 ## Documentation

--- a/book/src/ci-cd-integration.md
+++ b/book/src/ci-cd-integration.md
@@ -30,6 +30,17 @@ Actions workflows. See the
 for inputs, usage examples, and fetch depth configuration for
 `--local-path`.
 
+> **Gitea / Forgejo runners (including Codeberg):** pass your token
+> with `--token ${{ secrets.RELEASE_TOKEN }}` rather than
+> `env: FORGEJO_TOKEN` / `env: GITEA_TOKEN`. These runners inject their
+> own limited per-job token under those variable names, which can
+> shadow your PAT and cause private-repo PR creation to fail with an
+> opaque `404 Not Found`. The `--token` flag takes precedence over any
+> `*_TOKEN` environment variable. See
+> [Gitea and Forgejo Actions: Injected Token Shadows Your PAT][token-limit].
+
+[token-limit]: ./commands.md#gitea-and-forgejo-actions-injected-token-shadows-your-pat
+
 ## GitLab CI
 
 Use the Releasaurus Docker image directly in your `.gitlab-ci.yml`.

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -271,6 +271,35 @@ avoid this. A patch to Forgejo to allow force pushing the release branch has
 been accepted and will be available in v16.
 <https://codeberg.org/forgejo/forgejo/pulls/12663>
 
+### Gitea and Forgejo Actions: Injected Token Shadows Your PAT
+
+Gitea and Forgejo Actions runners (including Codeberg) automatically
+inject an ephemeral, limited per-job token into the job environment
+under the names `GITHUB_TOKEN`, `GITEA_TOKEN`, and `FORGEJO_TOKEN`. If
+you supply your own token through one of those environment variables
+— for example `env: FORGEJO_TOKEN: ${{ secrets.RELEASE_TOKEN }}` — the
+runner's injected value can take precedence inside the action, and
+Releasaurus authenticates with the limited token instead of your PAT.
+
+That injected token can usually _read_ the repository, so startup
+succeeds, but it cannot create a pull request on a **private** repo.
+Gitea/Forgejo return `404 Not Found` for the unauthorized write
+against the `.../pulls` endpoint, which is easy to misread as a
+missing repository. Public repos hide the problem because reads are
+anonymous.
+
+**Fix:** pass your token on the command line with `--token` instead of
+through an environment variable. The `--token` flag takes precedence
+over any `*_TOKEN` environment variable, so it bypasses the injected
+value:
+
+```yaml
+command_args: >-
+  --forge forgejo
+  --repo ${{ github.server_url }}/${{ github.repository }}
+  --token ${{ secrets.RELEASE_TOKEN }}
+```
+
 ### Azure DevOps: Release Branch Requires "Allow rewriting history"
 
 When updating a release PR, Releasaurus resets the release branch to the


### PR DESCRIPTION
## Description

Documents issue and workaround in gitea / forgejo action runners where the injected action token overrides the user's step "env" token causing authentication issues

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [x] Documentation tested (if applicable)

## Related Issues

Relates to #331 
