### PR TITLE
fix: Ignore invalid semver tags for local repos

### DIFF
--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -465,9 +465,11 @@ impl Forge for LocalRepo {
                     && tag_prefix_regex.is_match(stripped)
                 {
                     let commit = reference.peel_to_commit()?;
-                    let semver = semver::Version::parse(
+                    let Ok(semver) = semver::Version::parse(
                         tag_prefix_regex.replace_all(stripped, "").as_ref(),
-                    )?;
+                    ) else {
+                        continue;
+                    };
 
                     let tag = Tag {
                         sha: commit.id().to_string(),


### PR DESCRIPTION
## Description

Local forges will error out if any of the tags are invalid semver tags. The other forges (e.g. Gitea, GitHub) just ignore those tags. This change makes the local forge behave like the others.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing completed
- [ ] Documentation tested (if applicable)

## Related Issues

N/A

## Additional Notes

Encountered this on Codeberg when having "rolling" tags that are invalid semver versions, so 1 commit had tags "v0.1.0", "v0", and "latest".
