### PR TITLE
feat: adds templates for commit messages and pr titles

### DIFF
--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -6,8 +6,8 @@ supported languages. For guidance and examples, see
 
 Configuration is grouped under three top-level tables: `[repository]`
 (repo-wide settings), `[defaults]` (release defaults for every package,
-split into `[defaults.versioning]` and `[defaults.changelog]`), and one or
-more `[[package]]` entries. All keys are optional.
+with `[defaults.versioning]` and `[defaults.changelog]` subtables), and
+one or more `[[package]]` entries. All keys are optional.
 
 Unknown keys are rejected, so a misspelled or misplaced option fails at
 config load rather than being silently ignored.
@@ -41,6 +41,33 @@ sha = "abc123d"
 message = "fix: corrected description"
 ```
 
+## `[defaults]`
+
+Keys set directly on `[defaults]`, rather than in one of its subtables.
+All four are Tera templates for the release commit message and PR title;
+see [Commit Message & PR Title Templates][pr-templates] for which one
+applies when.
+
+[pr-templates]: ./configuration.md#commit-message--pr-title-templates
+
+| Key                                | Type   | Default                                                     | Applies when                                                                           |
+| ---------------------------------- | ------ | ----------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `commit_message_template`          | string | `chore({{ branch }}): release {{ package_name }} {{ tag }}` | `separate_pull_requests = true`, or one `[[package]]`. Overridable per package.        |
+| `pr_title_template`                | string | `chore({{ branch }}): release {{ package_name }} {{ tag }}` | `separate_pull_requests = true`, or one `[[package]]`. Overridable per package.        |
+| `monorepo_commit_message_template` | string | `chore({{ branch }}): release {{ repo_name }}`              | Multiple `[[package]]` with `separate_pull_requests = false`. No per-package override. |
+| `monorepo_pr_title_template`       | string | `chore({{ branch }}): release {{ repo_name }}`              | Multiple `[[package]]` with `separate_pull_requests = false`. No per-package override. |
+
+The two contexts differ: `branch` and `repo_name` are always available,
+while `package_name`, `tag`, and `semver` exist only in the per-package
+templates. Referencing a variable that isn't in scope is rejected at
+config load.
+
+```toml
+[defaults]
+pr_title_template = "🚀 Release {{ package_name }} {{ tag }}"
+monorepo_pr_title_template = "🚀 Release {{ repo_name }} ({{ branch }})"
+```
+
 ## `[defaults.versioning]`
 
 Everything that affects the computed version, plus the commit filtering
@@ -48,18 +75,18 @@ and grouping rules (which affect the version as well as the changelog).
 Each package may override these individually via its own `versioning`
 table (see [`[[package]]`](#package)).
 
-| Key                               | Type   | Default         | Description                                                                                                                                           |
-| --------------------------------- | ------ | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version_type`                    | string | `major.minor.patch` | Version format to produce. See [Version Types](./configuration.md#version-types) for the five accepted values.                                    |
-| `auto_start_next`                 | bool   | `false`         | Bump patch versions automatically after a release (see [`start-next`](./commands.md#start-next)).                                                     |
-| `breaking_always_increment_major` | bool   | `true`          | Breaking changes (`feat!:`, `BREAKING CHANGE:`) bump major.                                                                                           |
-| `features_always_increment_minor` | bool   | `true`          | `feat:` commits bump minor.                                                                                                                           |
-| `custom_major_increment_regex`    | string | none            | Additional regex that triggers a major bump.                                                                                                          |
-| `custom_minor_increment_regex`    | string | none            | Additional regex that triggers a minor bump.                                                                                                          |
-| `skip_merge_commits`              | bool   | `true`          | Exclude merge commits.                                                                                                                                |
-| `named_parsers`                   | table  | built-in groups | Override built-in commit groups (`pattern`/`title`/`order`/`skip` per group). See [Changelog Customization](./changelog.md#commit-groups--filtering). |
-| `custom_parser`                   | array  | none            | Define additional commit groups, checked before the defaults. Note the singular key. `pattern`, `title` and `order` are all required.                 |
-| `prerelease`                      | table  | none (stable)   | Prerelease settings; see [`[defaults.versioning.prerelease]`](#defaultsversioningprerelease).                                                         |
+| Key                               | Type   | Default             | Description                                                                                                                                           |
+| --------------------------------- | ------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version_type`                    | string | `major.minor.patch` | Version format to produce. See [Version Types](./configuration.md#version-types) for the five accepted values.                                        |
+| `auto_start_next`                 | bool   | `false`             | Bump patch versions automatically after a release (see [`start-next`](./commands.md#start-next)).                                                     |
+| `breaking_always_increment_major` | bool   | `true`              | Breaking changes (`feat!:`, `BREAKING CHANGE:`) bump major.                                                                                           |
+| `features_always_increment_minor` | bool   | `true`              | `feat:` commits bump minor.                                                                                                                           |
+| `custom_major_increment_regex`    | string | none                | Additional regex that triggers a major bump.                                                                                                          |
+| `custom_minor_increment_regex`    | string | none                | Additional regex that triggers a minor bump.                                                                                                          |
+| `skip_merge_commits`              | bool   | `true`              | Exclude merge commits.                                                                                                                                |
+| `named_parsers`                   | table  | built-in groups     | Override built-in commit groups (`pattern`/`title`/`order`/`skip` per group). See [Changelog Customization](./changelog.md#commit-groups--filtering). |
+| `custom_parser`                   | array  | none                | Define additional commit groups, checked before the defaults. Note the singular key. `pattern`, `title` and `order` are all required.                 |
+| `prerelease`                      | table  | none (stable)       | Prerelease settings; see [`[defaults.versioning.prerelease]`](#defaultsversioningprerelease).                                                         |
 
 ### Custom increment regexes
 
@@ -152,6 +179,8 @@ One entry per package; repeatable.
 | `additional_manifest_files` | string[] / object[] | none                             | Extra files to version-bump (see below).                                                                                  |
 | `versioning`                | table               | inherits `[defaults.versioning]` | Per-package versioning override (see [Per-package overrides](#per-package-overrides)).                                    |
 | `changelog`                 | table               | inherits `[defaults.changelog]`  | Per-package changelog override (see [Per-package overrides](#per-package-overrides)).                                     |
+| `commit_message_template`   | string              | inherits `[defaults]`            | Release commit message for this package's PR (see [`[defaults]`](#defaults)).                                             |
+| `pr_title_template`         | string              | inherits `[defaults]`            | Release PR title for this package's PR (see [`[defaults]`](#defaults)).                                                   |
 
 `sub_packages` entries take `name`, `path`, and `release_type`.
 
@@ -231,6 +260,14 @@ One table replaces rather than merges:
   ask for. Restate `strategy` alongside a package-level `suffix` whenever
   your default strategy isn't the `versioned` built-in.
 
+`commit_message_template` and `pr_title_template` are plain strings rather
+than tables, so there is nothing to merge: the package's value wins, else
+the `[defaults]` value, else the built-in. Set them directly on the
+package, not inside a nested table. The `monorepo_*` templates have no
+package-level form at all — they describe a PR spanning several packages,
+so no one package owns them, and setting one on a `[[package]]` is a
+config error.
+
 ## Complete Example
 
 ```toml
@@ -238,6 +275,10 @@ One table replaces rather than merges:
 base_branch = "main"
 first_release_search_depth = 400
 separate_pull_requests = false
+
+[defaults]
+pr_title_template = "🚀 Release {{ package_name }} {{ tag }}"
+monorepo_pr_title_template = "🚀 Release {{ repo_name }}"
 
 [defaults.versioning]
 auto_start_next = false
@@ -276,6 +317,7 @@ path = "./services/api"
 release_type = "rust"
 tag_prefix = "api-v"
 versioning = { prerelease = { suffix = "alpha", strategy = "versioned" } }
+pr_title_template = "api: {{ tag }}"
 ```
 
 ## Environment Variables

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -102,6 +102,92 @@ tag_prefix = "backend-v"
 In either mode, target one package with `--package <name>` on `release-pr`
 and `release`.
 
+### Commit Message & PR Title Templates
+
+The release commit message and the PR title are
+[Tera](https://keats.github.io/tera/) templates. By default they match:
+
+```text
+chore(main): release my-package v1.2.3     # one package, or separate PRs
+chore(main): release my-repo               # combined PR, multiple packages
+```
+
+A PR that covers a single package can name that package and its version;
+one that covers several can't. So there are two sets of templates, and
+which set applies is fixed by your config rather than by what changed:
+
+| Your config                                                 | Commit message                     | PR title                     |
+| ----------------------------------------------------------- | ---------------------------------- | ---------------------------- |
+| `separate_pull_requests = true`                             | `commit_message_template`          | `pr_title_template`          |
+| One `[[package]]`                                           | `commit_message_template`          | `pr_title_template`          |
+| Multiple `[[package]]` and `separate_pull_requests = false` | `monorepo_commit_message_template` | `monorepo_pr_title_template` |
+
+Each package gets its own PR under `separate_pull_requests = true`, and a
+single-package repo only ever has one, so both cases can use the
+per-package pair. A combined PR across multiple packages uses the
+`monorepo_*` pair.
+
+Only top-level `[[package]]` entries count. A single package with
+[sub-packages](#grouped-releases-sub-packages) is still one package, since
+sub-packages share their parent's PR and tag.
+
+> Because the choice comes from your config, a multi-package repo with
+> `separate_pull_requests = false` uses the `monorepo_*` pair on **every**
+> run — including runs where only one package changed, and including
+> `--package <name>`. That keeps the format predictable, at the cost of
+> those PRs not naming the package. Use `separate_pull_requests = true` if
+> you want every PR titled after its package.
+
+Set them under `[defaults]`, and override the per-package pair on
+individual packages:
+
+```toml
+[defaults]
+commit_message_template = "chore({{ branch }}): release {{ package_name }} {{ semver }}"
+pr_title_template = "🚀 Release {{ package_name }} {{ tag }}"
+monorepo_commit_message_template = "chore({{ branch }}): release {{ repo_name }}"
+monorepo_pr_title_template = "🚀 Release {{ repo_name }}"
+
+[[package]]
+name = "frontend"
+path = "./apps/web"
+release_type = "node"
+# This package alone gets a ticket-scoped commit and a plainer title.
+commit_message_template = "chore(web): release {{ tag }} [skip ci]"
+pr_title_template = "Web release {{ tag }}"
+```
+
+#### Variables
+
+Available in **all four** templates:
+
+| Variable    | Description                       | Example   |
+| ----------- | --------------------------------- | --------- |
+| `branch`    | The base branch being released to | `main`    |
+| `repo_name` | Repository name                   | `my-repo` |
+
+Available in `commit_message_template` and `pr_title_template` **only**,
+because a PR spanning several packages has no single one of these:
+
+| Variable       | Description                        | Example      |
+| -------------- | ---------------------------------- | ------------ |
+| `package_name` | Name of the package being released | `frontend`   |
+| `tag`          | Full tag, including the tag prefix | `web-v1.2.3` |
+| `semver`       | Version alone, without the prefix  | `1.2.3`      |
+
+Referencing a variable that isn't in scope is an error, and it's caught
+when the config loads rather than partway through a release — so
+`monorepo_pr_title_template = "{{ package_name }}"` fails before anything
+is pushed.
+
+Filters work as they do in the changelog `body` template, so you can
+reshape a value rather than needing a variable for every form of it:
+
+```toml
+[defaults]
+pr_title_template = "Release {{ package_name | upper }} {{ tag }}"
+```
+
 ### Tracking Shared Code
 
 Use `additional_paths` so a package also releases when shared directories

--- a/crates/core/src/config/defaults.rs
+++ b/crates/core/src/config/defaults.rs
@@ -10,6 +10,20 @@ use crate::config::{
     },
 };
 
+pub const DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE: &str =
+    "chore({{ branch }}): release {{ package_name }} {{ tag }}";
+
+pub const DEFAULT_MONOREPO_COMMIT_AND_PR_TITLE_TEMPLATE: &str =
+    "chore({{ branch }}): release {{ repo_name }}";
+
+fn default_commit_and_pr_title() -> String {
+    DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE.into()
+}
+
+fn default_monorepo_commit_and_pr_title() -> String {
+    DEFAULT_MONOREPO_COMMIT_AND_PR_TITLE_TEMPLATE.into()
+}
+
 fn default_versioning() -> VersioningConfig {
     VersioningConfig {
         version_type: Some(DEFAULT_VERSION_TYPE),
@@ -33,6 +47,32 @@ fn default_versioning() -> VersioningConfig {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(default, deny_unknown_fields)] // Use default for missing fields
 pub struct DefaultsConfig {
+    /// Tera template for generating release commit messages when
+    /// repository.separate_pull_requests=false and multiple packages
+    /// configured. Has the following variables available in the template
+    /// context: branch, repo_name
+    #[schemars(default = "default_monorepo_commit_and_pr_title")]
+    pub monorepo_commit_message_template: Option<String>,
+    /// Tera template for generating release PR titles when
+    /// repository.separate_pull_requests=false and multiple packages
+    /// configured. Has the following variables available in the template
+    /// context: branch, repo_name
+    #[schemars(default = "default_monorepo_commit_and_pr_title")]
+    pub monorepo_pr_title_template: Option<String>,
+    /// Tera template for generating release commit messages. When
+    /// repository.separate_pull_requests=true, or only one package configured,
+    /// this template will be used for each individual PR commit but can be
+    /// overridden at the package level. Has the following variables available
+    /// in the template context: branch, repo_name, package_name, tag, semver
+    #[schemars(default = "default_commit_and_pr_title")]
+    pub commit_message_template: Option<String>,
+    /// Tera template for generating release PR titles. When
+    /// repository.separate_pull_requests=true, or only one package configured,
+    /// this template will be used for each individual PR title but can be
+    /// overridden at the package level. Has the following variables available
+    /// in the template context: branch, repo_name, package_name, tag, semver
+    #[schemars(default = "default_commit_and_pr_title")]
+    pub pr_title_template: Option<String>,
     /// Default versioning config. Packages can override this configuration
     #[schemars(default = "default_versioning")]
     pub versioning: Option<VersioningConfig>,

--- a/crates/core/src/config/package.rs
+++ b/crates/core/src/config/package.rs
@@ -144,6 +144,23 @@ pub struct PackageConfig {
     pub changelog: Option<ChangelogConfig>,
     /// Versioning config for calculating next versions of packages
     pub versioning: Option<VersioningConfig>,
+    /// Tera template for generating release commit messages. When
+    /// repository.separate_pull_requests=true, or only one package configured,
+    /// this template will be used for the package PR commit message. When
+    /// repository.separate_pull_requests=false and multiple packages
+    /// configured, the template defined for
+    /// defaults.monorepo_commit_message_template is used instead. Has the
+    /// following variables available in the template context: branch,
+    /// repo_name, package_name, tag, semver
+    pub commit_message_template: Option<String>,
+    /// Tera template for generating release PR titles. When
+    /// repository.separate_pull_requests=true, or only one package configured,
+    /// this template will be used for the package PR title. When
+    /// repository.separate_pull_requests=false and multiple packages
+    /// configured, the template defined for defaults.monorepo_pr_title_template
+    /// is used instead. Has the following variables available in the template
+    /// context: branch, repo_name, package_name, tag, semver
+    pub pr_title_template: Option<String>,
 }
 
 impl Default for PackageConfig {
@@ -159,6 +176,8 @@ impl Default for PackageConfig {
             additional_manifest_files: None,
             changelog: None,
             versioning: None,
+            commit_message_template: None,
+            pr_title_template: None,
         }
     }
 }

--- a/crates/core/src/config/toml.rs
+++ b/crates/core/src/config/toml.rs
@@ -180,4 +180,69 @@ mod tests {
         assert_eq!(parsers.0[0].pattern.as_ref().unwrap().as_str(), "^deps");
         assert_eq!(parsers.0[0].order, Some(3));
     }
+
+    #[test]
+    fn parses_commit_and_pr_title_templates() {
+        let raw = r#"
+            [defaults]
+            monorepo_commit_message_template = "chore: release {{ repo_name }}"
+            monorepo_pr_title_template = "Release {{ repo_name }}"
+            commit_message_template = "chore: {{ package_name }} {{ tag }}"
+            pr_title_template = "Release {{ package_name }} {{ tag }}"
+
+            [[package]]
+            name = "frontend"
+            commit_message_template = "web: {{ tag }}"
+            pr_title_template = "Web {{ tag }}"
+        "#;
+
+        let config: Config = toml::from_str(raw).unwrap();
+
+        assert_eq!(
+            config.defaults.monorepo_commit_message_template.unwrap(),
+            "chore: release {{ repo_name }}"
+        );
+        assert_eq!(
+            config.defaults.monorepo_pr_title_template.unwrap(),
+            "Release {{ repo_name }}"
+        );
+        assert_eq!(
+            config.defaults.commit_message_template.unwrap(),
+            "chore: {{ package_name }} {{ tag }}"
+        );
+        assert_eq!(
+            config.defaults.pr_title_template.unwrap(),
+            "Release {{ package_name }} {{ tag }}"
+        );
+
+        let package = &config.packages[0];
+
+        assert_eq!(
+            package.commit_message_template.as_deref().unwrap(),
+            "web: {{ tag }}"
+        );
+        assert_eq!(
+            package.pr_title_template.as_deref().unwrap(),
+            "Web {{ tag }}"
+        );
+    }
+
+    /// The `monorepo_*` templates describe a PR spanning several packages,
+    /// so there is nothing for a single package to override. Setting one
+    /// there must fail rather than be silently ignored.
+    #[test]
+    fn rejects_monorepo_template_under_package() {
+        let raw = r#"
+            [[package]]
+            name = "frontend"
+            monorepo_pr_title_template = "Release {{ repo_name }}"
+        "#;
+
+        let err = toml::from_str::<Config>(raw).unwrap_err().to_string();
+
+        assert!(
+            err.contains("monorepo_pr_title_template"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/crates/core/src/orchestrator/package_processor.rs
+++ b/crates/core/src/orchestrator/package_processor.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use color_eyre::eyre::eyre;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -277,6 +278,10 @@ impl PackageProcessor {
                 sha_compare_link: target.sha_compare_link.clone(),
                 file_changes,
                 release_branch,
+                commit_message_template: target_config
+                    .commit_message_template
+                    .clone(),
+                pr_title_template: target_config.pr_title_template.clone(),
             });
         }
 
@@ -351,14 +356,17 @@ impl PackageProcessor {
                 .flat_map(|p| p.file_changes.clone())
                 .collect();
 
-            let message =
-                self.release_message_for_pr_package_list(&bundle.packages);
+            let commit_message =
+                self.release_commit_message_for_pr_package_list(&bundle)?;
+
+            let pr_title =
+                self.release_pr_title_for_pr_package_list(&bundle)?;
 
             self.forge
                 .create_release_branch(CreateReleaseBranchRequest {
                     base_branch: self.config.base_branch.clone(),
                     release_branch: release_branch.clone(),
-                    message: message.clone(),
+                    message: commit_message,
                     file_changes,
                 })
                 .await?;
@@ -369,7 +377,7 @@ impl PackageProcessor {
             let request = CreatePrRequest {
                 base_branch: self.config.base_branch.clone(),
                 head_branch: release_branch.clone(),
-                title: message,
+                title: pr_title,
                 body: self.release_pr_body_for_pr_package_list(
                     &bundle.packages,
                     existing_body,
@@ -388,21 +396,74 @@ impl PackageProcessor {
     ////////////////////////////////////////////////////////////////////////////
     //// Private
     ////////////////////////////////////////////////////////////////////////////
-    fn release_message_for_pr_package_list(
+    fn release_commit_message_for_pr_package_list(
         &self,
-        pr_packages: &[ReleasePRPackage],
-    ) -> String {
-        let mut message =
-            format!("chore({}): release", self.config.base_branch);
+        pr_bundle: &PRBundle,
+    ) -> Result<String> {
+        self.render_release_template(
+            pr_bundle,
+            "commit message",
+            |pkg| &pkg.commit_message_template,
+            &self.config.monorepo_commit_message_template,
+        )
+    }
 
-        if pr_packages.len() == 1 {
-            message = format!(
-                "{message} {} {}",
-                pr_packages[0].name, pr_packages[0].tag.name
-            );
+    fn release_pr_title_for_pr_package_list(
+        &self,
+        pr_bundle: &PRBundle,
+    ) -> Result<String> {
+        self.render_release_template(
+            pr_bundle,
+            "PR title",
+            |pkg| &pkg.pr_title_template,
+            &self.config.monorepo_pr_title_template,
+        )
+    }
+
+    /// Renders one of the release templates for a PR bundle.
+    ///
+    /// Which template applies is decided by config alone, not by what is
+    /// being released: a repo with one configured package, or with
+    /// `separate_pull_requests` on, can only ever produce single-package
+    /// PRs, so those use the package's own template. Everything else is a
+    /// combined PR that may span several packages and uses the monorepo
+    /// template — including on runs where only one package happens to have
+    /// changes. Deciding this from config keeps the format stable from one
+    /// release to the next.
+    ///
+    /// Both templates were validated during config resolution, so a
+    /// failure here means the real values tripped something the probe
+    /// values did not.
+    fn render_release_template(
+        &self,
+        pr_bundle: &PRBundle,
+        what: &str,
+        package_template: impl Fn(&ReleasePRPackage) -> &str,
+        monorepo_template: &str,
+    ) -> Result<String> {
+        if pr_bundle.packages.is_empty() {
+            return Err(ReleasaurusError::Other(eyre!(
+                "Cannot generate {what} for empty package list"
+            )));
         }
 
-        message
+        let mut context = tera::Context::new();
+        context.insert("repo_name", &self.config.repo_name);
+        context.insert("branch", &self.config.base_branch);
+
+        let template = if self.config.separate_pull_requests
+            || self.config.package_configs.hash().len() == 1
+        {
+            let package = &pr_bundle.packages[0];
+            context.insert("package_name", &package.name);
+            context.insert("tag", &package.tag.name);
+            context.insert("semver", &package.tag.semver.to_string());
+            package_template(package)
+        } else {
+            monorepo_template
+        };
+
+        Ok(tera::Tera::one_off(template, &context, false)?)
     }
 
     fn release_pr_body_for_pr_package_list(

--- a/crates/core/src/orchestrator/package_processor/tests.rs
+++ b/crates/core/src/orchestrator/package_processor/tests.rs
@@ -7,9 +7,12 @@
 //! - `pr_grouping`: PR grouping and branch logic tests (separate vs grouped)
 //! - `pr_requests`: PR request generation and branch creation tests
 //!   (metadata, file changes, branch creation order)
+//! - `pr_templates`: Commit message and PR title template tests
+//!   (per-package vs. monorepo selection, render context)
 
 mod analyze;
 mod common;
 mod pr_grouping;
 mod pr_requests;
+mod pr_templates;
 mod prepare;

--- a/crates/core/src/orchestrator/package_processor/tests/common.rs
+++ b/crates/core/src/orchestrator/package_processor/tests/common.rs
@@ -1,6 +1,10 @@
 //! Common test utilities for orchestrator core tests.
 
-use std::rc::Rc;
+use semver::Version;
+use std::{
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 use url::Url;
 
 use crate::{
@@ -11,9 +15,11 @@ use crate::{
     },
     forge::{
         manager::{ForgeManager, ForgeOptions},
+        request::{Commit, CreateReleaseBranchRequest, PrMetadataBlock, Tag},
         traits::MockForge,
     },
     orchestrator::package_processor::PackageProcessor,
+    packages::{releasable::ReleasablePackage, release_pr::ReleasePRPackage},
     resolver::Resolver,
 };
 
@@ -57,4 +63,79 @@ pub fn create_package_processor(
     let resolved_config = resolver.resolve(pkg_configs).unwrap();
 
     PackageProcessor::new(resolved_config, forge)
+}
+
+/// Stubs metadata encoding with the plain HTML comment form used by
+/// GitHub and Gitea.
+pub fn expect_html_comment_encoding(mock: &mut MockForge) {
+    mock.expect_encode_pr_metadata()
+        .returning(|json| PrMetadataBlock {
+            inline_content: format!("<!--{json}-->"),
+            div_attribute: String::new(),
+        });
+}
+
+/// Records the commit messages passed to `create_release_branch` so a
+/// test can compare them against expected strings instead of asserting
+/// inside a `withf` predicate, which reports nothing useful on failure.
+///
+/// `Arc<Mutex<_>>` rather than the `Rc` used elsewhere in the crate
+/// because mockall requires its return closures to be `Send`.
+pub fn capture_release_branch_messages(
+    mock: &mut MockForge,
+    times: usize,
+) -> Arc<Mutex<Vec<String>>> {
+    let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(vec![]));
+    let sink = Arc::clone(&captured);
+
+    mock.expect_create_release_branch().times(times).returning(
+        move |req: CreateReleaseBranchRequest| {
+            sink.lock().unwrap().push(req.message);
+            Ok(Commit {
+                sha: "abc123".to_string(),
+            })
+        },
+    );
+
+    captured
+}
+
+/// Builds a minimal releasable package with `tag` parsed into a semver.
+pub fn releasable(name: &str, tag: &str) -> ReleasablePackage {
+    ReleasablePackage {
+        name: name.into(),
+        tag: tag_for(tag),
+        notes: format!("notes for {name}"),
+        ..Default::default()
+    }
+}
+
+/// Builds a release PR package for tests that drive the render helpers
+/// directly rather than going through `create_pr_branches`.
+pub fn release_pr_package(
+    name: &str,
+    tag: &str,
+    commit_message_template: &str,
+    pr_title_template: &str,
+) -> ReleasePRPackage {
+    ReleasePRPackage {
+        name: name.into(),
+        tag: tag_for(tag),
+        notes: String::new(),
+        tag_compare_link: String::new(),
+        sha_compare_link: String::new(),
+        file_changes: vec![],
+        release_branch: "releasaurus-release-main".into(),
+        commit_message_template: commit_message_template.into(),
+        pr_title_template: pr_title_template.into(),
+    }
+}
+
+/// Builds a tag from a `v`-prefixed name, parsing the remainder as semver.
+fn tag_for(name: &str) -> Tag {
+    Tag {
+        name: name.into(),
+        semver: Version::parse(name.trim_start_matches('v')).unwrap(),
+        ..Default::default()
+    }
 }

--- a/crates/core/src/orchestrator/package_processor/tests/pr_requests.rs
+++ b/crates/core/src/orchestrator/package_processor/tests/pr_requests.rs
@@ -15,23 +15,12 @@ use crate::{
         Config, package::PackageConfigBuilder, repository::RepositoryConfig,
     },
     forge::{
-        request::{
-            Commit, CreateReleaseBranchRequest, PrMetadataBlock, PullRequest,
-            Tag,
-        },
+        request::{Commit, CreateReleaseBranchRequest, PullRequest, Tag},
         traits::MockForge,
     },
     orchestrator::tests::common::{PrBodyInput, make_pr_body},
     packages::releasable::ReleasablePackage,
 };
-
-fn expect_html_comment_encoding(mock: &mut MockForge) {
-    mock.expect_encode_pr_metadata()
-        .returning(|json| PrMetadataBlock {
-            inline_content: format!("<!--{json}-->"),
-            div_attribute: String::new(),
-        });
-}
 
 #[tokio::test]
 async fn create_pr_branches_creates_branch_before_pr_request() {

--- a/crates/core/src/orchestrator/package_processor/tests/pr_templates.rs
+++ b/crates/core/src/orchestrator/package_processor/tests/pr_templates.rs
@@ -1,0 +1,418 @@
+//! Tests for the Tera templates that generate release commit messages
+//! and PR titles.
+//!
+//! Two tiers are in play, selected by config alone: a per-package
+//! template when `separate_pull_requests` is on or a single package is
+//! configured, and a `monorepo_*` template otherwise. What is actually
+//! being released does not enter into it, which is what keeps the format
+//! stable across runs — see `render_release_template`.
+
+use std::sync::{Arc, Mutex};
+
+use super::common::*;
+
+use crate::{
+    config::{
+        Config,
+        defaults::DefaultsConfig,
+        package::{PackageConfig, PackageConfigBuilder},
+        repository::RepositoryConfig,
+    },
+    forge::traits::MockForge,
+    packages::release_pr::PRBundle,
+    result::ReleasaurusError,
+};
+
+/// Wires up the mock calls every path through `create_pr_branches` makes,
+/// and captures the commit messages handed to the forge.
+fn prepare_mock(branches: usize) -> (MockForge, Arc<Mutex<Vec<String>>>) {
+    let mut mock = MockForge::new();
+
+    mock.expect_get_merged_release_pr().returning(|_| Ok(None));
+    mock.expect_get_open_release_pr().returning(|_| Ok(None));
+    expect_html_comment_encoding(&mut mock);
+
+    let messages = capture_release_branch_messages(&mut mock, branches);
+
+    (mock, messages)
+}
+
+/// Config carrying only template overrides.
+fn config(
+    separate_pull_requests: bool,
+    defaults: DefaultsConfig,
+) -> Option<Config> {
+    Some(Config {
+        repository: RepositoryConfig {
+            separate_pull_requests,
+            ..RepositoryConfig::default()
+        },
+        defaults,
+        ..Config::default()
+    })
+}
+
+fn package_defaults(commit_message: &str, pr_title: &str) -> DefaultsConfig {
+    DefaultsConfig {
+        commit_message_template: Some(commit_message.into()),
+        pr_title_template: Some(pr_title.into()),
+        ..DefaultsConfig::default()
+    }
+}
+
+fn monorepo_defaults(commit_message: &str, pr_title: &str) -> DefaultsConfig {
+    DefaultsConfig {
+        monorepo_commit_message_template: Some(commit_message.into()),
+        monorepo_pr_title_template: Some(pr_title.into()),
+        ..DefaultsConfig::default()
+    }
+}
+
+fn two_packages() -> Vec<PackageConfig> {
+    vec![
+        PackageConfigBuilder::default()
+            .name("pkg-a")
+            .path(".")
+            .build()
+            .unwrap(),
+        PackageConfigBuilder::default()
+            .name("pkg-b")
+            .path(".")
+            .build()
+            .unwrap(),
+    ]
+}
+
+/// A repo with one configured package can only ever produce a
+/// single-package PR, so it uses the per-package template regardless of
+/// `separate_pull_requests`. The monorepo templates are set here too, so
+/// the test fails if the wrong tier is picked rather than silently
+/// falling back to a built-in default.
+#[tokio::test]
+async fn single_configured_package_uses_package_template() {
+    let (mock, messages) = prepare_mock(1);
+
+    let processor = create_package_processor(
+        mock,
+        None,
+        config(
+            false,
+            DefaultsConfig {
+                commit_message_template: Some("pkg: {{ package_name }}".into()),
+                pr_title_template: Some("pkg title: {{ tag }}".into()),
+                monorepo_commit_message_template: Some(
+                    "mono: {{ repo_name }}".into(),
+                ),
+                monorepo_pr_title_template: Some(
+                    "mono title: {{ repo_name }}".into(),
+                ),
+                ..DefaultsConfig::default()
+            },
+        ),
+    );
+
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![releasable("test-pkg", "v1.2.3")])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].request.title, "pkg title: v1.2.3");
+    assert_eq!(messages.lock().unwrap().as_slice(), ["pkg: test-pkg"]);
+}
+
+/// Multiple configured packages with `separate_pull_requests = false`
+/// means a combined PR, which uses the monorepo templates.
+#[tokio::test]
+async fn multiple_configured_packages_use_monorepo_template() {
+    let (mock, messages) = prepare_mock(1);
+
+    let processor = create_package_processor(
+        mock,
+        Some(two_packages()),
+        config(
+            false,
+            monorepo_defaults(
+                "mono commit: {{ repo_name }}",
+                "mono title: {{ repo_name }} on {{ branch }}",
+            ),
+        ),
+    );
+
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![
+            releasable("pkg-a", "v1.0.0"),
+            releasable("pkg-b", "v2.0.0"),
+        ])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].request.title, "mono title: test-repo on main");
+    assert_eq!(
+        messages.lock().unwrap().as_slice(),
+        ["mono commit: test-repo"]
+    );
+}
+
+/// The selection depends only on config, so a combined-PR monorepo keeps
+/// using the monorepo templates on runs where a single package has
+/// changes.
+#[tokio::test]
+async fn combined_pr_uses_monorepo_template_when_one_package_releases() {
+    let (mock, messages) = prepare_mock(1);
+
+    let pkg_configs = vec![
+        PackageConfigBuilder::default()
+            .name("pkg-a")
+            .path(".")
+            .commit_message_template("A commit {{ tag }}")
+            .pr_title_template("A title {{ tag }}")
+            .build()
+            .unwrap(),
+        PackageConfigBuilder::default()
+            .name("pkg-b")
+            .path(".")
+            .build()
+            .unwrap(),
+    ];
+
+    let processor = create_package_processor(
+        mock,
+        Some(pkg_configs),
+        config(
+            false,
+            monorepo_defaults(
+                "mono commit: {{ repo_name }}",
+                "mono title: {{ repo_name }}",
+            ),
+        ),
+    );
+
+    // Only pkg-a has anything to release this run.
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![releasable("pkg-a", "v1.0.0")])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].request.title, "mono title: test-repo");
+    assert_eq!(
+        messages.lock().unwrap().as_slice(),
+        ["mono commit: test-repo"]
+    );
+}
+
+/// Each package carries its own resolved templates through to the PR it
+/// ends up in, rather than the first package's winning for all of them.
+#[tokio::test]
+async fn separate_prs_use_each_packages_own_template() {
+    let (mock, messages) = prepare_mock(2);
+
+    let pkg_configs = vec![
+        PackageConfigBuilder::default()
+            .name("pkg-a")
+            .path(".")
+            .commit_message_template("A commit {{ tag }}")
+            .pr_title_template("A title {{ tag }}")
+            .build()
+            .unwrap(),
+        PackageConfigBuilder::default()
+            .name("pkg-b")
+            .path(".")
+            .commit_message_template("B commit {{ tag }}")
+            .pr_title_template("B title {{ tag }}")
+            .build()
+            .unwrap(),
+    ];
+
+    let processor = create_package_processor(
+        mock,
+        Some(pkg_configs),
+        config(true, DefaultsConfig::default()),
+    );
+
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![
+            releasable("pkg-a", "v1.0.0"),
+            releasable("pkg-b", "v2.0.0"),
+        ])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(requests.len(), 2);
+
+    let mut titles: Vec<&str> =
+        requests.iter().map(|r| r.request.title.as_str()).collect();
+    titles.sort();
+    assert_eq!(titles, ["A title v1.0.0", "B title v2.0.0"]);
+
+    let mut commits = messages.lock().unwrap().clone();
+    commits.sort();
+    assert_eq!(commits, ["A commit v1.0.0", "B commit v2.0.0"]);
+}
+
+/// Pins the documented per-package context, including that `tag` carries
+/// the tag prefix while `semver` is the bare version.
+#[tokio::test]
+async fn renders_all_package_context_variables() {
+    let (mock, messages) = prepare_mock(1);
+
+    let all = "{{ branch }}|{{ repo_name }}|{{ package_name }}|{{ tag }}|\
+               {{ semver }}";
+
+    let processor = create_package_processor(
+        mock,
+        None,
+        config(true, package_defaults(all, all)),
+    );
+
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![releasable("test-pkg", "v1.2.3")])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    let expected = "main|test-repo|test-pkg|v1.2.3|1.2.3";
+
+    assert_eq!(requests[0].request.title, expected);
+    assert_eq!(messages.lock().unwrap()[0], expected);
+}
+
+/// Pins the documented monorepo context, which is deliberately narrower.
+#[tokio::test]
+async fn renders_all_monorepo_context_variables() {
+    let (mock, messages) = prepare_mock(1);
+
+    let all = "{{ branch }}|{{ repo_name }}";
+
+    let processor = create_package_processor(
+        mock,
+        Some(two_packages()),
+        config(false, monorepo_defaults(all, all)),
+    );
+
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![
+            releasable("pkg-a", "v1.0.0"),
+            releasable("pkg-b", "v2.0.0"),
+        ])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(requests[0].request.title, "main|test-repo");
+    assert_eq!(messages.lock().unwrap()[0], "main|test-repo");
+}
+
+/// The two built-in defaults, rendered. These strings are what the book
+/// documents, and changing either is a user-visible change.
+#[tokio::test]
+async fn defaults_produce_the_documented_commit_and_title() {
+    let (mock, messages) = prepare_mock(1);
+
+    let processor = create_package_processor(mock, None, None);
+
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![releasable("test-pkg", "v1.2.3")])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(
+        requests[0].request.title,
+        "chore(main): release test-pkg v1.2.3"
+    );
+    assert_eq!(
+        messages.lock().unwrap()[0],
+        "chore(main): release test-pkg v1.2.3"
+    );
+
+    // ... and the monorepo default, once a combined PR holds two packages
+    let (mock, messages) = prepare_mock(1);
+
+    let processor = create_package_processor(
+        mock,
+        Some(two_packages()),
+        config(false, DefaultsConfig::default()),
+    );
+
+    let grouped = processor
+        .release_pr_packages_by_branch(vec![
+            releasable("pkg-a", "v1.0.0"),
+            releasable("pkg-b", "v2.0.0"),
+        ])
+        .await
+        .unwrap();
+
+    let requests = processor.create_pr_branches(grouped).await.unwrap();
+
+    assert_eq!(requests[0].request.title, "chore(main): release test-repo");
+    assert_eq!(
+        messages.lock().unwrap()[0],
+        "chore(main): release test-repo"
+    );
+}
+
+/// Templates are validated during config resolution, so this path should
+/// be unreachable in practice — but a real value could still trip
+/// something the probe values did not, and it must surface as an error
+/// rather than a malformed commit message.
+#[test]
+fn render_failure_surfaces_a_template_error() {
+    let processor = create_package_processor(MockForge::new(), None, None);
+
+    let bundle = PRBundle {
+        existing_pr: None,
+        packages: vec![release_pr_package(
+            "test-pkg",
+            "v1.2.3",
+            "{{ nope }}",
+            "{{ nope }}",
+        )],
+    };
+
+    let err = processor
+        .release_commit_message_for_pr_package_list(&bundle)
+        .unwrap_err();
+    assert!(matches!(err, ReleasaurusError::TemplateError(_)));
+
+    let err = processor
+        .release_pr_title_for_pr_package_list(&bundle)
+        .unwrap_err();
+    assert!(matches!(err, ReleasaurusError::TemplateError(_)));
+}
+
+/// Rendering reads `packages[0]`, so an empty bundle has to be rejected
+/// before that indexing rather than panicking.
+#[test]
+fn empty_bundle_is_rejected() {
+    let processor = create_package_processor(MockForge::new(), None, None);
+
+    let bundle = PRBundle {
+        existing_pr: None,
+        packages: vec![],
+    };
+
+    assert!(
+        processor
+            .release_commit_message_for_pr_package_list(&bundle)
+            .is_err()
+    );
+    assert!(
+        processor
+            .release_pr_title_for_pr_package_list(&bundle)
+            .is_err()
+    );
+}

--- a/crates/core/src/packages/releasable_builder.rs
+++ b/crates/core/src/packages/releasable_builder.rs
@@ -73,7 +73,13 @@ impl ReleasablePackageBuilder for SerializableReleasablePackage {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{config::release_type::ReleaseType, forge::request::Tag};
+    use crate::{
+        config::{
+            defaults::DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE,
+            release_type::ReleaseType,
+        },
+        forge::request::Tag,
+    };
 
     use super::*;
 
@@ -90,6 +96,9 @@ mod tests {
             compiled_additional_manifests: vec![],
             analyzer_config: Default::default(),
             versioning_config: Default::default(),
+            commit_message_template: DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE
+                .into(),
+            pr_title_template: DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE.into(),
         }
     }
 

--- a/crates/core/src/packages/release_pr.rs
+++ b/crates/core/src/packages/release_pr.rs
@@ -11,6 +11,8 @@ pub struct ReleasePRPackage {
     pub sha_compare_link: String,
     pub file_changes: Vec<FileChange>,
     pub release_branch: String,
+    pub commit_message_template: String,
+    pub pr_title_template: String,
 }
 
 /// Groups the packages sharing a release branch with the existing open PR

--- a/crates/core/src/packages/resolved.rs
+++ b/crates/core/src/packages/resolved.rs
@@ -37,4 +37,6 @@ pub struct ResolvedPackage {
     pub aggregate_prereleases: bool,
     pub analyzer_config: AnalyzerConfig,
     pub versioning_config: VersioningConfig,
+    pub commit_message_template: String,
+    pub pr_title_template: String,
 }

--- a/crates/core/src/packages/resolved_hash.rs
+++ b/crates/core/src/packages/resolved_hash.rs
@@ -69,7 +69,10 @@ impl ResolvedPackageHash {
 mod tests {
     use crate::{
         analyzer::config::AnalyzerConfig,
-        config::{release_type::ReleaseType, versioning::VersioningConfig},
+        config::{
+            defaults::DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE,
+            release_type::ReleaseType, versioning::VersioningConfig,
+        },
     };
 
     use super::*;
@@ -88,6 +91,9 @@ mod tests {
             compiled_additional_manifests: vec![],
             analyzer_config: AnalyzerConfig::default(),
             versioning_config: VersioningConfig::default(),
+            commit_message_template: DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE
+                .into(),
+            pr_title_template: DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE.into(),
         }
     }
 

--- a/crates/core/src/resolver.rs
+++ b/crates/core/src/resolver.rs
@@ -13,6 +13,7 @@ use crate::{
         base_branch::resolve_base_branch,
         commit_modifiers::resolve_commit_modifiers,
         package::{PackageResolverParams, resolve_package},
+        templates::resolve_monorepo_templates,
     },
     result::{ReleasaurusError, Result},
 };
@@ -28,10 +29,16 @@ pub mod resolvers;
 /// [`ResolvedPackage`][crate::packages::resolved::ResolvedPackage]s
 /// held by `package_configs`.
 pub struct ResolvedConfig {
+    /// Repository name
+    pub repo_name: String,
     /// Branch release PRs target and commits are read from.
     pub base_branch: String,
     /// Whether each package gets its own release PR.
     pub separate_pull_requests: bool,
+    /// Template to use for commit messages when separate_pull_requests=false
+    pub monorepo_commit_message_template: String,
+    /// Template to use for PR titles when separate_pull_requests=false
+    pub monorepo_pr_title_template: String,
     /// Resolved per-package config, indexed by package name.
     pub package_configs: ResolvedPackageHash,
 }
@@ -80,26 +87,19 @@ impl Resolver {
             &self.commit_modifiers,
         )?;
 
-        let default_versioning = self.toml_config.defaults.versioning.as_ref();
-
-        let default_changelog = self
-            .toml_config
-            .defaults
-            .changelog
-            .clone()
-            .unwrap_or_default();
-
         let separate_pull_requests =
             self.toml_config.repository.separate_pull_requests;
 
         let mut resolved_packages = vec![];
 
+        let monorepo_templates =
+            resolve_monorepo_templates(&self.toml_config.defaults)?;
+
         for package in packages {
             let params = PackageResolverParams {
                 package_config: package,
                 repo_name: &self.repo_name,
-                default_versioning,
-                default_changelog: &default_changelog,
+                defaults: &self.toml_config.defaults,
                 commit_modifiers: &commit_modifiers,
                 package_overrides: &self.package_overrides,
                 global_overrides: &self.global_overrides,
@@ -115,9 +115,91 @@ impl Resolver {
         let resolved_hash = ResolvedPackageHash::new(resolved_packages)?;
 
         Ok(Rc::new(ResolvedConfig {
+            repo_name: self.repo_name.clone(),
             base_branch,
             package_configs: resolved_hash,
             separate_pull_requests,
+            monorepo_commit_message_template: monorepo_templates.commit_message,
+            monorepo_pr_title_template: monorepo_templates.pr_title,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::config::{defaults::DefaultsConfig, package::PackageConfig};
+
+    use super::*;
+
+    fn resolver(toml_config: Config) -> Resolver {
+        Resolver::builder()
+            .toml_config(Rc::new(toml_config))
+            .repo_name("test-repo")
+            .repo_default_branch("main")
+            .release_link_base_url(Url::parse("https://example.com/").unwrap())
+            .compare_link_base_url(
+                Url::parse("https://example.com/compare/").unwrap(),
+            )
+            .package_overrides(HashMap::new())
+            .global_overrides(GlobalOverrides::default())
+            .commit_modifiers(CommitModifiers::default())
+            .build()
+            .unwrap()
+    }
+
+    fn package(name: &str) -> PackageConfig {
+        PackageConfig {
+            name: name.into(),
+            ..PackageConfig::default()
+        }
+    }
+
+    /// `repo_name` and the two monorepo templates live on `ResolvedConfig`
+    /// rather than on a package, so nothing else in the pipeline covers
+    /// them reaching the other side of resolution.
+    #[test]
+    fn resolve_carries_repo_name_and_monorepo_templates() {
+        let resolver = resolver(Config {
+            defaults: DefaultsConfig {
+                monorepo_commit_message_template: Some("mono commit".into()),
+                monorepo_pr_title_template: Some("mono title".into()),
+                commit_message_template: Some("pkg commit".into()),
+                pr_title_template: Some("pkg title".into()),
+                ..DefaultsConfig::default()
+            },
+            ..Config::default()
+        });
+
+        let resolved = resolver.resolve(vec![package("test-pkg")]).unwrap();
+
+        assert_eq!(resolved.repo_name, "test-repo");
+        assert_eq!(resolved.monorepo_commit_message_template, "mono commit");
+        assert_eq!(resolved.monorepo_pr_title_template, "mono title");
+
+        let pkg = resolved.package_configs.get("test-pkg").unwrap();
+
+        assert_eq!(pkg.commit_message_template, "pkg commit");
+        assert_eq!(pkg.pr_title_template, "pkg title");
+    }
+
+    /// Validation runs during resolution, so a bad template stops the
+    /// release before any forge call is made.
+    #[test]
+    fn resolve_rejects_an_invalid_template() {
+        let resolver = resolver(Config {
+            defaults: DefaultsConfig {
+                monorepo_pr_title_template: Some("{{ package_name }}".into()),
+                ..DefaultsConfig::default()
+            },
+            ..Config::default()
+        });
+
+        let Err(err) = resolver.resolve(vec![package("test-pkg")]) else {
+            panic!("expected the invalid template to be rejected");
+        };
+
+        assert!(matches!(err, ReleasaurusError::InvalidConfig(_)));
     }
 }

--- a/crates/core/src/resolver/resolvers.rs
+++ b/crates/core/src/resolver/resolvers.rs
@@ -16,6 +16,7 @@ pub mod path_utils;
 pub mod prerelease;
 pub mod sub_packages;
 pub mod tag_prefix;
+pub mod templates;
 pub mod versioning;
 
 #[cfg(test)]

--- a/crates/core/src/resolver/resolvers/package.rs
+++ b/crates/core/src/resolver/resolvers/package.rs
@@ -2,7 +2,8 @@ use url::Url;
 
 use crate::{
     config::{
-        changelog::{ChangelogConfig, DEFAULT_AGGREGATE_PRERELEASES},
+        changelog::DEFAULT_AGGREGATE_PRERELEASES,
+        defaults::DefaultsConfig,
         overrides::{CommitModifiers, GlobalOverrides, PackageOverridesHash},
         package::PackageConfig,
         versioning::{DEFAULT_VERSION_TYPE, VersioningConfig},
@@ -16,6 +17,7 @@ use crate::{
         path_utils::{normalize_additional_paths, normalize_package_paths},
         sub_packages::resolve_sub_packages_full,
         tag_prefix::resolve_tag_prefix,
+        templates::resolve_package_templates,
         versioning::resolve_versioning,
     },
     result::Result,
@@ -24,8 +26,7 @@ use crate::{
 pub struct PackageResolverParams<'a> {
     pub package_config: PackageConfig,
     pub repo_name: &'a str,
-    pub default_versioning: Option<&'a VersioningConfig>,
-    pub default_changelog: &'a ChangelogConfig,
+    pub defaults: &'a DefaultsConfig,
     pub commit_modifiers: &'a CommitModifiers,
     pub package_overrides: &'a PackageOverridesHash,
     pub global_overrides: &'a GlobalOverrides,
@@ -39,8 +40,7 @@ pub fn resolve_package(
     let PackageResolverParams {
         package_config,
         repo_name,
-        default_versioning,
-        default_changelog,
+        defaults,
         commit_modifiers,
         package_overrides,
         global_overrides,
@@ -60,7 +60,7 @@ pub fn resolve_package(
     let versioning_config = resolve_versioning(
         &name,
         &package_config,
-        default_versioning,
+        defaults.versioning.as_ref(),
         package_overrides,
         global_overrides,
     )?;
@@ -83,8 +83,10 @@ pub fn resolve_package(
     let normalized_additional_paths =
         normalize_additional_paths(&package_config);
 
+    let default_changelog = defaults.changelog.clone().unwrap_or_default();
+
     let changelog_config =
-        resolve_changelog_config(&package_config, default_changelog);
+        resolve_changelog_config(&package_config, &default_changelog);
 
     let aggregate_prereleases = changelog_config
         .aggregate_prereleases
@@ -101,6 +103,9 @@ pub fn resolve_package(
     });
 
     let release_type = package_config.release_type.unwrap_or_default();
+
+    let templates =
+        resolve_package_templates(&name, &package_config, defaults)?;
 
     // Resolve sub-packages
     let sub_packages = resolve_sub_packages_full(
@@ -124,6 +129,8 @@ pub fn resolve_package(
         compiled_additional_manifests,
         analyzer_config,
         versioning_config,
+        commit_message_template: templates.commit_message,
+        pr_title_template: templates.pr_title,
     })
 }
 

--- a/crates/core/src/resolver/resolvers/sub_packages.rs
+++ b/crates/core/src/resolver/resolvers/sub_packages.rs
@@ -52,6 +52,10 @@ pub fn resolve_sub_packages_full(
                 compiled_additional_manifests: vec![],
                 analyzer_config: analyzer_config.clone(),
                 versioning_config: versioning_config.clone(),
+                // A sub-package shares its parent's release PR, so it
+                // never renders a commit message or title of its own.
+                commit_message_template: String::new(),
+                pr_title_template: String::new(),
             }
         })
         .collect()

--- a/crates/core/src/resolver/resolvers/templates.rs
+++ b/crates/core/src/resolver/resolvers/templates.rs
@@ -1,0 +1,448 @@
+//! Resolution and validation of the Tera templates used for release
+//! commit messages and PR titles.
+//!
+//! Templates are validated here rather than at render time so a typo
+//! fails before any forge call is made. See
+//! [`validate`] for why that matters.
+
+use crate::{
+    config::{
+        defaults::{
+            DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE,
+            DEFAULT_MONOREPO_COMMIT_AND_PR_TITLE_TEMPLATE, DefaultsConfig,
+        },
+        package::PackageConfig,
+    },
+    result::{ReleasaurusError, Result},
+};
+
+/// Templates for a PR covering a single package. Used when
+/// `separate_pull_requests` is enabled, and for a combined PR that ends
+/// up carrying only one package.
+#[derive(Debug)]
+pub struct PackageTemplates {
+    pub commit_message: String,
+    pub pr_title: String,
+}
+
+/// Templates for a combined PR carrying more than one package.
+#[derive(Debug)]
+pub struct MonorepoTemplates {
+    pub commit_message: String,
+    pub pr_title: String,
+}
+
+/// Variables a per-package template may reference, paired with the probe
+/// values used to validate it.
+///
+/// The probes are shaped like real values — a `v`-prefixed tag, a bare
+/// semver — so a template that pipes them through a filter validates the
+/// same way it will render.
+const PACKAGE_VARIABLES: &[(&str, &str)] = &[
+    ("branch", "main"),
+    ("repo_name", "repo"),
+    ("package_name", "package"),
+    ("tag", "v0.0.0"),
+    ("semver", "0.0.0"),
+];
+
+/// Variables a monorepo template may reference. Deliberately a subset of
+/// [`PACKAGE_VARIABLES`]: a combined PR spans several packages, so there
+/// is no single package name, tag, or version to offer.
+const MONOREPO_VARIABLES: &[(&str, &str)] =
+    &[("branch", "main"), ("repo_name", "repo")];
+
+/// Resolves the commit message and PR title templates for one package.
+///
+/// Precedence is the package's own value, then `[defaults]`, then the
+/// built-in [`DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE`].
+pub fn resolve_package_templates(
+    package_name: &str,
+    package_config: &PackageConfig,
+    defaults: &DefaultsConfig,
+) -> Result<PackageTemplates> {
+    let commit_message = resolve_package_template_with_defaults(
+        package_config.commit_message_template.as_ref(),
+        defaults.commit_message_template.as_ref(),
+    );
+
+    let pr_title = resolve_package_template_with_defaults(
+        package_config.pr_title_template.as_ref(),
+        defaults.pr_title_template.as_ref(),
+    );
+
+    let scope = format!("package \"{package_name}\"");
+
+    validate(
+        &scope,
+        "commit_message_template",
+        &commit_message,
+        PACKAGE_VARIABLES,
+    )?;
+    validate(&scope, "pr_title_template", &pr_title, PACKAGE_VARIABLES)?;
+
+    Ok(PackageTemplates {
+        commit_message,
+        pr_title,
+    })
+}
+
+/// Resolves the templates used for a combined PR carrying more than one
+/// package. These have no per-package override — a single PR spanning
+/// several packages has no one package to take them from.
+pub fn resolve_monorepo_templates(
+    defaults: &DefaultsConfig,
+) -> Result<MonorepoTemplates> {
+    let commit_message = defaults
+        .monorepo_commit_message_template
+        .clone()
+        .unwrap_or_else(|| {
+            DEFAULT_MONOREPO_COMMIT_AND_PR_TITLE_TEMPLATE.into()
+        });
+
+    let pr_title =
+        defaults
+            .monorepo_pr_title_template
+            .clone()
+            .unwrap_or_else(|| {
+                DEFAULT_MONOREPO_COMMIT_AND_PR_TITLE_TEMPLATE.into()
+            });
+
+    validate(
+        "[defaults]",
+        "monorepo_commit_message_template",
+        &commit_message,
+        MONOREPO_VARIABLES,
+    )?;
+    validate(
+        "[defaults]",
+        "monorepo_pr_title_template",
+        &pr_title,
+        MONOREPO_VARIABLES,
+    )?;
+
+    Ok(MonorepoTemplates {
+        commit_message,
+        pr_title,
+    })
+}
+
+/// First template set wins, falling back to the built-in default.
+fn resolve_package_template_with_defaults(
+    package: Option<&String>,
+    default: Option<&String>,
+) -> String {
+    package
+        .or(default)
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE.into())
+}
+
+/// Renders `template` against the probe values in `variables`, discarding
+/// the output.
+///
+/// This catches both malformed syntax and references to variables that
+/// will not be in the render context — notably a package-only variable
+/// such as `package_name` in a `monorepo_*` template, which the two-tier
+/// design invites. Tera treats an undefined variable as an error, so
+/// without this the mistake surfaces mid-release instead of at config
+/// load.
+fn validate(
+    scope: &str,
+    key: &str,
+    template: &str,
+    variables: &[(&str, &str)],
+) -> Result<()> {
+    let mut context = tera::Context::new();
+
+    for (name, probe) in variables {
+        context.insert(*name, probe);
+    }
+
+    tera::Tera::one_off(template, &context, false)
+        .map(|_| ())
+        .map_err(|e| {
+            ReleasaurusError::invalid_config(format!(
+                "{scope}: {key}: {}",
+                flatten(&e)
+            ))
+        })
+}
+
+/// Name Tera gives a [`tera::Tera::one_off`] template. It shows up in
+/// error messages, where it means nothing to someone editing a config
+/// file.
+const ONE_OFF_TEMPLATE_NAME: &str = "__tera_one_off";
+
+/// Joins a [`tera::Error`] with its source chain.
+///
+/// Tera's outermost message is only ever `Failed to parse/render
+/// '<template>'`; the actionable detail — the missing variable, the
+/// syntax error and its position — sits further down the chain, so
+/// reporting just the outermost error would say nothing useful.
+fn flatten(err: &tera::Error) -> String {
+    let mut messages = vec![];
+    let mut next: Option<&(dyn std::error::Error + 'static)> = Some(err);
+
+    while let Some(err) = next {
+        messages.push(err.to_string().trim().to_string());
+        next = err.source();
+    }
+
+    messages
+        .join(": ")
+        .replace(&format!(" while rendering '{ONE_OFF_TEMPLATE_NAME}'"), "")
+        .replace(&format!("'{ONE_OFF_TEMPLATE_NAME}'"), "template")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::resolver::resolvers::test_helper::create_test_package;
+
+    use super::*;
+
+    /// Every variable the book documents for a per-package template must
+    /// be in the probe context, or a valid template would be rejected at
+    /// config load.
+    const ALL_PACKAGE_VARIABLES: &str = "{{ branch }} {{ repo_name }} \
+         {{ package_name }} {{ tag }} {{ semver }}";
+
+    const ALL_MONOREPO_VARIABLES: &str = "{{ branch }} {{ repo_name }}";
+
+    fn defaults_with(
+        commit_message: Option<&str>,
+        pr_title: Option<&str>,
+    ) -> DefaultsConfig {
+        DefaultsConfig {
+            commit_message_template: commit_message.map(Into::into),
+            pr_title_template: pr_title.map(Into::into),
+            ..DefaultsConfig::default()
+        }
+    }
+
+    #[test]
+    fn package_template_precedence() {
+        let mut pkg = create_test_package("test");
+        pkg.commit_message_template = Some("pkg commit".into());
+        pkg.pr_title_template = Some("pkg title".into());
+
+        let defaults =
+            defaults_with(Some("default commit"), Some("default title"));
+
+        // Package wins over defaults
+        let templates =
+            resolve_package_templates("test", &pkg, &defaults).unwrap();
+        assert_eq!(templates.commit_message, "pkg commit");
+        assert_eq!(templates.pr_title, "pkg title");
+
+        // Package wins with no defaults set
+        let templates =
+            resolve_package_templates("test", &pkg, &DefaultsConfig::default())
+                .unwrap();
+        assert_eq!(templates.commit_message, "pkg commit");
+        assert_eq!(templates.pr_title, "pkg title");
+
+        // Defaults win when the package is silent
+        let templates = resolve_package_templates(
+            "test",
+            &create_test_package("test"),
+            &defaults,
+        )
+        .unwrap();
+        assert_eq!(templates.commit_message, "default commit");
+        assert_eq!(templates.pr_title, "default title");
+
+        // Built-in when neither is set
+        let templates = resolve_package_templates(
+            "test",
+            &create_test_package("test"),
+            &DefaultsConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            templates.commit_message,
+            DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE
+        );
+        assert_eq!(templates.pr_title, DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE);
+    }
+
+    /// The two templates resolve through separate but identically-shaped
+    /// chains, so a swapped field would otherwise go unnoticed.
+    #[test]
+    fn resolves_each_template_independently() {
+        let mut pkg = create_test_package("test");
+        pkg.commit_message_template = Some("only commit".into());
+
+        let templates =
+            resolve_package_templates("test", &pkg, &DefaultsConfig::default())
+                .unwrap();
+
+        assert_eq!(templates.commit_message, "only commit");
+        assert_eq!(templates.pr_title, DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE);
+
+        let mut pkg = create_test_package("test");
+        pkg.pr_title_template = Some("only title".into());
+
+        let templates =
+            resolve_package_templates("test", &pkg, &DefaultsConfig::default())
+                .unwrap();
+
+        assert_eq!(
+            templates.commit_message,
+            DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE
+        );
+        assert_eq!(templates.pr_title, "only title");
+
+        // Same independence one tier down, in [defaults]
+        let templates = resolve_package_templates(
+            "test",
+            &create_test_package("test"),
+            &defaults_with(Some("only default commit"), None),
+        )
+        .unwrap();
+
+        assert_eq!(templates.commit_message, "only default commit");
+        assert_eq!(templates.pr_title, DEFAULT_COMMIT_AND_PR_TITLE_TEMPLATE);
+    }
+
+    #[test]
+    fn monorepo_template_precedence() {
+        let defaults = DefaultsConfig {
+            monorepo_commit_message_template: Some("mono commit".into()),
+            monorepo_pr_title_template: Some("mono title".into()),
+            ..DefaultsConfig::default()
+        };
+
+        let templates = resolve_monorepo_templates(&defaults).unwrap();
+        assert_eq!(templates.commit_message, "mono commit");
+        assert_eq!(templates.pr_title, "mono title");
+
+        let templates =
+            resolve_monorepo_templates(&DefaultsConfig::default()).unwrap();
+        assert_eq!(
+            templates.commit_message,
+            DEFAULT_MONOREPO_COMMIT_AND_PR_TITLE_TEMPLATE
+        );
+        assert_eq!(
+            templates.pr_title,
+            DEFAULT_MONOREPO_COMMIT_AND_PR_TITLE_TEMPLATE
+        );
+    }
+
+    #[test]
+    fn accepts_all_documented_package_variables() {
+        let mut pkg = create_test_package("test");
+        pkg.commit_message_template = Some(ALL_PACKAGE_VARIABLES.into());
+        pkg.pr_title_template = Some(ALL_PACKAGE_VARIABLES.into());
+
+        let result =
+            resolve_package_templates("test", &pkg, &DefaultsConfig::default());
+
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    #[test]
+    fn accepts_all_documented_monorepo_variables() {
+        let defaults = DefaultsConfig {
+            monorepo_commit_message_template: Some(
+                ALL_MONOREPO_VARIABLES.into(),
+            ),
+            monorepo_pr_title_template: Some(ALL_MONOREPO_VARIABLES.into()),
+            ..DefaultsConfig::default()
+        };
+
+        let result = resolve_monorepo_templates(&defaults);
+
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+
+    /// The built-in defaults must survive their own validation.
+    #[test]
+    fn accepts_the_built_in_defaults() {
+        assert!(
+            resolve_package_templates(
+                "test",
+                &create_test_package("test"),
+                &DefaultsConfig::default(),
+            )
+            .is_ok()
+        );
+
+        assert!(resolve_monorepo_templates(&DefaultsConfig::default()).is_ok());
+    }
+
+    #[test]
+    fn rejects_unknown_variable_in_package_template() {
+        let mut pkg = create_test_package("test");
+        pkg.pr_title_template = Some("release {{ pkg_name }}".into());
+
+        let err =
+            resolve_package_templates("test", &pkg, &DefaultsConfig::default())
+                .unwrap_err();
+
+        assert!(matches!(err, ReleasaurusError::InvalidConfig(_)));
+    }
+
+    /// A monorepo template covers several packages at once, so the
+    /// package-scoped variables are absent. This is the mistake the
+    /// two-tier design invites, and it must fail at config load.
+    #[test]
+    fn rejects_package_only_variable_in_monorepo_template() {
+        for template in [
+            "release {{ package_name }}",
+            "release {{ tag }}",
+            "release {{ semver }}",
+        ] {
+            let defaults = DefaultsConfig {
+                monorepo_pr_title_template: Some(template.into()),
+                ..DefaultsConfig::default()
+            };
+
+            let err = resolve_monorepo_templates(&defaults).unwrap_err();
+
+            assert!(
+                matches!(err, ReleasaurusError::InvalidConfig(_)),
+                "expected {template} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_template_syntax() {
+        let mut pkg = create_test_package("test");
+        pkg.commit_message_template = Some("release {{ branch".into());
+
+        let err =
+            resolve_package_templates("test", &pkg, &DefaultsConfig::default())
+                .unwrap_err();
+
+        assert!(matches!(err, ReleasaurusError::InvalidConfig(_)));
+
+        let defaults = DefaultsConfig {
+            monorepo_commit_message_template: Some(
+                "release {% if branch %}".into(),
+            ),
+            ..DefaultsConfig::default()
+        };
+
+        let err = resolve_monorepo_templates(&defaults).unwrap_err();
+
+        assert!(matches!(err, ReleasaurusError::InvalidConfig(_)));
+    }
+
+    /// Filters are a common reason to reach for a template, so the probe
+    /// values have to survive being piped through one.
+    #[test]
+    fn accepts_filters_applied_to_probe_values() {
+        let mut pkg = create_test_package("test");
+        pkg.pr_title_template = Some(
+            r#"{{ package_name | upper }} {{ tag | replace(from="v", to="") }}"#
+                .into(),
+        );
+
+        let result =
+            resolve_package_templates("test", &pkg, &DefaultsConfig::default());
+
+        assert!(result.is_ok(), "{:?}", result.err());
+    }
+}

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -20,6 +20,10 @@
       "description": "Default configuration applied to every package",
       "$ref": "#/$defs/DefaultsConfig",
       "default": {
+        "monorepo_commit_message_template": null,
+        "monorepo_pr_title_template": null,
+        "commit_message_template": null,
+        "pr_title_template": null,
         "versioning": null,
         "changelog": null
       }
@@ -41,7 +45,9 @@
           "additional_paths": null,
           "additional_manifest_files": null,
           "changelog": null,
-          "versioning": null
+          "versioning": null,
+          "commit_message_template": null,
+          "pr_title_template": null
         }
       ]
     }
@@ -121,6 +127,38 @@
       "description": "Default configuration applied to every package",
       "type": "object",
       "properties": {
+        "monorepo_commit_message_template": {
+          "description": "Tera template for generating release commit messages when\nrepository.separate_pull_requests=false and multiple packages\nconfigured. Has the following variables available in the template\ncontext: branch, repo_name",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "chore({{ branch }}): release {{ repo_name }}"
+        },
+        "monorepo_pr_title_template": {
+          "description": "Tera template for generating release PR titles when\nrepository.separate_pull_requests=false and multiple packages\nconfigured. Has the following variables available in the template\ncontext: branch, repo_name",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "chore({{ branch }}): release {{ repo_name }}"
+        },
+        "commit_message_template": {
+          "description": "Tera template for generating release commit messages. When\nrepository.separate_pull_requests=true, or only one package configured,\nthis template will be used for each individual PR commit but can be\noverridden at the package level. Has the following variables available\nin the template context: branch, repo_name, package_name, tag, semver",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "chore({{ branch }}): release {{ package_name }} {{ tag }}"
+        },
+        "pr_title_template": {
+          "description": "Tera template for generating release PR titles. When\nrepository.separate_pull_requests=true, or only one package configured,\nthis template will be used for each individual PR title but can be\noverridden at the package level. Has the following variables available\nin the template context: branch, repo_name, package_name, tag, semver",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": "chore({{ branch }}): release {{ package_name }} {{ tag }}"
+        },
         "versioning": {
           "description": "Default versioning config. Packages can override this configuration",
           "anyOf": [
@@ -643,6 +681,22 @@
             {
               "type": "null"
             }
+          ],
+          "default": null
+        },
+        "commit_message_template": {
+          "description": "Tera template for generating release commit messages. When\nrepository.separate_pull_requests=true, or only one package configured,\nthis template will be used for the package PR commit message. When\nrepository.separate_pull_requests=false and multiple packages\nconfigured, the template defined for\ndefaults.monorepo_commit_message_template is used instead. Has the\nfollowing variables available in the template context: branch,\nrepo_name, package_name, tag, semver",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "pr_title_template": {
+          "description": "Tera template for generating release PR titles. When\nrepository.separate_pull_requests=true, or only one package configured,\nthis template will be used for the package PR title. When\nrepository.separate_pull_requests=false and multiple packages\nconfigured, the template defined for defaults.monorepo_pr_title_template\nis used instead. Has the following variables available in the template\ncontext: branch, repo_name, package_name, tag, semver",
+          "type": [
+            "string",
+            "null"
           ],
           "default": null
         }


### PR DESCRIPTION
## Description

Allows users to set tera templates for generating release commit messages and PR titles.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)

## Related Issues

Addresses #350 

