### PR TITLE
refactor: refactors how release commits are omitted from releases

### DIFF
--- a/crates/core/src/analyzer/commit.rs
+++ b/crates/core/src/analyzer/commit.rs
@@ -122,17 +122,6 @@ impl Commit {
                     );
                     return None;
                 }
-                if let Some(matcher) = config.release_commit_matcher.as_ref()
-                    && matcher.is_match(&commit.raw_title)
-                {
-                    log::debug!(
-                        "omitting release commit: {} : {}",
-                        commit.short_id,
-                        commit.raw_title
-                    );
-
-                    return None;
-                }
 
                 Some(commit)
             }
@@ -192,8 +181,6 @@ fn trim_to_cow(s: &str) -> Cow<'_, str> {
 
 #[cfg(test)]
 mod tests {
-    use regex::Regex;
-
     use crate::forge::request::ForgeCommitBuilder;
 
     use super::*;
@@ -458,36 +445,6 @@ mod tests {
         assert_eq!(commit.title, "Merge pull request #123 from feature/auth");
         assert_eq!(commit.author_name, "GitHub");
         assert_eq!(commit.author_email, "noreply@github.com");
-    }
-
-    #[test]
-    fn test_parses_and_omits_release_commit() {
-        let analyzer_config = AnalyzerConfig {
-            skip_chore: false,
-            release_commit_matcher: Some(
-                Regex::new(r#"^chore\(main\):\srelease.+"#).unwrap(),
-            ),
-            tag_prefix: Some("test-package-v".into()),
-            ..AnalyzerConfig::default()
-        };
-        let group_parser = GroupParser::default();
-        let forge_commit = ForgeCommitBuilder::default()
-            .id("vwx234")
-            .message("chore(main): release test-package test-package-v1.0.0")
-            .author_name("GitHub")
-            .author_email("noreply@github.com")
-            .timestamp(1640995900)
-            .merge_commit(false)
-            .build()
-            .unwrap();
-
-        let commit = Commit::parse_forge_commit(
-            &group_parser,
-            &forge_commit,
-            &analyzer_config,
-        );
-
-        assert!(commit.is_none());
     }
 
     #[test]

--- a/crates/core/src/analyzer/config.rs
+++ b/crates/core/src/analyzer/config.rs
@@ -1,7 +1,6 @@
 //! Configuration for changelog generation and commit analysis.
 
 use derive_builder::Builder;
-use regex::Regex;
 use url::Url;
 
 use crate::config::{prerelease::PrereleaseConfig, resolved::CommitModifiers};
@@ -42,8 +41,6 @@ pub struct AnalyzerConfig {
     pub compare_link_base_url: Option<Url>,
     /// Prerelease settings (if enabled).
     pub prerelease: Option<PrereleaseConfig>,
-    /// regex to match and exclude release commits
-    pub release_commit_matcher: Option<Regex>,
     /// Always increments major version on breaking commits
     pub breaking_always_increment_major: bool,
     /// Always increments minor version on feature commits
@@ -76,7 +73,6 @@ impl Default for AnalyzerConfig {
             release_link_base_url: None,
             compare_link_base_url: None,
             prerelease: None,
-            release_commit_matcher: None,
             breaking_always_increment_major: true,
             features_always_increment_minor: true,
             custom_major_increment_regex: None,

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -615,6 +615,7 @@ impl Forge for AzureDevops {
         &self,
         prefix: &str,
         branch: &str,
+        starting_sha: Option<String>,
     ) -> Result<Vec<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
         let mut url = self.base_url.join("refs")?;
@@ -639,6 +640,11 @@ impl Forge for AzureDevops {
             // Only return tags reachable from the target branch.
             if !self.is_ancestor_of_branch(&r.object_id, branch).await? {
                 continue;
+            }
+            if let Some(sha) = starting_sha.as_ref()
+                && r.object_id == *sha
+            {
+                break;
             }
             let timestamp = self.get_commit_timestamp(&r.object_id).await.ok();
             tags.push(Tag {

--- a/crates/core/src/forge/forgejo.rs
+++ b/crates/core/src/forge/forgejo.rs
@@ -170,8 +170,11 @@ impl Forge for Forgejo {
         &self,
         prefix: &str,
         branch: &str,
+        starting_sha: Option<String>,
     ) -> Result<Vec<Tag>> {
-        self.gitea.get_latest_tags_for_prefix(prefix, branch).await
+        self.gitea
+            .get_latest_tags_for_prefix(prefix, branch, starting_sha)
+            .await
     }
 
     async fn get_commits(

--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -356,6 +356,7 @@ impl Forge for Gitea {
         &self,
         prefix: &str,
         branch: &str,
+        starting_sha: Option<String>,
     ) -> Result<Vec<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
         let mut has_more = true;
@@ -399,6 +400,18 @@ impl Forge for Gitea {
                             .is_tag_ancestor_of_branch(&tag.commit.sha, branch)
                             .await?
                     {
+                        // Reached the starting SHA (e.g. last stable tag):
+                        // stop paging entirely, not just this page. Tag
+                        // ordering from the API is not guaranteed, so this is
+                        // a best-effort bound; downstream callers re-sort and
+                        // filter by SHA membership.
+                        if let Some(sha) = starting_sha.as_ref()
+                            && tag.commit.sha == *sha
+                        {
+                            has_more = false;
+                            break;
+                        }
+
                         tags.push(Tag {
                             name: tag.name,
                             semver: sver,

--- a/crates/core/src/forge/github.rs
+++ b/crates/core/src/forge/github.rs
@@ -378,6 +378,7 @@ impl Forge for Github {
         &self,
         prefix: &str,
         branch: &str,
+        starting_sha: Option<String>,
     ) -> Result<Vec<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
 
@@ -420,6 +421,18 @@ impl Forge for Github {
                             .as_ref()
                             .map(|t| t.oid.clone())
                             .unwrap_or(tag.target.oid.clone());
+
+                        // Reached the starting SHA (e.g. last stable tag):
+                        // stop paging entirely, not just this page. Tag
+                        // ordering from the API is not guaranteed, so this is
+                        // a best-effort bound; downstream callers re-sort and
+                        // filter by SHA membership.
+                        if let Some(start) = starting_sha.as_ref()
+                            && sha == *start
+                        {
+                            has_next_page = false;
+                            break;
+                        }
 
                         if self.is_tag_ancestor_of_branch(&sha, branch).await? {
                             let committed_date =

--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -354,6 +354,7 @@ impl Forge for Gitlab {
         &self,
         prefix: &str,
         branch: &str,
+        starting_sha: Option<String>,
     ) -> Result<Vec<Tag>> {
         let re = Regex::new(format!(r"^{prefix}").as_str())?;
 
@@ -378,6 +379,12 @@ impl Forge for Gitlab {
                         .is_tag_ancestor_of_branch(&tag.commit.id, branch)
                         .await?
                 {
+                    if let Some(sha) = starting_sha.as_ref()
+                        && tag.commit.id == *sha
+                    {
+                        break;
+                    }
+
                     tags.push(Tag {
                         name: tag.name,
                         semver: sver,

--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -440,6 +440,7 @@ impl Forge for LocalRepo {
         &self,
         prefix: &str,
         branch: &str,
+        starting_sha: Option<String>,
     ) -> Result<Vec<Tag>> {
         let regex_prefix = format!(r"^{}", prefix);
         let tag_prefix_regex = Regex::new(&regex_prefix)?;
@@ -465,6 +466,14 @@ impl Forge for LocalRepo {
                     && tag_prefix_regex.is_match(stripped)
                 {
                     let commit = reference.peel_to_commit()?;
+                    let commit_id = commit.id().to_string();
+
+                    if let Some(sha) = starting_sha.as_ref()
+                        && commit_id == *sha
+                    {
+                        break;
+                    }
+
                     let Ok(semver) = semver::Version::parse(
                         tag_prefix_regex.replace_all(stripped, "").as_ref(),
                     ) else {
@@ -818,7 +827,7 @@ mod tests {
 
         let forge = LocalRepo::new(dir.path(), None).await.unwrap();
         let mut result = forge
-            .get_latest_tags_for_prefix("v", &branch)
+            .get_latest_tags_for_prefix("v", &branch, None)
             .await
             .unwrap();
         result.sort_by(|a, b| b.semver.cmp(&a.semver));
@@ -1267,7 +1276,7 @@ tag_search_depth = 10
         // Querying main_branch must return v1.0.0 only; v2.0.0 is
         // not in main_branch's history.
         let mut result = forge
-            .get_latest_tags_for_prefix("v", &main_branch)
+            .get_latest_tags_for_prefix("v", &main_branch, None)
             .await
             .unwrap();
         result.sort_by(|a, b| b.semver.cmp(&a.semver));

--- a/crates/core/src/forge/manager.rs
+++ b/crates/core/src/forge/manager.rs
@@ -120,7 +120,7 @@ impl ForgeManager {
     ) -> Result<Option<Tag>> {
         let mut tags = self
             .forge
-            .get_latest_tags_for_prefix(prefix, branch)
+            .get_latest_tags_for_prefix(prefix, branch, None)
             .await?;
 
         if tags.is_empty() {
@@ -135,6 +135,21 @@ impl ForgeManager {
         Ok(tags.into_iter().next())
     }
 
+    pub async fn get_tags_for_prefix_since(
+        &self,
+        prefix: &str,
+        branch: &str,
+        starting_sha: &str,
+    ) -> Result<Vec<Tag>> {
+        self.forge
+            .get_latest_tags_for_prefix(
+                prefix,
+                branch,
+                Some(starting_sha.to_string()),
+            )
+            .await
+    }
+
     pub async fn get_latest_stable_release_tag(
         &self,
         prefix: &str,
@@ -142,7 +157,7 @@ impl ForgeManager {
     ) -> Result<Option<Tag>> {
         let mut tags = self
             .forge
-            .get_latest_tags_for_prefix(prefix, branch)
+            .get_latest_tags_for_prefix(prefix, branch, None)
             .await?;
 
         if tags.is_empty() {
@@ -431,7 +446,7 @@ mod tests {
     fn mock_returning_tags(tags: Vec<Tag>) -> MockForge {
         let mut mock = MockForge::new();
         mock.expect_get_latest_tags_for_prefix()
-            .returning(move |_, _| Ok(tags.clone()));
+            .returning(move |_, _, _| Ok(tags.clone()));
         mock
     }
 

--- a/crates/core/src/forge/traits.rs
+++ b/crates/core/src/forge/traits.rs
@@ -69,6 +69,7 @@ pub trait Forge: Any + Send + Sync {
         &self,
         prefix: &str,
         branch: &str,
+        starting_sha: Option<String>,
     ) -> Result<Vec<Tag>>;
     /// Fetch commits for a package path, optionally starting from a specific
     /// SHA. Commits are returned newest-first; callers (e.g. the analyzer)

--- a/crates/core/src/orchestrator/commit_fetcher.rs
+++ b/crates/core/src/orchestrator/commit_fetcher.rs
@@ -144,6 +144,21 @@ impl CommitFetcher {
             .await?;
 
         if let Some(tag) = latest_stable_tag {
+            // fetch previous tags starting from point of last stable release
+            // so we can omit these prerelease "release" commits in the
+            // changelog
+            let tag_shas: HashSet<String> = self
+                .forge
+                .get_tags_for_prefix_since(
+                    &pkg.tag_prefix,
+                    &self.base_branch,
+                    &tag.sha,
+                )
+                .await?
+                .into_iter()
+                .map(|t| t.sha)
+                .collect();
+
             commits = self
                 .forge
                 .get_commits(
@@ -154,6 +169,11 @@ impl CommitFetcher {
 
             commits =
                 self.filter_commits_for_package(pkg, Some(&tag), &commits);
+
+            // omit previous prereleases tagged commits from changelog
+            // prevents commits like "chore: release <pkg> vX.X.X-rc.0" from
+            // appearing in changelog
+            commits.retain(|c| !tag_shas.contains(&c.id));
         }
 
         Ok(commits)
@@ -622,7 +642,7 @@ mod tests {
         mock_forge
             .expect_get_latest_tags_for_prefix()
             .times(2)
-            .returning(|prefix, _branch| {
+            .returning(|prefix, _branch, _sha| {
                 if prefix.contains("pkg-a") {
                     // pkg-a has newer tag (timestamp 2000)
                     Ok(vec![Tag {
@@ -710,7 +730,7 @@ mod tests {
         mock_forge
             .expect_get_latest_tags_for_prefix()
             .times(2)
-            .returning(|prefix, _branch| {
+            .returning(|prefix, _branch, _sha| {
                 if prefix.contains("pkg-a") {
                     Ok(vec![Tag {
                         sha: "some-sha".to_string(),
@@ -800,14 +820,15 @@ mod tests {
     #[tokio::test]
     async fn graduating_to_stable_true_when_prerelease_tag_and_no_config() {
         let mut mock = MockForge::new();
-        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
-            Ok(vec![Tag {
-                name: "v1.0.0-rc.1".to_string(),
-                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
-                sha: "sha-rc1".to_string(),
-                timestamp: Some(1000),
-            }])
-        });
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(|_, _, _| {
+                Ok(vec![Tag {
+                    name: "v1.0.0-rc.1".to_string(),
+                    semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                    sha: "sha-rc1".to_string(),
+                    timestamp: Some(1000),
+                }])
+            });
         mock.expect_get_commits().returning(|_, _| Ok(vec![]));
 
         let pkg = PackageConfigBuilder::default()
@@ -832,14 +853,15 @@ mod tests {
     #[tokio::test]
     async fn graduating_to_stable_false_when_stable_tag() {
         let mut mock = MockForge::new();
-        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
-            Ok(vec![Tag {
-                name: "v1.0.0".to_string(),
-                semver: semver::Version::parse("1.0.0").unwrap(),
-                sha: "sha-1.0.0".to_string(),
-                timestamp: Some(1000),
-            }])
-        });
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(|_, _, _| {
+                Ok(vec![Tag {
+                    name: "v1.0.0".to_string(),
+                    semver: semver::Version::parse("1.0.0").unwrap(),
+                    sha: "sha-1.0.0".to_string(),
+                    timestamp: Some(1000),
+                }])
+            });
         mock.expect_get_commits().returning(|_, _| Ok(vec![]));
 
         let pkg = PackageConfigBuilder::default()
@@ -866,14 +888,15 @@ mod tests {
         // Current tag is a prerelease, but the package config still declares
         // a prerelease strategy — so we are NOT graduating to stable.
         let mut mock = MockForge::new();
-        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
-            Ok(vec![Tag {
-                name: "v1.0.0-rc.1".to_string(),
-                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
-                sha: "sha-rc1".to_string(),
-                timestamp: Some(1000),
-            }])
-        });
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(|_, _, _| {
+                Ok(vec![Tag {
+                    name: "v1.0.0-rc.1".to_string(),
+                    semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                    sha: "sha-rc1".to_string(),
+                    timestamp: Some(1000),
+                }])
+            });
         mock.expect_get_commits().returning(|_, _| Ok(vec![]));
 
         let pkg = PackageConfigBuilder::default()
@@ -903,7 +926,7 @@ mod tests {
     async fn graduating_to_stable_false_when_no_tag() {
         let mut mock = MockForge::new();
         mock.expect_get_latest_tags_for_prefix()
-            .returning(|_, _| Ok(vec![]));
+            .returning(|_, _, _| Ok(vec![]));
         mock.expect_get_commits().returning(|_, _| Ok(vec![]));
 
         let pkg = PackageConfigBuilder::default()
@@ -930,14 +953,15 @@ mod tests {
         // Current tag is a prerelease and the package config has an empty
         // suffix — the user has cleared the suffix to graduate to stable.
         let mut mock = MockForge::new();
-        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
-            Ok(vec![Tag {
-                name: "v1.0.0-rc.1".to_string(),
-                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
-                sha: "sha-rc1".to_string(),
-                timestamp: Some(1000),
-            }])
-        });
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(|_, _, _| {
+                Ok(vec![Tag {
+                    name: "v1.0.0-rc.1".to_string(),
+                    semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                    sha: "sha-rc1".to_string(),
+                    timestamp: Some(1000),
+                }])
+            });
         mock.expect_get_commits().returning(|_, _| Ok(vec![]));
 
         let pkg = PackageConfigBuilder::default()
@@ -968,14 +992,15 @@ mod tests {
         // Current tag is a prerelease and the prerelease config has no suffix
         // set at all — treated the same as empty, i.e. graduating to stable.
         let mut mock = MockForge::new();
-        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
-            Ok(vec![Tag {
-                name: "v1.0.0-rc.1".to_string(),
-                semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
-                sha: "sha-rc1".to_string(),
-                timestamp: Some(1000),
-            }])
-        });
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(|_, _, _| {
+                Ok(vec![Tag {
+                    name: "v1.0.0-rc.1".to_string(),
+                    semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                    sha: "sha-rc1".to_string(),
+                    timestamp: Some(1000),
+                }])
+            });
         mock.expect_get_commits().returning(|_, _| Ok(vec![]));
 
         let pkg = PackageConfigBuilder::default()
@@ -1007,22 +1032,23 @@ mod tests {
     async fn fetch_additional_returns_empty_when_no_stable_tag() {
         // Only prerelease tags exist — no stable tag to aggregate from.
         let mut mock = MockForge::new();
-        mock.expect_get_latest_tags_for_prefix().returning(|_, _| {
-            Ok(vec![
-                Tag {
-                    name: "v1.0.0-rc.1".to_string(),
-                    semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
-                    sha: "sha-rc1".to_string(),
-                    timestamp: None,
-                },
-                Tag {
-                    name: "v1.0.0-rc.2".to_string(),
-                    semver: semver::Version::parse("1.0.0-rc.2").unwrap(),
-                    sha: "sha-rc2".to_string(),
-                    timestamp: None,
-                },
-            ])
-        });
+        mock.expect_get_latest_tags_for_prefix()
+            .returning(|_, _, _| {
+                Ok(vec![
+                    Tag {
+                        name: "v1.0.0-rc.1".to_string(),
+                        semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+                        sha: "sha-rc1".to_string(),
+                        timestamp: None,
+                    },
+                    Tag {
+                        name: "v1.0.0-rc.2".to_string(),
+                        semver: semver::Version::parse("1.0.0-rc.2").unwrap(),
+                        sha: "sha-rc2".to_string(),
+                        timestamp: None,
+                    },
+                ])
+            });
 
         let pkg_config = PackageConfigBuilder::default()
             .name("test-pkg")
@@ -1073,7 +1099,7 @@ mod tests {
         let mut mock = MockForge::new();
 
         mock.expect_get_latest_tags_for_prefix()
-            .returning(move |_, _| Ok(vec![stable_tag.clone()]));
+            .returning(move |_, _, _| Ok(vec![stable_tag.clone()]));
         mock.expect_get_commits()
             .returning(move |_, _| Ok(commits.clone()));
 
@@ -1129,7 +1155,7 @@ mod tests {
 
         let mut mock = MockForge::new();
         mock.expect_get_latest_tags_for_prefix()
-            .returning(move |_, _| Ok(vec![stable_tag.clone()]));
+            .returning(move |_, _, _| Ok(vec![stable_tag.clone()]));
         mock.expect_get_commits()
             .returning(move |_, _| Ok(commits.clone()));
 

--- a/crates/core/src/orchestrator/package_processor/tests/prepare.rs
+++ b/crates/core/src/orchestrator/package_processor/tests/prepare.rs
@@ -26,7 +26,7 @@ async fn generate_prepared_with_dummy_commit_skips_untagged_packages() {
 
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| Ok(vec![])); // No tags exist
+        .returning(|_, _, _| Ok(vec![])); // No tags exist
 
     let processor = create_package_processor(mock_forge, None, None);
 
@@ -56,7 +56,7 @@ async fn generate_prepared_with_dummy_commit_filters_by_targets() {
     let mut mock_forge = MockForge::new();
 
     mock_forge.expect_get_latest_tags_for_prefix().returning(
-        |prefix, _branch| {
+        |prefix, _branch, _sha| {
             Ok(vec![Tag {
                 name: format!("{prefix}1.0.0"),
                 timestamp: Some(1000),
@@ -141,7 +141,7 @@ async fn aggregate_prereleases_disabled_skips_extra_fetch() {
 
     mock.expect_get_latest_tags_for_prefix()
         .times(1)
-        .returning(move |_, _| Ok(vec![pre_tag.clone()]));
+        .returning(move |_, _, _| Ok(vec![pre_tag.clone()]));
     mock.expect_get_commits()
         .times(1)
         .returning(|_, _| Ok(vec![]));
@@ -162,7 +162,7 @@ async fn aggregate_prereleases_enabled_not_graduating_skips_extra_fetch() {
 
     mock.expect_get_latest_tags_for_prefix()
         .times(1)
-        .returning(move |_, _| Ok(vec![s_tag.clone()]));
+        .returning(move |_, _, _| Ok(vec![s_tag.clone()]));
     mock.expect_get_commits()
         .times(1)
         .returning(|_, _| Ok(vec![]));
@@ -196,7 +196,7 @@ async fn aggregate_prereleases_enabled_and_graduating_merges_commits() {
     mock.expect_get_latest_tags_for_prefix()
         .once()
         .in_sequence(&mut seq)
-        .returning(move |_, _| Ok(vec![pre_tag.clone()]));
+        .returning(move |_, _, _| Ok(vec![pre_tag.clone()]));
 
     // Step 2: fetch commits since the prerelease tag SHA
     mock.expect_get_commits()
@@ -208,7 +208,15 @@ async fn aggregate_prereleases_enabled_and_graduating_merges_commits() {
     mock.expect_get_latest_tags_for_prefix()
         .once()
         .in_sequence(&mut seq)
-        .returning(move |_, _| Ok(vec![s_tag.clone()]));
+        .returning(move |_, _, _| Ok(vec![s_tag.clone()]));
+
+    // Step 3b: fetch prerelease tags since the stable SHA so their release
+    // commits can be omitted. None of the window commits are release
+    // commits here, so return no tags.
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _, _| Ok(vec![]));
 
     // Step 4: fetch commits since the stable tag SHA (historical range)
     mock.expect_get_commits()
@@ -247,7 +255,7 @@ async fn aggregate_prereleases_deduplicates_overlapping_commits() {
     mock.expect_get_latest_tags_for_prefix()
         .once()
         .in_sequence(&mut seq)
-        .returning(move |_, _| Ok(vec![pre_tag.clone()]));
+        .returning(move |_, _, _| Ok(vec![pre_tag.clone()]));
 
     mock.expect_get_commits()
         .once()
@@ -257,7 +265,14 @@ async fn aggregate_prereleases_deduplicates_overlapping_commits() {
     mock.expect_get_latest_tags_for_prefix()
         .once()
         .in_sequence(&mut seq)
-        .returning(move |_, _| Ok(vec![s_tag.clone()]));
+        .returning(move |_, _, _| Ok(vec![s_tag.clone()]));
+
+    // Fetch prerelease tags since the stable SHA for release-commit
+    // omission. None of the window commits are release commits here.
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _, _| Ok(vec![]));
 
     // Historical window contains ONLY the same commit as current window.
     mock.expect_get_commits()
@@ -279,4 +294,74 @@ async fn aggregate_prereleases_deduplicates_overlapping_commits() {
         "duplicate commit should appear only once"
     );
     assert_eq!(prepared[0].commits[0].id, "current");
+}
+
+#[tokio::test]
+async fn aggregate_prereleases_omits_prerelease_release_commits() {
+    // A prerelease "release" commit (whose SHA matches a prerelease tag that
+    // points at it) must be omitted from the aggregated changelog, while
+    // ordinary commits in the same window are retained.
+    let mut mock = MockForge::new();
+    let mut seq = mockall::Sequence::new();
+
+    let pre_tag = prerelease_tag();
+    let s_tag = stable_tag();
+
+    // Tag and commit share a SHA: this is a prerelease release commit.
+    let rc_release_tag = Tag {
+        name: "v1.0.0-rc.1".to_string(),
+        semver: semver::Version::parse("1.0.0-rc.1").unwrap(),
+        sha: "sha-rc-release".to_string(),
+        timestamp: Some(800),
+    };
+    let release_commit = pkg_commit("sha-rc-release", 800);
+    let feature = pkg_commit("feature", 600);
+
+    // Step 1: collect current tag for the package
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _, _| Ok(vec![pre_tag.clone()]));
+
+    // Step 2: current window has no new commits
+    mock.expect_get_commits()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(|_, _| Ok(vec![]));
+
+    // Step 3: look up last stable tag for aggregation
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _, _| Ok(vec![s_tag.clone()]));
+
+    // Step 3b: prerelease tags since the stable SHA — the release commit's
+    // tag is returned so its commit gets omitted.
+    mock.expect_get_latest_tags_for_prefix()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _, _| Ok(vec![rc_release_tag.clone()]));
+
+    // Step 4: historical window contains the release commit and a feature.
+    mock.expect_get_commits()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(move |_, _| {
+            Ok(vec![release_commit.clone(), feature.clone()])
+        });
+
+    let processor = create_package_processor(
+        mock,
+        Some(vec![graduating_pkg()]),
+        Some(aggregate_config()),
+    );
+
+    let prepared = processor.prepare_packages(None).await.unwrap();
+    assert_eq!(prepared.len(), 1);
+    assert_eq!(
+        prepared[0].commits.len(),
+        1,
+        "prerelease release commit should be omitted"
+    );
+    assert_eq!(prepared[0].commits[0].id, "feature");
 }

--- a/crates/core/src/orchestrator/tests/current_releases.rs
+++ b/crates/core/src/orchestrator/tests/current_releases.rs
@@ -22,7 +22,7 @@ async fn get_current_releases_retrieves_release_data() {
 
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| {
+        .returning(|_, _, _| {
             Ok(vec![Tag {
                 name: "v1.0.0".to_string(),
                 ..Default::default()
@@ -55,7 +55,7 @@ async fn get_next_releases_filters_by_package_name() {
 
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| Ok(vec![]));
+        .returning(|_, _, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![

--- a/crates/core/src/orchestrator/tests/next_release.rs
+++ b/crates/core/src/orchestrator/tests/next_release.rs
@@ -25,7 +25,7 @@ async fn start_next_release_creates_commits_for_tagged_packages() {
 
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| {
+        .returning(|_, _, _| {
             Ok(vec![Tag {
                 semver: Version::parse("1.0.0").unwrap(),
                 ..Default::default()
@@ -57,7 +57,7 @@ async fn start_next_release_filters_by_target_packages() {
     mock_forge
         .expect_get_latest_tags_for_prefix()
         .times(2)
-        .returning(|prefix, _branch| {
+        .returning(|prefix, _branch, _sha| {
             if prefix.contains("pkg-a") {
                 Ok(vec![Tag {
                     semver: Version::parse("1.0.0").unwrap(),
@@ -113,7 +113,7 @@ async fn start_next_release_skips_untagged_packages() {
     // Return None indicating no tag exists for this package
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| Ok(vec![]));
+        .returning(|_, _, _| Ok(vec![]));
 
     // Should NOT call create_commit since package has no tag
     mock_forge.expect_create_commit().times(0);

--- a/crates/core/src/orchestrator/tests/pr_workflow.rs
+++ b/crates/core/src/orchestrator/tests/pr_workflow.rs
@@ -27,7 +27,7 @@ async fn create_release_prs_succeeds_when_no_commits_since_last_tag() {
     // Has tag, but no new commits
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| {
+        .returning(|_, _, _| {
             Ok(vec![Tag {
                 name: "v1.0.0".to_string(),
                 semver: Version::parse("1.0.0").unwrap(),
@@ -56,7 +56,7 @@ async fn create_release_prs_returns_error_when_merged_pr_not_yet_released() {
     // No tags exist yet
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| Ok(vec![]));
+        .returning(|_, _, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -105,7 +105,7 @@ async fn create_release_prs_creates_new_prs() {
     // No tags exist yet
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| Ok(vec![]));
+        .returning(|_, _, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -204,7 +204,7 @@ async fn create_release_prs_targets_specific_package() {
     // No tags exist yet
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| Ok(vec![]));
+        .returning(|_, _, _| Ok(vec![]));
 
     mock_forge.expect_get_commits().returning(|_, _| {
         Ok(vec![
@@ -330,7 +330,7 @@ async fn create_release_prs_updates_existing_prs() {
 
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| {
+        .returning(|_, _, _| {
             Ok(vec![Tag {
                 name: "v1.0.0".to_string(),
                 semver: Version::parse("1.0.0").unwrap(),

--- a/crates/core/src/orchestrator/tests/release_workflow.rs
+++ b/crates/core/src/orchestrator/tests/release_workflow.rs
@@ -254,7 +254,7 @@ async fn create_releases_triggers_auto_start_next() {
 
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| {
+        .returning(|_, _, _| {
             Ok(vec![Tag {
                 semver: Version::parse("1.0.0").unwrap(),
                 ..Default::default()

--- a/crates/core/src/orchestrator/tests/release_workflow_legacy.rs
+++ b/crates/core/src/orchestrator/tests/release_workflow_legacy.rs
@@ -108,7 +108,7 @@ Release notes
 
     mock_forge
         .expect_get_latest_tags_for_prefix()
-        .returning(|_, _| {
+        .returning(|_, _, _| {
             Ok(vec![Tag {
                 semver: Version::parse("1.0.0").unwrap(),
                 ..Default::default()

--- a/crates/core/src/resolver/resolvers/analyzer.rs
+++ b/crates/core/src/resolver/resolvers/analyzer.rs
@@ -4,7 +4,6 @@
 //! handling complex interactions between global config, package
 //! config, and CLI overrides.
 
-use regex::Regex;
 use std::rc::Rc;
 
 use crate::{
@@ -34,9 +33,6 @@ pub struct AnalyzerParams {
 /// settings, and generates package-specific patterns (like release
 /// commit matcher).
 pub fn build_analyzer_config(params: AnalyzerParams) -> AnalyzerConfig {
-    let release_commit_matcher =
-        build_release_commit_matcher(&params.package_name);
-
     AnalyzerConfig {
         body: params.config.changelog.body.clone(),
         breaking_always_increment_major: params.breaking_always_increment_major,
@@ -45,7 +41,6 @@ pub fn build_analyzer_config(params: AnalyzerParams) -> AnalyzerConfig {
         features_always_increment_minor: params.features_always_increment_minor,
         include_author: params.config.changelog.include_author,
         prerelease: params.prerelease,
-        release_commit_matcher,
         release_link_base_url: Some(
             params.config.release_link_base_url.clone(),
         ),
@@ -64,43 +59,5 @@ pub fn build_analyzer_config(params: AnalyzerParams) -> AnalyzerConfig {
         skip_miscellaneous: params.config.changelog.skip_miscellaneous,
         tag_prefix: Some(params.tag_prefix),
         commit_modifiers: params.config.commit_modifiers.clone(),
-    }
-}
-
-/// Builds a regex matcher for release commits for this package.
-///
-/// Release commits follow the pattern:
-/// `chore(base_branch): release package_name`
-fn build_release_commit_matcher(package_name: &str) -> Option<Regex> {
-    Regex::new(&format!(
-        r#"^chore\(.*\): release {}"#,
-        regex::escape(package_name)
-    ))
-    .ok()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn builds_release_commit_matcher_correctly() {
-        let matcher = build_release_commit_matcher("my-package");
-        assert!(matcher.is_some());
-
-        let regex = matcher.unwrap();
-        assert!(regex.is_match("chore(main): release my-package"));
-        assert!(regex.is_match("chore(dev): release my-package"));
-        assert!(!regex.is_match("chore(main): release other-package"));
-    }
-
-    #[test]
-    fn escapes_special_regex_characters() {
-        let matcher = build_release_commit_matcher("my-package");
-        assert!(matcher.is_some());
-
-        let regex = matcher.unwrap();
-        // Parentheses in package name should be escaped
-        assert!(!regex.is_match("chore(main): release my(package"));
     }
 }


### PR DESCRIPTION
## Description

Instead of relying on brittle commit message parsing and matching, we now match directly on tag shas to determine if a commit is a "release commit". The opens the door to allow users to define custom templating for commit / PR messages in the future.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Chore (refactor)

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [ ] Documentation tested (if applicable)
