### PR TITLE
Configurable config dir

### DIFF
--- a/book/src/commands.md
+++ b/book/src/commands.md
@@ -142,6 +142,7 @@ These apply to every command:
 | `--local-path <path>`    | `RELEASAURUS_LOCAL_PATH`                     | Local clone for hybrid mode |
 | `--base-branch <branch>` | —                                            | Override the base branch    |
 | `--debug`                | `RELEASAURUS_DEBUG`                          | Verbose logging             |
+| `--config`               | `RELEASAURUS_CONFIG`                         | Custom file path location   |
 
 Available forge types: `github`, `gitlab`, `gitea`, `forgejo`,
 `azure-devops` (experimental), and `local` (testing). For the full list

--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -188,6 +188,7 @@ and would otherwise shadow your PAT — see
 | `RELEASAURUS_FORGE`                                     | Default `--forge`                                                   |
 | `RELEASAURUS_REPO`                                      | Default `--repo`                                                    |
 | `RELEASAURUS_LOCAL_PATH`                                | Default `--local-path` (hybrid mode)                                |
+| `RELEASAURUS_CONFIG`                                    | Default `--config`                                                  |
 | `RELEASAURUS_DEBUG`                                     | Enable debug logging when set to any non-empty value                |
 | `RELEASAURUS_DRY_RUN`                                   | Enable dry-run (auto-enables debug) when set to any non-empty value |
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -774,6 +774,11 @@ mod tests {
             .output()
             .unwrap();
         Command::new("git")
+            .args(["config", "commit.gpgsign", "false"])
+            .current_dir(path)
+            .output()
+            .unwrap();
+        Command::new("git")
             .args(["config", "user.email", "test@test.com"])
             .current_dir(path)
             .output()

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -47,6 +47,11 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub base_branch: Option<String>,
 
+    /// Path to the configuration file. Defaults to "releasaurus.toml" in the
+    /// repository root
+    #[arg(long, global = true, env = "RELEASAURUS_CONFIG")]
+    pub config: Option<PathBuf>,
+
     /// Subcommand to execute
     #[command(subcommand)]
     pub command: Command,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -107,7 +107,10 @@ async fn create_orchestrator(cli: &Cli, dry_run: bool) -> Result<Orchestrator> {
 
     let config = Rc::new(
         forge
-            .load_config(global_overrides.base_branch.clone())
+            .load_config(
+                global_overrides.base_branch.clone(),
+                cli.config.as_ref().map(|p| p.to_string_lossy().to_string()),
+            )
             .await?,
     );
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -109,7 +109,9 @@ async fn create_orchestrator(cli: &Cli, dry_run: bool) -> Result<Orchestrator> {
         forge
             .load_config(
                 global_overrides.base_branch.clone(),
-                cli.config.as_ref().map(|p| p.to_string_lossy().to_string()),
+                cli.config
+                    .as_deref()
+                    .map(|p| p.to_string_lossy().into_owned()),
             )
             .await?,
     );

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -560,12 +560,15 @@ impl Forge for AzureDevops {
         Ok(Some(content))
     }
 
-    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
+    async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config> {
+        let path =
+            config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest {
-                branch,
-                path: DEFAULT_CONFIG_FILE.into(),
-            })
+            .get_file_content(GetFileContentRequest { branch, path })
             .await?
         {
             let config: Config = toml::from_str(&content)?;

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -565,14 +565,22 @@ impl Forge for AzureDevops {
         branch: Option<String>,
         config_path: Option<String>,
     ) -> Result<Config> {
+        let is_custom = config_path.is_some();
         let path =
             config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest { branch, path })
+            .get_file_content(GetFileContentRequest {
+                branch,
+                path: path.clone(),
+            })
             .await?
         {
             let config: Config = toml::from_str(&content)?;
             Ok(config)
+        } else if is_custom {
+            Err(ReleasaurusError::invalid_config(format!(
+                "configuration file not found at: {path}"
+            )))
         } else {
             Ok(Config::default())
         }

--- a/crates/core/src/forge/forgejo.rs
+++ b/crates/core/src/forge/forgejo.rs
@@ -149,8 +149,12 @@ impl Forge for Forgejo {
         self.gitea.get_file_content(req).await
     }
 
-    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
-        self.gitea.load_config(branch).await
+    async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config> {
+        self.gitea.load_config(branch, config_path).await
     }
 
     async fn get_release_by_tag(

--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -288,12 +288,15 @@ impl Forge for Gitea {
         Ok(Some(content))
     }
 
-    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
+    async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config> {
+        let path =
+            config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest {
-                branch,
-                path: DEFAULT_CONFIG_FILE.into(),
-            })
+            .get_file_content(GetFileContentRequest { branch, path })
             .await?
         {
             let config: Config = toml::from_str(&content)?;

--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -293,15 +293,23 @@ impl Forge for Gitea {
         branch: Option<String>,
         config_path: Option<String>,
     ) -> Result<Config> {
+        let is_custom = config_path.is_some();
         let path =
             config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest { branch, path })
+            .get_file_content(GetFileContentRequest {
+                branch,
+                path: path.clone(),
+            })
             .await?
         {
             let config: Config = toml::from_str(&content)?;
 
             Ok(config)
+        } else if is_custom {
+            Err(ReleasaurusError::invalid_config(format!(
+                "configuration file not found at: {path}"
+            )))
         } else {
             Ok(Config::default())
         }

--- a/crates/core/src/forge/github.rs
+++ b/crates/core/src/forge/github.rs
@@ -254,12 +254,15 @@ impl Forge for Github {
         self.tag_search_depth = if depth == 0 { usize::MAX } else { depth }
     }
 
-    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
+    async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config> {
+        let path =
+            config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest {
-                branch,
-                path: DEFAULT_CONFIG_FILE.into(),
-            })
+            .get_file_content(GetFileContentRequest { branch, path })
             .await?
         {
             let config: Config = toml::from_str(&content)?;

--- a/crates/core/src/forge/github.rs
+++ b/crates/core/src/forge/github.rs
@@ -259,15 +259,23 @@ impl Forge for Github {
         branch: Option<String>,
         config_path: Option<String>,
     ) -> Result<Config> {
+        let is_custom = config_path.is_some();
         let path =
             config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest { branch, path })
+            .get_file_content(GetFileContentRequest {
+                branch,
+                path: path.clone(),
+            })
             .await?
         {
             let config: Config = toml::from_str(&content)?;
 
             Ok(config)
+        } else if is_custom {
+            Err(ReleasaurusError::invalid_config(format!(
+                "configuration file not found at: {path}"
+            )))
         } else {
             Ok(Config::default())
         }

--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -208,12 +208,15 @@ impl Forge for Gitlab {
         self.tag_search_depth = if depth == 0 { usize::MAX } else { depth }
     }
 
-    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
+    async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config> {
+        let path =
+            config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest {
-                branch,
-                path: DEFAULT_CONFIG_FILE.into(),
-            })
+            .get_file_content(GetFileContentRequest { branch, path })
             .await?
         {
             let config: Config = toml::from_str(&content)?;

--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -213,15 +213,23 @@ impl Forge for Gitlab {
         branch: Option<String>,
         config_path: Option<String>,
     ) -> Result<Config> {
+        let is_custom = config_path.is_some();
         let path =
             config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest { branch, path })
+            .get_file_content(GetFileContentRequest {
+                branch,
+                path: path.clone(),
+            })
             .await?
         {
             let config: Config = toml::from_str(&content)?;
 
             Ok(config)
+        } else if is_custom {
+            Err(ReleasaurusError::invalid_config(format!(
+                "configuration file not found at: {path}"
+            )))
         } else {
             Ok(Config::default())
         }

--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -400,12 +400,15 @@ impl Forge for LocalRepo {
         Ok(Some(content))
     }
 
-    async fn load_config(&self, branch: Option<String>) -> Result<Config> {
+    async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config> {
+        let path =
+            config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest {
-                branch,
-                path: DEFAULT_CONFIG_FILE.into(),
-            })
+            .get_file_content(GetFileContentRequest { branch, path })
             .await?
         {
             let config: Config = toml::from_str(&content)?;

--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -1066,6 +1066,101 @@ mod tests {
         );
     }
 
+    /// `load_config` with a custom config path reads that file
+    /// instead of the default `releasaurus.toml`.
+    #[tokio::test]
+    async fn load_config_custom_path() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+        add_commit(&repo, "initial commit");
+
+        let custom_toml = dir.path().join("my-config.toml");
+        std::fs::write(
+            &custom_toml,
+            r#"
+base_branch = "develop"
+first_release_search_depth = 50
+tag_search_depth = 10
+"#,
+        )
+        .unwrap();
+
+        let forge = LocalRepo::new(dir.path(), None).await.unwrap();
+        let config = forge
+            .load_config(None, Some("my-config.toml".to_string()))
+            .await
+            .unwrap();
+
+        assert_eq!(config.base_branch, Some("develop".to_string()));
+        assert_eq!(config.first_release_search_depth, 50);
+        assert_eq!(config.tag_search_depth, 10);
+    }
+
+    /// `load_config` with no config path reads the default
+    /// `releasaurus.toml` file.
+    #[tokio::test]
+    async fn load_config_default_path() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+        add_commit(&repo, "initial commit");
+
+        let default_toml = dir.path().join("releasaurus.toml");
+        std::fs::write(
+            &default_toml,
+            r#"
+base_branch = "develop"
+first_release_search_depth = 50
+tag_search_depth = 10
+"#,
+        )
+        .unwrap();
+
+        let forge = LocalRepo::new(dir.path(), None).await.unwrap();
+        let config = forge.load_config(None, None).await.unwrap();
+
+        assert_eq!(config.base_branch, Some("develop".to_string()));
+        assert_eq!(config.first_release_search_depth, 50);
+        assert_eq!(config.tag_search_depth, 10);
+    }
+
+    /// `load_config` with a non-existent custom path returns the
+    /// default config.
+    #[tokio::test]
+    async fn load_config_returns_default_when_custom_path_not_found() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+        add_commit(&repo, "initial commit");
+
+        let forge = LocalRepo::new(dir.path(), None).await.unwrap();
+        let config = forge
+            .load_config(None, Some("nonexistent.toml".to_string()))
+            .await
+            .unwrap();
+
+        let default = Config::default();
+        assert_eq!(config.base_branch, default.base_branch);
+        assert_eq!(
+            config.first_release_search_depth,
+            default.first_release_search_depth
+        );
+        assert_eq!(config.tag_search_depth, default.tag_search_depth);
+        assert_eq!(
+            config.separate_pull_requests,
+            default.separate_pull_requests
+        );
+        assert_eq!(
+            config.breaking_always_increment_major,
+            default.breaking_always_increment_major
+        );
+        assert_eq!(
+            config.features_always_increment_minor,
+            default.features_always_increment_minor
+        );
+    }
+
     /// `local_tag_commit` must create an annotated tag pointing to
     /// the specified commit OID.
     #[tokio::test]

--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -405,14 +405,22 @@ impl Forge for LocalRepo {
         branch: Option<String>,
         config_path: Option<String>,
     ) -> Result<Config> {
+        let is_custom = config_path.is_some();
         let path =
             config_path.unwrap_or_else(|| DEFAULT_CONFIG_FILE.to_string());
         if let Some(content) = self
-            .get_file_content(GetFileContentRequest { branch, path })
+            .get_file_content(GetFileContentRequest {
+                branch,
+                path: path.clone(),
+            })
             .await?
         {
             let config: Config = toml::from_str(&content)?;
             Ok(config)
+        } else if is_custom {
+            Err(ReleasaurusError::invalid_config(format!(
+                "configuration file not found at: {path}"
+            )))
         } else {
             log::info!("repository configuration not found: using default");
             Ok(Config::default())
@@ -1125,20 +1133,38 @@ tag_search_depth = 10
         assert_eq!(config.tag_search_depth, 10);
     }
 
-    /// `load_config` with a non-existent custom path returns the
-    /// default config.
+    /// `load_config` with a non-existent custom path returns an error.
     #[tokio::test]
-    async fn load_config_returns_default_when_custom_path_not_found() {
+    async fn load_config_errors_when_custom_path_not_found() {
         let dir = TempDir::new().unwrap();
         let repo = git2::Repository::init(dir.path()).unwrap();
         configure_git_user(&repo);
         add_commit(&repo, "initial commit");
 
         let forge = LocalRepo::new(dir.path(), None).await.unwrap();
-        let config = forge
+        let err = forge
             .load_config(None, Some("nonexistent.toml".to_string()))
             .await
-            .unwrap();
+            .unwrap_err();
+
+        assert!(matches!(err, ReleasaurusError::InvalidConfig(_)));
+        assert!(
+            err.to_string()
+                .contains("configuration file not found at: nonexistent.toml")
+        );
+    }
+
+    /// `load_config` without a custom path and no default config file
+    /// returns the default config.
+    #[tokio::test]
+    async fn load_config_returns_default_when_no_custom() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        configure_git_user(&repo);
+        add_commit(&repo, "initial commit");
+
+        let forge = LocalRepo::new(dir.path(), None).await.unwrap();
+        let config = forge.load_config(None, None).await.unwrap();
 
         let default = Config::default();
         assert_eq!(config.base_branch, default.base_branch);

--- a/crates/core/src/forge/manager.rs
+++ b/crates/core/src/forge/manager.rs
@@ -86,10 +86,18 @@ impl ForgeManager {
         result
     }
 
-    pub async fn load_config(&self, branch: Option<String>) -> Result<Config> {
-        log::info!("Loading configuration from forge (branch: {:?})", branch);
+    pub async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config> {
+        log::info!(
+            "Loading configuration from forge (branch: {:?}, config: {:?})",
+            branch,
+            config_path
+        );
 
-        let result = self.forge.load_config(branch).await;
+        let result = self.forge.load_config(branch, config_path).await;
 
         if let Err(e) = &result {
             log::error!("Failed to load configuration: {}", e);

--- a/crates/core/src/forge/tests/common/run.rs
+++ b/crates/core/src/forge/tests/common/run.rs
@@ -385,7 +385,7 @@ pub async fn run_forge_test(
     // load_config -> Default::default()
     ////////////////////////////////////////////////////////////////////////////
     log::info!("loading non-existent config file");
-    let config = forge.load_config(None).await.unwrap();
+    let config = forge.load_config(None, None).await.unwrap();
     assert_eq!(
         config.packages[0].workspace_root,
         Config::default().packages[0].workspace_root
@@ -419,7 +419,7 @@ pub async fn run_forge_test(
     sleep(SHORT_WAIT).await;
 
     let config = forge
-        .load_config(Some(default_branch.to_string()))
+        .load_config(Some(default_branch.to_string()), None)
         .await
         .unwrap();
 

--- a/crates/core/src/forge/traits.rs
+++ b/crates/core/src/forge/traits.rs
@@ -36,8 +36,12 @@ pub trait Forge: Any + Send + Sync {
     /// Sets the tag search depth when searching for tags. Previous tags are
     /// used as markers for commits to include in next release
     fn set_tag_search_depth(&mut self, depth: usize);
-    /// Load releasaurus.toml configuration from repository root.
-    async fn load_config(&self, branch: Option<String>) -> Result<Config>;
+    /// Load configuration from repository root.
+    async fn load_config(
+        &self,
+        branch: Option<String>,
+        config_path: Option<String>,
+    ) -> Result<Config>;
     /// Fetch file content from repository by path, returning None if file
     /// doesn't exist.
     async fn get_file_content(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -50,7 +50,7 @@
 //!
 //!     // 2. Load releasaurus.toml from the repository.
 //!     let config = Rc::new(
-//!         forge_manager.load_config(None).await?,
+//!         forge_manager.load_config(None, None).await?,
 //!     );
 //!
 //!     // 3. Resolve packages and build config.


### PR DESCRIPTION
## Description

This adds a --config argument to specify a custom config path. This is useful if you don't want to pollute your root too much with config files. 

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)

## Related Issues

None.

## Additional Notes

None.
