### PR TITLE
feat: support token env vars prefixed with RELEASAURUS_

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -19,21 +19,25 @@ Actions and Gitea Actions workflows.
 
 ## Authentication on Gitea / Forgejo Actions
 
-> ⚠️ **Pass your token with `--token`, not `env: FORGEJO_TOKEN` /
-> `env: GITEA_TOKEN`, on Gitea and Forgejo runners (including
-> Codeberg).**
+> ⚠️ **On Gitea and Forgejo runners (including Codeberg), set your
+> token via `env: RELEASAURUS_FORGEJO_TOKEN` /
+> `env: RELEASAURUS_GITEA_TOKEN` — not the bare `FORGEJO_TOKEN` /
+> `GITEA_TOKEN`.**
 >
 > These runners automatically inject an ephemeral, limited per-job
 > token into the environment under `GITHUB_TOKEN`, `GITEA_TOKEN`, and
 > `FORGEJO_TOKEN`. A token you set via step `env:` under one of those
-> names can be shadowed by the runner's value, so Releasaurus ends up
-> using the limited token. It can read the repo (so the run starts
+> bare names can be shadowed by the runner's value, so Releasaurus ends
+> up using the limited token. It can read the repo (so the run starts
 > fine) but cannot open a pull request on a **private** repo —
 > Gitea/Forgejo return a `404 Not Found` on `.../pulls`. Public repos
 > hide the issue.
 >
-> Passing `--token ${{ secrets.RELEASE_TOKEN }}` takes precedence over
-> any `*_TOKEN` environment variable and avoids the collision. See the
+> Releasaurus reads the `RELEASAURUS_`-prefixed variable before the
+> bare name, and the runner doesn't inject the prefixed name, so it
+> can't be shadowed. (Passing `--token ${{ secrets.RELEASE_TOKEN }}`
+> works too — it beats every env var — but command args are more
+> likely to surface in CI logs.) See the
 > [example below](#gitea--forgejo-actions).
 
 ## Examples
@@ -106,8 +110,9 @@ jobs:
 
 ### Gitea / Forgejo Actions
 
-On Gitea and Forgejo runners (including Codeberg), pass the token with
-`--token` rather than `env: FORGEJO_TOKEN` / `env: GITEA_TOKEN` — see
+On Gitea and Forgejo runners (including Codeberg), set the token via
+`env: RELEASAURUS_FORGEJO_TOKEN` / `env: RELEASAURUS_GITEA_TOKEN`
+rather than the bare `FORGEJO_TOKEN` / `GITEA_TOKEN` — see
 [the authentication note above][auth-note] for why.
 
 [auth-note]: #authentication-on-gitea--forgejo-actions
@@ -132,8 +137,9 @@ jobs:
           command_args: >-
             --forge forgejo
             --repo ${{ github.server_url }}/${{ github.repository }}
-            --token ${{ secrets.RELEASE_TOKEN }}
             --local-path ${{ github.workspace }}
+        env:
+          RELEASAURUS_FORGEJO_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 ```
 
 ## Documentation

--- a/book/src/ci-cd-integration.md
+++ b/book/src/ci-cd-integration.md
@@ -30,13 +30,15 @@ Actions workflows. See the
 for inputs, usage examples, and fetch depth configuration for
 `--local-path`.
 
-> **Gitea / Forgejo runners (including Codeberg):** pass your token
-> with `--token ${{ secrets.RELEASE_TOKEN }}` rather than
-> `env: FORGEJO_TOKEN` / `env: GITEA_TOKEN`. These runners inject their
-> own limited per-job token under those variable names, which can
-> shadow your PAT and cause private-repo PR creation to fail with an
-> opaque `404 Not Found`. The `--token` flag takes precedence over any
-> `*_TOKEN` environment variable. See
+> **Gitea / Forgejo runners (including Codeberg):** supply your token
+> through `env: RELEASAURUS_FORGEJO_TOKEN` (or
+> `RELEASAURUS_GITEA_TOKEN`) rather than the bare `FORGEJO_TOKEN` /
+> `GITEA_TOKEN`. These runners auto-inject their own limited per-job
+> token under the bare names, which shadows your PAT and makes
+> private-repo PR creation fail with an opaque `404 Not Found`.
+> Releasaurus reads the `RELEASAURUS_`-prefixed name first, and the
+> runner doesn't inject it, so it can't be shadowed. Passing `--token`
+> works too (it beats every env var). See
 > [Gitea and Forgejo Actions: Injected Token Shadows Your PAT][token-limit].
 
 [token-limit]: ./commands.md#gitea-and-forgejo-actions-injected-token-shadows-your-pat

--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -134,14 +134,14 @@ Output is a JSON array of `{ name, notes }` objects.
 
 These apply to every command:
 
-| Flag                     | Env fallback             | Description                 |
-| ------------------------ | ------------------------ | --------------------------- |
-| `--repo <url>`           | `RELEASAURUS_REPO`       | Repository URL              |
-| `--forge <forge>`        | `RELEASAURUS_FORGE`      | Forge type (see below)      |
-| `--token <token>`        | `GITHUB_TOKEN`, etc.     | Auth token                  |
-| `--local-path <path>`    | `RELEASAURUS_LOCAL_PATH` | Local clone for hybrid mode |
-| `--base-branch <branch>` | —                        | Override the base branch    |
-| `--debug`                | `RELEASAURUS_DEBUG`      | Verbose logging             |
+| Flag                     | Env fallback                                 | Description                 |
+| ------------------------ | -------------------------------------------- | --------------------------- |
+| `--repo <url>`           | `RELEASAURUS_REPO`                           | Repository URL              |
+| `--forge <forge>`        | `RELEASAURUS_FORGE`                          | Forge type (see below)      |
+| `--token <token>`        | `RELEASAURUS_<FORGE>_TOKEN`, `<FORGE>_TOKEN` | Auth token                  |
+| `--local-path <path>`    | `RELEASAURUS_LOCAL_PATH`                     | Local clone for hybrid mode |
+| `--base-branch <branch>` | —                                            | Override the base branch    |
+| `--debug`                | `RELEASAURUS_DEBUG`                          | Verbose logging             |
 
 Available forge types: `github`, `gitlab`, `gitea`, `forgejo`,
 `azure-devops` (experimental), and `local` (testing). For the full list
@@ -288,10 +288,20 @@ against the `.../pulls` endpoint, which is easy to misread as a
 missing repository. Public repos hide the problem because reads are
 anonymous.
 
-**Fix:** pass your token on the command line with `--token` instead of
-through an environment variable. The `--token` flag takes precedence
-over any `*_TOKEN` environment variable, so it bypasses the injected
-value:
+**Fix (recommended):** supply your token through the
+`RELEASAURUS_`-prefixed environment variable — e.g.
+`RELEASAURUS_FORGEJO_TOKEN` for Forgejo, `RELEASAURUS_GITEA_TOKEN` for
+Gitea. Releasaurus reads it _before_ the bare `*_TOKEN` name, and the
+runner does not inject the prefixed name, so it can't be shadowed:
+
+```yaml
+env:
+  RELEASAURUS_FORGEJO_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+```
+
+**Alternative:** pass the token on the command line with `--token`,
+which takes precedence over every environment variable. Note that
+command arguments are more likely to appear in CI logs than env vars:
 
 ```yaml
 command_args: >-

--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -168,18 +168,28 @@ Releasaurus selects the auth token automatically from the `--forge` type;
 `--token` overrides it. The `RELEASAURUS_*` variables are fallbacks for
 their matching CLI flags, and flags always win.
 
-| Variable                 | Purpose                                                             |
-| ------------------------ | ------------------------------------------------------------------- |
-| `GITHUB_TOKEN`           | GitHub auth token                                                   |
-| `GITLAB_TOKEN`           | GitLab auth token                                                   |
-| `GITEA_TOKEN`            | Gitea auth token                                                    |
-| `FORGEJO_TOKEN`          | Forgejo auth token                                                  |
-| `AZURE_DEVOPS_TOKEN`     | Azure DevOps PAT (experimental)                                     |
-| `RELEASAURUS_FORGE`      | Default `--forge`                                                   |
-| `RELEASAURUS_REPO`       | Default `--repo`                                                    |
-| `RELEASAURUS_LOCAL_PATH` | Default `--local-path` (hybrid mode)                                |
-| `RELEASAURUS_DEBUG`      | Enable debug logging when set to any non-empty value                |
-| `RELEASAURUS_DRY_RUN`    | Enable dry-run (auto-enables debug) when set to any non-empty value |
+For the auth token, each forge accepts two env vars: a
+`RELEASAURUS_`-prefixed name and the bare name. The prefixed name takes
+precedence. Prefer it on Gitea/Forgejo CI runners (including Codeberg),
+which auto-inject their own limited token into the bare `*_TOKEN` name
+and would otherwise shadow your PAT — see
+[the CI/CD integration notes](./ci-cd-integration.md) and
+[this known limitation][token-limit].
+
+[token-limit]: ./commands.md#gitea-and-forgejo-actions-injected-token-shadows-your-pat
+
+| Variable                                                | Purpose                                                             |
+| ------------------------------------------------------- | ------------------------------------------------------------------- |
+| `RELEASAURUS_GITHUB_TOKEN` / `GITHUB_TOKEN`             | GitHub auth token                                                   |
+| `RELEASAURUS_GITLAB_TOKEN` / `GITLAB_TOKEN`             | GitLab auth token                                                   |
+| `RELEASAURUS_GITEA_TOKEN` / `GITEA_TOKEN`               | Gitea auth token                                                    |
+| `RELEASAURUS_FORGEJO_TOKEN` / `FORGEJO_TOKEN`           | Forgejo auth token                                                  |
+| `RELEASAURUS_AZURE_DEVOPS_TOKEN` / `AZURE_DEVOPS_TOKEN` | Azure DevOps PAT (experimental)                                     |
+| `RELEASAURUS_FORGE`                                     | Default `--forge`                                                   |
+| `RELEASAURUS_REPO`                                      | Default `--repo`                                                    |
+| `RELEASAURUS_LOCAL_PATH`                                | Default `--local-path` (hybrid mode)                                |
+| `RELEASAURUS_DEBUG`                                     | Enable debug logging when set to any non-empty value                |
+| `RELEASAURUS_DRY_RUN`                                   | Enable dry-run (auto-enables debug) when set to any non-empty value |
 
 ### Required token scopes
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -95,7 +95,7 @@ impl ForgeArgs {
                             Arc::new(github),
                             local_path,
                             &repo,
-                            TokenVar::Github,
+                            vec![TokenVar::ReleasaurusGithub, TokenVar::Github],
                         )
                         .await?
                     } else {
@@ -111,7 +111,7 @@ impl ForgeArgs {
                             Arc::new(gitlab),
                             local_path,
                             &repo,
-                            TokenVar::Gitlab,
+                            vec![TokenVar::ReleasaurusGitlab, TokenVar::Gitlab],
                         )
                         .await?
                     } else {
@@ -128,7 +128,7 @@ impl ForgeArgs {
                             Arc::new(gitea),
                             local_path,
                             &repo,
-                            TokenVar::Gitea,
+                            vec![TokenVar::ReleasaurusGitea, TokenVar::Gitea],
                         )
                         .await?
                     } else {
@@ -144,7 +144,10 @@ impl ForgeArgs {
                             Arc::new(forgejo),
                             local_path,
                             &repo,
-                            TokenVar::Forgejo,
+                            vec![
+                                TokenVar::ReleasaurusForgejo,
+                                TokenVar::Forgejo,
+                            ],
                         )
                         .await?
                     } else {
@@ -161,7 +164,10 @@ impl ForgeArgs {
                             Arc::new(azure),
                             local_path,
                             &repo,
-                            TokenVar::AzureDevops,
+                            vec![
+                                TokenVar::ReleasaurusAzureDevops,
+                                TokenVar::AzureDevops,
+                            ],
                         )
                         .await?
                     } else {
@@ -192,10 +198,10 @@ impl ForgeArgs {
         forge: Arc<dyn Forge>,
         local_path: &Path,
         repo: &RepoUrl,
-        token_var: TokenVar,
+        token_vars: Vec<TokenVar>,
     ) -> Result<Box<dyn Forge>> {
         let token =
-            resolve_token(self.token.clone(), repo.token.as_ref(), token_var)?;
+            resolve_token(self.token.clone(), repo.token.as_ref(), token_vars)?;
 
         Ok(Box::new(
             LocalRepo::new(

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -98,8 +98,11 @@ impl AzureDevops {
             .install_default()
             .ok();
 
-        let token =
-            resolve_token(token, url.token.as_ref(), TokenVar::AzureDevops)?;
+        let token = resolve_token(
+            token,
+            url.token.as_ref(),
+            vec![TokenVar::ReleasaurusAzureDevops, TokenVar::AzureDevops],
+        )?;
 
         let link_base_url = url.link_base_url();
 

--- a/crates/core/src/forge/config.rs
+++ b/crates/core/src/forge/config.rs
@@ -99,14 +99,24 @@ pub const LEGACY_PENDING_LABEL: &str = "releasaurus:pending";
 /// authenticating each forge type
 #[derive(Clone, Copy, strum::Display)]
 pub enum TokenVar {
+    #[strum(to_string = "RELEASAURUS_GITHUB_TOKEN")]
+    ReleasaurusGithub,
     #[strum(to_string = "GITHUB_TOKEN")]
     Github,
+    #[strum(to_string = "RELEASAURUS_GITLAB_TOKEN")]
+    ReleasaurusGitlab,
     #[strum(to_string = "GITLAB_TOKEN")]
     Gitlab,
+    #[strum(to_string = "RELEASAURUS_GITEA_TOKEN")]
+    ReleasaurusGitea,
     #[strum(to_string = "GITEA_TOKEN")]
     Gitea,
+    #[strum(to_string = "RELEASAURUS_FORGEJO_TOKEN")]
+    ReleasaurusForgejo,
     #[strum(to_string = "FORGEJO_TOKEN")]
     Forgejo,
+    #[strum(to_string = "RELEASAURUS_AZURE_DEVOPS_TOKEN")]
+    ReleasaurusAzureDevops,
     #[strum(to_string = "AZURE_DEVOPS_TOKEN")]
     AzureDevops,
 }
@@ -120,12 +130,14 @@ pub enum TokenVar {
 pub fn resolve_token(
     cli_token: Option<SecretString>,
     url_token: Option<&SecretString>,
-    token_var: TokenVar,
+    token_vars: Vec<TokenVar>,
 ) -> Result<SecretString> {
     cli_token
         .or_else(|| url_token.cloned())
         .or_else(|| {
-            env::var(token_var.to_string()).ok().map(SecretString::from)
+            token_vars.iter().find_map(|v| {
+                env::var(v.to_string()).ok().map(SecretString::from)
+            })
         })
         .ok_or_else(|| {
             ReleasaurusError::AuthenticationError(
@@ -146,7 +158,7 @@ mod tests {
         let url_token = SecretString::from("url_token");
 
         let result =
-            resolve_token(cli_token, Some(&url_token), TokenVar::Github);
+            resolve_token(cli_token, Some(&url_token), vec![TokenVar::Github]);
 
         assert_eq!(result.unwrap().expose_secret(), "cli_token");
     }
@@ -155,7 +167,8 @@ mod tests {
     fn resolve_token_falls_back_to_url_token() {
         let url_token = SecretString::from("url_token");
 
-        let result = resolve_token(None, Some(&url_token), TokenVar::Gitlab);
+        let result =
+            resolve_token(None, Some(&url_token), vec![TokenVar::Gitlab]);
 
         assert_eq!(result.unwrap().expose_secret(), "url_token");
     }
@@ -166,8 +179,54 @@ mod tests {
             TokenVar::Github.to_string(),
             Some("env_token"),
             || {
-                let result = resolve_token(None, None, TokenVar::Github);
+                let result = resolve_token(None, None, vec![TokenVar::Github]);
                 assert_eq!(result.unwrap().expose_secret(), "env_token");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_token_prefers_releasaurus_prefixed_env_var() {
+        // When both the RELEASAURUS_-prefixed var and the bare forge var
+        // are set, the prefixed one wins. This lets users authenticate via
+        // env on CI runners (Gitea/Forgejo) that auto-inject their own
+        // value into the bare `*_TOKEN` name.
+        temp_env::with_vars(
+            [
+                (
+                    TokenVar::ReleasaurusForgejo.to_string(),
+                    Some("releasaurus_token"),
+                ),
+                (TokenVar::Forgejo.to_string(), Some("injected_token")),
+            ],
+            || {
+                let result = resolve_token(
+                    None,
+                    None,
+                    vec![TokenVar::ReleasaurusForgejo, TokenVar::Forgejo],
+                );
+                assert_eq!(
+                    result.unwrap().expose_secret(),
+                    "releasaurus_token"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_token_falls_back_to_bare_env_var_when_prefixed_unset() {
+        temp_env::with_vars(
+            [
+                (TokenVar::ReleasaurusForgejo.to_string(), None::<&str>),
+                (TokenVar::Forgejo.to_string(), Some("bare_token")),
+            ],
+            || {
+                let result = resolve_token(
+                    None,
+                    None,
+                    vec![TokenVar::ReleasaurusForgejo, TokenVar::Forgejo],
+                );
+                assert_eq!(result.unwrap().expose_secret(), "bare_token");
             },
         );
     }
@@ -175,7 +234,7 @@ mod tests {
     #[test]
     fn resolve_token_errors_when_no_token_available() {
         temp_env::with_var_unset(TokenVar::Gitea.to_string(), || {
-            let result = resolve_token(None, None, TokenVar::Gitea);
+            let result = resolve_token(None, None, vec![TokenVar::Gitea]);
             assert!(result.is_err());
             let err = result.unwrap_err();
             assert!(matches!(err, ReleasaurusError::AuthenticationError(_)));
@@ -217,7 +276,8 @@ mod tests {
             Some("env_token"),
             || {
                 let cli_token = Some(SecretString::from("cli_token"));
-                let result = resolve_token(cli_token, None, TokenVar::Gitea);
+                let result =
+                    resolve_token(cli_token, None, vec![TokenVar::Gitea]);
                 assert_eq!(result.unwrap().expose_secret(), "cli_token");
             },
         );
@@ -230,8 +290,11 @@ mod tests {
             Some("env_token"),
             || {
                 let url_token = SecretString::from("url_token");
-                let result =
-                    resolve_token(None, Some(&url_token), TokenVar::Gitlab);
+                let result = resolve_token(
+                    None,
+                    Some(&url_token),
+                    vec![TokenVar::Gitlab],
+                );
                 assert_eq!(result.unwrap().expose_secret(), "url_token");
             },
         );

--- a/crates/core/src/forge/forgejo.rs
+++ b/crates/core/src/forge/forgejo.rs
@@ -47,8 +47,11 @@ impl Forgejo {
             .install_default()
             .ok();
 
-        let token =
-            resolve_token(token, url.token.as_ref(), TokenVar::Forgejo)?;
+        let token = resolve_token(
+            token,
+            url.token.as_ref(),
+            vec![TokenVar::ReleasaurusForgejo, TokenVar::Forgejo],
+        )?;
 
         let mut headers = HeaderMap::new();
 
@@ -77,9 +80,12 @@ impl Forgejo {
 
         let base_url = Url::parse(&base_url)?;
 
-        let gitea =
-            Gitea::new(url.clone(), Some(token), Some(TokenVar::Forgejo))
-                .await?;
+        let gitea = Gitea::new(
+            url.clone(),
+            Some(token),
+            Some(vec![TokenVar::ReleasaurusForgejo, TokenVar::Forgejo]),
+        )
+        .await?;
 
         Ok(Self {
             client,

--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -60,7 +60,7 @@ impl Gitea {
     pub async fn new(
         url: RepoUrl,
         token: Option<SecretString>,
-        token_var: Option<TokenVar>,
+        token_vars: Option<Vec<TokenVar>>,
     ) -> Result<Self> {
         rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
@@ -69,7 +69,8 @@ impl Gitea {
         let token = resolve_token(
             token,
             url.token.as_ref(),
-            token_var.unwrap_or(TokenVar::Gitea),
+            token_vars
+                .unwrap_or(vec![TokenVar::ReleasaurusGitea, TokenVar::Gitea]),
         )?;
 
         let link_base_url = url.link_base_url();

--- a/crates/core/src/forge/github.rs
+++ b/crates/core/src/forge/github.rs
@@ -72,7 +72,11 @@ impl Github {
             .install_default()
             .ok();
 
-        let token = resolve_token(token, url.token.as_ref(), TokenVar::Github)?;
+        let token = resolve_token(
+            token,
+            url.token.as_ref(),
+            vec![TokenVar::ReleasaurusGithub, TokenVar::Github],
+        )?;
 
         let link_base_url = url.link_base_url();
 

--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -92,7 +92,11 @@ impl Gitlab {
             .install_default()
             .ok();
 
-        let token = resolve_token(token, url.token.as_ref(), TokenVar::Gitlab)?;
+        let token = resolve_token(
+            token,
+            url.token.as_ref(),
+            vec![TokenVar::ReleasaurusGitlab, TokenVar::Gitlab],
+        )?;
 
         let link_base_url = url.link_base_url();
         let path = url.path.trim_start_matches('/');

--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -921,7 +921,7 @@ mod tests {
 
         let forge = LocalRepo::new(dir.path(), None).await.unwrap();
         let change = FileChange {
-            path: dir.path().join("version.txt").to_string_lossy().to_string(),
+            path: "version.txt".to_string(),
             content: "1.2.3".to_string(),
             update_type: FileUpdateType::Replace,
         };
@@ -969,7 +969,7 @@ mod tests {
 
         let forge = LocalRepo::new(dir.path(), None).await.unwrap();
         let change = FileChange {
-            path: file_path.to_string_lossy().to_string(),
+            path: "CHANGELOG.md".to_string(),
             content: "new\n".to_string(),
             update_type: FileUpdateType::Prepend,
         };


### PR DESCRIPTION
## Description

To further address the issue of some pipeline runners injecting environment variables that shadow `<FORGE>_TOKEN` vars and cause auth issues for releasaurus, this commit allows uses to prefix these vars with RELEASAURS_ and will take precedence over non-prefixed versions.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

## Related Issues

Fixes #331 
