### PR TITLE
fix!: fixes issues with misalignment of breaking group and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ cd book
 mdbook serve --open
 ```
 
+## Upgrading to v1.0.0
+
+v1.0.0 restructures `releasaurus.toml`; a v0.22.x config will not load.
+See the [migration guide](./book/src/migration-0.22-to-1.0.md)
+([published version](https://releasaurus.rgon.io/migration-0.22-to-1.0.html)).
+
 ## License
 
 Licensed under either of

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,6 +6,10 @@
 
 - [Getting Started](./getting-started.md)
 
+# Migration
+
+- [v0.22 to v1.0](./migration-0.22-to-1.0.md)
+
 # Guide
 
 - [Commands](./commands.md)

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -45,15 +45,43 @@ Releasaurus ships with these default parsers:
 | `ci`             | `^ci`       | `⏩ CI/CD`               | `10`  |
 | `miscellaneous`  | `.*`        | `⚙️ Miscellaneous Tasks` | `11`  |
 
-`breaking` has no default `pattern` — breaking changes are detected via
-conventional-commit syntax (`feat!:`, `BREAKING CHANGE:`). Setting a
-`pattern` on `breaking` uses your pattern instead, but only for
-changelog grouping: the version bump is always computed from
-conventional-commit syntax, so a `feat!:` still bumps major even if your
-pattern routes it under another group. To make additional patterns bump
-the major version, use [`custom_major_increment_regex`][major-regex].
+`breaking` is the one group not selected by its `pattern`. A commit is
+breaking when conventional-commit syntax says so — a `!` before the
+colon, or a `BREAKING CHANGE:` footer — and breaking always wins over
+the commit's type, so `feat!: …` lands under `❌ Breaking` rather than
+`🚀 Features`.
+
+Setting `breaking.pattern` **adds to** that detection rather than
+replacing it. Commits matching your pattern are treated as breaking on
+top of the ones conventional syntax already catches, so you cannot lose
+a `feat!:` by writing a pattern that doesn't happen to match it:
+
+```toml
+[defaults.versioning.named_parsers]
+breaking.pattern = "^breaking"
+```
+
+With that config, both `breaking: drop the v1 endpoint` and
+`feat!: drop the v1 endpoint` are grouped under `❌ Breaking` and bump
+the major version.
+
+`breaking.pattern` and [`custom_major_increment_regex`][major-regex] are
+two spellings of the same thing — a pattern that marks a commit
+breaking. Either one groups the commit under `❌ Breaking`, marks it
+`[**breaking**]` in the default template, and bumps major. Setting both
+is fine; the two are combined, and a commit matching either is breaking.
+Reach for `breaking.pattern` when you are already customizing
+`named_parsers`, and `custom_major_increment_regex` when versioning is
+all you care about.
 
 [major-regex]: ./configuration-reference.md#custom-increment-regexes
+
+Because breaking is decided before the type patterns are consulted,
+`skip` on another group cannot swallow a breaking commit — a `feat!:`
+reaches `❌ Breaking` even with `feature.skip = true`. The two ways a
+breaking change can still be dropped are both explicit: `breaking.skip
+= true`, or a custom parser with `skip = true` that matches it (see
+below).
 
 Override only the fields you want to change under
 `[defaults.versioning.named_parsers]`; everything you omit falls back to the

--- a/book/src/configuration-reference.md
+++ b/book/src/configuration-reference.md
@@ -81,8 +81,8 @@ table (see [`[[package]]`](#package)).
 | `auto_start_next`                 | bool   | `false`             | Bump patch versions automatically after a release (see [`start-next`](./commands.md#start-next)).                                                     |
 | `breaking_always_increment_major` | bool   | `true`              | Breaking changes (`feat!:`, `BREAKING CHANGE:`) bump major.                                                                                           |
 | `features_always_increment_minor` | bool   | `true`              | `feat:` commits bump minor.                                                                                                                           |
-| `custom_major_increment_regex`    | string | none                | Additional regex that triggers a major bump.                                                                                                          |
-| `custom_minor_increment_regex`    | string | none                | Additional regex that triggers a minor bump.                                                                                                          |
+| `custom_major_increment_regex`    | string | none                | Additional regex marking a commit breaking: bumps major **and** groups it under `❌ Breaking`.                                                         |
+| `custom_minor_increment_regex`    | string | none                | Additional regex that triggers a minor bump. No grouping effect.                                                                                       |
 | `skip_merge_commits`              | bool   | `true`              | Exclude merge commits.                                                                                                                                |
 | `named_parsers`                   | table  | built-in groups     | Override built-in commit groups (`pattern`/`title`/`order`/`skip` per group). See [Changelog Customization](./changelog.md#commit-groups--filtering). |
 | `custom_parser`                   | array  | none                | Define additional commit groups, checked before the defaults. Note the singular key. `pattern`, `title` and `order` are all required.                 |
@@ -100,6 +100,19 @@ message. In TOML double-quoted strings, escape backslashes (`\\`):
 custom_major_increment_regex = "\\[MAJOR\\]"   # matches "[MAJOR]"
 custom_minor_increment_regex = "FEATURE"        # no escaping needed
 ```
+
+The two are not symmetric. `custom_major_increment_regex` marks a
+matching commit **breaking**, which groups it under `❌ Breaking` and
+marks it `[**breaking**]` in the default body template as well as bumping
+major. `custom_minor_increment_regex` only affects the version.
+
+`[defaults.versioning.named_parsers] breaking.pattern` is the same
+mechanism as `custom_major_increment_regex` under a different name; set
+either, or both, in which case a commit matching either is breaking. See
+[Commit Groups & Filtering](./changelog.md#built-in-groups-named_parsers).
+
+An invalid pattern is rejected when the config loads, not part-way
+through a release.
 
 ### `[defaults.versioning.prerelease]`
 

--- a/book/src/migration-0.22-to-1.0.md
+++ b/book/src/migration-0.22-to-1.0.md
@@ -18,7 +18,9 @@ here is optional: a 0.22 config will not load on 1.0.0.
 4. [Monorepo commit message and PR
    title](#monorepo-commit-message-and-pr-title) — the default now
    includes the repository name.
-5. [Library API](#library-api) — for Rust consumers of
+5. [`custom_major_increment_regex`](#custom_major_increment_regex-now-groups-commits-as-breaking)
+   — matching commits are now grouped as breaking, not just bumped.
+6. [Library API](#library-api) — for Rust consumers of
    `releasaurus-core`.
 
 Unknown keys are now rejected at config load. A key you forget to move
@@ -58,9 +60,9 @@ Configuration is now grouped under three top-level tables:
 - `[[package]]` — one entry per package, unchanged in spirit; each may
   override `[defaults]` with its own `versioning` and `changelog`.
 
-The full reference lives in the book at
-[`book/src/configuration-reference.md`](./book/src/configuration-reference.md).
-The tables below cover only what moved.
+The full reference lives in the
+[Configuration Reference](./configuration-reference.md). The tables
+below cover only what moved.
 
 ### Root-level keys
 
@@ -124,7 +126,7 @@ Three group names are spelled out rather than abbreviated — watch
 
 So this:
 
-```toml
+```text
 [changelog]
 skip_ci = true
 skip_chore = true
@@ -173,7 +175,7 @@ is almost never what you want:
 
 Before:
 
-```toml
+```text
 [[package]]
 name = "backend"
 path = "./services/api"
@@ -201,7 +203,7 @@ built-in `versioned`.
 
 This repository's own config, before and after. Before:
 
-```toml
+```text
 #:schema ./schema/schema.json
 
 tag_search_depth = 25
@@ -284,10 +286,11 @@ unexpected version.
 
 Release commit messages and PR titles are now rendered from Tera
 templates, and the default for combined monorepo PRs includes the
-repository name. This is the one change that alters output without any
-config edit on your part, so check anything that matches on release PR
-titles — branch protection rules, required status checks, CI `if:`
-conditions, merge automation.
+repository name. This is one of two changes that alter output without
+any config edit on your part (the other is
+[`custom_major_increment_regex`](#custom_major_increment_regex-now-groups-commits-as-breaking)),
+so check anything that matches on release PR titles — branch protection
+rules, required status checks, CI `if:` conditions, merge automation.
 
 0.22.x picked the format from how many packages happened to be in the
 PR on that run:
@@ -324,6 +327,30 @@ per-package templates additionally have `package_name`, `tag`, and
 `semver`. Referencing a variable that is not in scope is rejected at
 config load.
 
+## `custom_major_increment_regex` now groups commits as breaking
+
+The key moved to `[defaults.versioning]` like the rest, but its effect
+also widened. In 0.22.x it only influenced the version bump; a matching
+commit still appeared under whatever group its type prefix selected. In
+1.0.0 a commit it matches is treated as breaking outright: grouped under
+`❌ Breaking`, marked `[**breaking**]` in the default body template, and
+bumping major as before.
+
+**Who this affects:** anyone who already sets
+`custom_major_increment_regex`. No config edit is required and the
+computed version does not change — only which changelog heading those
+commits appear under.
+
+If you were relying on the old split — bump major, but keep the commit
+filed under its own type — there is no longer a setting for that; the
+two concepts are deliberately unified. The reverse case is now possible
+though: `[defaults.versioning.named_parsers] breaking.pattern` is the
+same mechanism under a different name, so pick whichever key reads
+better and know they are combined if you set both.
+
+`custom_minor_increment_regex` is unchanged — it affects the version
+bump only, with no grouping effect.
+
 ## Library API
 
 For Rust consumers of the `releasaurus-core` crate. The CLI binary
@@ -345,10 +372,9 @@ Beyond the moves:
   hang off `ResolvedConfig::package_configs`. Drop the
   `.package_configs(...)` call from `Orchestrator::builder()`. The
   crate-level quick start in
-  [`crates/core/src/lib.rs`](./crates/core/src/lib.rs) shows the full
-  builder chain, and
-  [`book/src/library-api.md`](./book/src/library-api.md) has the
-  narrative version.
+  [`crates/core/src/lib.rs`](https://github.com/robgonnella/releasaurus/blob/main/crates/core/src/lib.rs)
+  shows the full builder chain, and [Library API](./library-api.md) has
+  the narrative version.
 - **`PrereleaseConfig::suffix` is a `String`**, not an
   `Option<String>`. The `suffix()` accessor that unwrapped it is gone —
   read the field directly, and treat `""` as "no prerelease".

--- a/crates/core/src/analyzer/commit.rs
+++ b/crates/core/src/analyzer/commit.rs
@@ -90,7 +90,7 @@ impl Commit {
         // Conventional commits give us a scope, a description, and breaking
         // change details. Anything that doesn't parse falls back to the raw
         // title/body split above.
-        let (scope, title, body, breaking, breaking_description) =
+        let (scope, title, body, mut breaking, breaking_description) =
             match ConventionalCommit::parse(raw_message.trim_end()) {
                 Ok(cc) => (
                     cc.scope().map(|s| s.to_string()),
@@ -101,6 +101,13 @@ impl Commit {
                 ),
                 Err(_) => (None, raw_title.clone(), raw_body, false, None),
             };
+
+        if !breaking
+            && let Some(custom) = config.custom_major_increment_regex.as_ref()
+            && custom.is_match(&raw_message)
+        {
+            breaking = true;
+        }
 
         let mut commit = Self {
             id: commit_id,

--- a/crates/core/src/analyzer/config.rs
+++ b/crates/core/src/analyzer/config.rs
@@ -2,6 +2,7 @@
 
 use derive_builder::Builder;
 use indexmap::IndexMap;
+use regex::Regex;
 use url::Url;
 
 use crate::config::{
@@ -45,9 +46,9 @@ pub struct AnalyzerConfig {
     /// built; not consulted for date-based version types.
     pub features_always_increment_minor: Option<bool>,
     /// Custom commit type regex matcher to increment major version
-    pub custom_major_increment_regex: Option<String>,
+    pub custom_major_increment_regex: Option<Regex>,
     /// Custom commit type regex matcher to increment minor version
-    pub custom_minor_increment_regex: Option<String>,
+    pub custom_minor_increment_regex: Option<Regex>,
     /// Custom commit modifiers to skip commit shas or reword commit messages
     /// when generating changelog content
     pub commit_modifiers: CommitModifiers,

--- a/crates/core/src/analyzer/group.rs
+++ b/crates/core/src/analyzer/group.rs
@@ -65,20 +65,9 @@ impl<'a> GroupParser<'a> {
         // this group.
         let breaking_parser = self.named_parsers.get(&Group::Breaking);
 
-        // If there is a user defined breaking parser i.e. pattern is some,
-        // use it
-        if let Some(parser) = breaking_parser
-            && let Some(pattern) = parser.pattern.as_ref()
-            && pattern.is_match(msg)
-        {
-            return Some(parser.into());
-        }
-
-        // If no user defined breaking parser is defined, use conventional
-        // commit parsing to determine breaking group
+        // Use conventional commit parsing to determine breaking group
         if commit.breaking
             && let Some(parser) = breaking_parser
-            && parser.pattern.is_none()
         {
             return Some(parser.into());
         }
@@ -447,32 +436,60 @@ mod tests {
         assert_eq!(parsed.group, custom[0].group_title());
     }
 
+    /// `Group::Breaking` is the one group this parser does not select by
+    /// `pattern` - it reads [`Commit::breaking`] instead. A user pattern
+    /// reaches that flag earlier, in
+    /// [`parse_forge_commit`][crate::analyzer::commit::Commit::parse_forge_commit],
+    /// via the resolved `custom_major_increment_regex`; by the time a commit
+    /// gets here the decision is already made. So `breaking.pattern` is
+    /// deliberately inert at this layer, and the flag alone decides.
+    ///
+    /// Set the pattern to something the message cannot match, to pin that the
+    /// flag is what is consulted rather than the pattern.
     #[test]
-    fn test_group_parser_user_defined_breaking_pattern() {
-        // Give the breaking parser an explicit pattern. This overrides
-        // conventional-commit breaking detection: only messages matching
-        // the pattern are classified as breaking.
+    fn test_group_parser_breaking_is_driven_by_flag_not_pattern() {
         let mut named_parsers = NAMED_PARSERS.clone();
         let breaking_parser = named_parsers.get_mut(&Group::Breaking).unwrap();
-        breaking_parser.pattern = Some(Regex::new(r"^breaking").unwrap());
+        breaking_parser.pattern = Some(Regex::new(r"^never-matches").unwrap());
         let breaking_title = breaking_parser.group_title();
+        let feature_title =
+            NAMED_PARSERS.get(&Group::Feature).unwrap().group_title();
 
         let parser = GroupParser::new(&named_parsers, &[]);
 
-        // A message matching the custom pattern lands in the breaking group.
-        let matching = create_test_commit("breaking: drop legacy api", false);
-        let parsed = parser.parse(&matching).unwrap();
-        assert_eq!(parsed.group, breaking_title);
+        // Flagged breaking, pattern does not match: still breaking.
+        let flagged = create_test_commit("feat!: drop legacy api", true);
+        assert_eq!(parser.parse(&flagged).unwrap().group, breaking_title);
 
-        // A conventional `feat!:` breaking commit whose message does NOT
-        // match the custom pattern falls through to the Feature group. Once
-        // a breaking pattern is defined, it is the user's responsibility to
-        // make it match the commits they consider breaking.
-        let feat_breaking = create_test_commit("feat!: breaking feature", true);
-        let feature_title =
-            NAMED_PARSERS.get(&Group::Feature).unwrap().group_title();
-        let parsed = parser.parse(&feat_breaking).unwrap();
-        assert_eq!(parsed.group, feature_title);
+        // Not flagged, and the pattern is irrelevant here: falls through to
+        // the ordinary type patterns.
+        let unflagged = create_test_commit("feat: add a thing", false);
+        assert_eq!(parser.parse(&unflagged).unwrap().group, feature_title);
+    }
+
+    /// Breaking is decided before the type patterns are consulted, so a
+    /// `skip` on another group cannot swallow a breaking commit - a `feat!:`
+    /// reaches `Breaking` even with `feature.skip = true`. An earlier design
+    /// let this combination drop the commit from both the changelog and the
+    /// version calculation; `book/src/changelog.md` now documents that it
+    /// cannot, and this pins it.
+    #[test]
+    fn test_group_parser_feature_skip_does_not_drop_breaking_commit() {
+        let mut named_parsers = NAMED_PARSERS.clone();
+
+        named_parsers.get_mut(&Group::Feature).unwrap().skip = Some(true);
+
+        let parser = GroupParser::new(&named_parsers, &[]);
+
+        let commit = create_test_commit("feat!: breaking feature", true);
+        let parsed = parser.parse(&commit).unwrap();
+        let breaking_parser = &named_parsers[&Group::Breaking];
+
+        assert!(
+            !parsed.skip,
+            "a conventional breaking commit should not be skipped"
+        );
+        assert_eq!(parsed.group, breaking_parser.group_title())
     }
 
     /// Miscellaneous is the catch-all even when its pattern no longer matches

--- a/crates/core/src/analyzer/tests/version_rules.rs
+++ b/crates/core/src/analyzer/tests/version_rules.rs
@@ -8,12 +8,88 @@
 //! - Combined flag scenarios
 //! - Non-conventional commit matching
 
+use regex::Regex;
 use semver::Version as SemVer;
 
 use crate::{
     analyzer::{Analyzer, config::AnalyzerConfig},
+    config::versioning::{Group, NAMED_PARSERS},
     forge::request::{ForgeCommit, Tag},
 };
+
+/// `custom_major_increment_regex` does not only bump the version - a commit
+/// it matches is treated as breaking outright, which means the `Breaking`
+/// changelog group and the `breaking` flag the default body template gates
+/// its `[**breaking**]` marker on.
+///
+/// This is the whole reason the flag is set during commit parsing rather than
+/// left to the version updater, and it is the half a version-only assertion
+/// misses: the bump comes from `next_version` reading the raw messages, so it
+/// happens either way and cannot distinguish the two designs.
+///
+/// `breaking.pattern` resolves into this same field (see
+/// `resolve_versioning`), so this covers both spellings.
+#[test]
+fn test_custom_major_regex_marks_commit_breaking_and_groups_it() {
+    let config = AnalyzerConfig {
+        custom_major_increment_regex: Some(Regex::new("^breaking").unwrap()),
+        ..AnalyzerConfig::default()
+    };
+    let breaking_title =
+        NAMED_PARSERS.get(&Group::Breaking).unwrap().group_title();
+    let analyzer = Analyzer::new(&config).unwrap();
+
+    let current_tag = Tag {
+        sha: "old123".to_string(),
+        name: "1.0.0".to_string(),
+        semver: SemVer::parse("1.0.0").unwrap(),
+        ..Tag::default()
+    };
+
+    let commits = vec![
+        ForgeCommit {
+            id: "abc123".to_string(),
+            message: "breaking: drop the v1 endpoint".to_string(),
+            timestamp: 2000,
+            ..ForgeCommit::default()
+        },
+        ForgeCommit {
+            id: "def456".to_string(),
+            message: "chore: tidy up".to_string(),
+            timestamp: 1000,
+            ..ForgeCommit::default()
+        },
+    ];
+
+    let release = analyzer
+        .analyze(commits, Some(current_tag))
+        .unwrap()
+        .unwrap();
+
+    let matched = release
+        .commits
+        .iter()
+        .find(|c| c.id == "abc123")
+        .expect("matching commit should survive analysis");
+
+    assert!(
+        matched.breaking,
+        "a matching commit must be flagged breaking"
+    );
+    assert_eq!(matched.group, breaking_title);
+    assert_eq!(release.tag.semver, SemVer::parse("2.0.0").unwrap());
+
+    // A commit the pattern does not match is untouched, so the regex cannot
+    // be quietly matching everything.
+    let other = release
+        .commits
+        .iter()
+        .find(|c| c.id == "def456")
+        .expect("non-matching commit should survive analysis");
+
+    assert!(!other.breaking);
+    assert_ne!(other.group, breaking_title);
+}
 
 /// Both increment flags reach the analyzer as `Option<bool>` - the resolver
 /// passes the config tiers through unresolved - so the default is applied
@@ -120,8 +196,9 @@ fn test_breaking_always_increment_major_disabled() {
 
 #[test]
 fn test_custom_major_regex_works_with_breaking_syntax() {
+    let major_regex = Regex::new("MAJOR").unwrap();
     let config = AnalyzerConfig {
-        custom_major_increment_regex: Some("MAJOR".to_string()),
+        custom_major_increment_regex: Some(major_regex),
         ..AnalyzerConfig::default()
     };
 
@@ -151,8 +228,9 @@ fn test_custom_major_regex_works_with_breaking_syntax() {
 
 #[test]
 fn test_custom_major_increment_regex() {
+    let doc_regex = Regex::new("doc").unwrap();
     let config = AnalyzerConfig {
-        custom_major_increment_regex: Some("doc".to_string()),
+        custom_major_increment_regex: Some(doc_regex),
         ..AnalyzerConfig::default()
     };
 
@@ -211,8 +289,9 @@ fn test_features_always_increment_minor_disabled() {
 
 #[test]
 fn test_custom_minor_increment_regex() {
+    let ci_regex = Regex::new(r"^ci").unwrap();
     let config = AnalyzerConfig {
-        custom_minor_increment_regex: Some("^ci".to_string()),
+        custom_minor_increment_regex: Some(ci_regex),
         ..AnalyzerConfig::default()
     };
     let analyzer = Analyzer::new(&config).unwrap();
@@ -240,8 +319,9 @@ fn test_custom_minor_increment_regex() {
 
 #[test]
 fn test_custom_minor_regex_works_with_feat_syntax() {
+    let ci_regex = Regex::new(r"ci").unwrap();
     let config = AnalyzerConfig {
-        custom_minor_increment_regex: Some("ci".to_string()),
+        custom_minor_increment_regex: Some(ci_regex),
         ..AnalyzerConfig::default()
     };
     let analyzer = Analyzer::new(&config).unwrap();
@@ -353,8 +433,9 @@ fn test_both_boolean_flags_disabled_patch_bump() {
 
 #[test]
 fn test_custom_regex_matches_non_conventional_commit() {
+    let wow_regex = Regex::new(r"wow").unwrap();
     let config = AnalyzerConfig {
-        custom_major_increment_regex: Some("wow".to_string()),
+        custom_major_increment_regex: Some(wow_regex),
         ..AnalyzerConfig::default()
     };
     let analyzer = Analyzer::new(&config).unwrap();

--- a/crates/core/src/analyzer/version_strategy/context.rs
+++ b/crates/core/src/analyzer/version_strategy/context.rs
@@ -59,13 +59,13 @@ impl<'a> Context<'a> {
             );
 
         if let Some(regex) = self.config.custom_major_increment_regex.as_ref() {
-            version_updater =
-                version_updater.with_custom_major_increment_regex(regex)?;
+            version_updater = version_updater
+                .with_custom_major_increment_regex(regex.as_str())?;
         }
 
         if let Some(regex) = self.config.custom_minor_increment_regex.as_ref() {
-            version_updater =
-                version_updater.with_custom_minor_increment_regex(regex)?;
+            version_updater = version_updater
+                .with_custom_minor_increment_regex(regex.as_str())?;
         }
 
         Ok(version_updater)

--- a/crates/core/src/config/toml.rs
+++ b/crates/core/src/config/toml.rs
@@ -76,6 +76,11 @@ mod tests {
     /// With `deny_unknown_fields`, this catches documented keys that don't
     /// exist or sit under the wrong table - the docs cannot drift from the
     /// config structs without failing here.
+    ///
+    /// The migration guide is included for its "after" examples, which are
+    /// what an upgrading user copies. Its "before" examples are deliberately
+    /// v0.22 config and would fail here, so they are fenced as ```text -
+    /// leave them that way.
     #[test]
     fn parses_every_toml_example_in_the_book() {
         const PAGES: &[(&str, &str)] = &[
@@ -98,6 +103,13 @@ mod tests {
                 include_str!(concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../../book/src/changelog.md"
+                )),
+            ),
+            (
+                "migration-0.22-to-1.0.md",
+                include_str!(concat!(
+                    env!("CARGO_MANIFEST_DIR"),
+                    "/../../book/src/migration-0.22-to-1.0.md"
                 )),
             ),
         ];

--- a/crates/core/src/config/versioning.rs
+++ b/crates/core/src/config/versioning.rs
@@ -311,14 +311,18 @@ pub struct VersioningConfig {
     /// trigger major bumps regardless of this setting. In TOML double-quoted
     /// strings, escape backslashes (e.g. `"\\[BREAKING\\]"` matches
     /// `[BREAKING]`).
+    #[schemars(with = "Option<String>")]
+    #[serde(default, with = "serde_regex")]
     #[merge(strategy = merge::option::overwrite_none)]
-    pub custom_major_increment_regex: Option<String>,
+    pub custom_major_increment_regex: Option<Regex>,
     /// Custom regex pattern matched against commit messages to trigger a
     /// minor version bump. This is additive — `feat:` commits always trigger
     /// minor bumps regardless of this setting. In TOML double-quoted strings,
     /// escape backslashes (e.g. `"\\[FEATURE\\]"` matches `[FEATURE]`).
+    #[schemars(with = "Option<String>")]
+    #[serde(default, with = "serde_regex")]
     #[merge(strategy = merge::option::overwrite_none)]
-    pub custom_minor_increment_regex: Option<String>,
+    pub custom_minor_increment_regex: Option<Regex>,
     /// Skips including merge commits in changelog
     #[merge(strategy = merge::option::overwrite_none)]
     #[schemars(default = "default_skip_merge_commits")]

--- a/crates/core/src/orchestrator/commit_fetcher.rs
+++ b/crates/core/src/orchestrator/commit_fetcher.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
-    path::Path,
+    path::{Path, PathBuf},
     rc::Rc,
 };
 
@@ -28,6 +28,11 @@ pub struct CommitFetcher {
     /// once for the whole run. Every lookup targets `config.base_branch`, so
     /// the sha alone identifies the answer.
     commit_prs: RefCell<HashMap<String, Option<ForgeCommitPR>>>,
+    /// Shas whose lookup errored, as opposed to succeeding with "no PR".
+    /// Both memoize as `None`, so the two are indistinguishable in
+    /// `commit_prs` - this is what lets the per-package summary count only
+    /// the links lost to failure, including on cache hits.
+    failed_pr_lookups: RefCell<HashSet<String>>,
 }
 
 impl CommitFetcher {
@@ -36,6 +41,7 @@ impl CommitFetcher {
             config,
             forge,
             commit_prs: RefCell::new(HashMap::new()),
+            failed_pr_lookups: RefCell::new(HashSet::new()),
         }
     }
 
@@ -75,8 +81,10 @@ impl CommitFetcher {
         tag: Option<&Tag>,
         commits: &[ForgeCommit],
     ) -> Vec<ForgeCommit> {
-        let mut package_paths = vec![package.normalized_full_path.clone()];
-        package_paths.extend(package.normalized_additional_paths.clone());
+        let package_paths: Vec<&PathBuf> =
+            std::iter::once(&package.normalized_full_path)
+                .chain(package.normalized_additional_paths.iter())
+                .collect();
 
         let mut package_commits: Vec<ForgeCommit> = vec![];
 
@@ -98,30 +106,19 @@ impl CommitFetcher {
                 let file_path = Path::new(file);
                 for package_path in package_paths.iter() {
                     if file_path.starts_with(package_path) {
-                        let raw_message = commit.message.to_string();
-                        let split_msg = raw_message
-                            .split_once("\n")
-                            .map(|(m, b)| (m.to_string(), b.to_string()));
-
-                        let (title, _body) = match split_msg {
-                            Some((t, b)) => {
-                                if b.is_empty() {
-                                    (t.trim().to_string(), None)
-                                } else {
-                                    (
-                                        t.trim().to_string(),
-                                        Some(b.trim().to_string()),
-                                    )
-                                }
-                            }
-                            None => (raw_message.to_string(), None),
-                        };
-
                         log::debug!(
                             "{}: including commit for analysis : {} : {}",
                             package.name,
                             commit.short_id,
-                            title
+                            // Subject line only. Built inside the macro so
+                            // nothing is computed at the default `Info`
+                            // level, and borrowed rather than allocated.
+                            commit
+                                .message
+                                .lines()
+                                .next()
+                                .unwrap_or_default()
+                                .trim()
                         );
 
                         package_commits.push(commit.clone());
@@ -209,6 +206,21 @@ impl CommitFetcher {
         for c in commits.iter_mut() {
             c.pr = self.commit_pr(&c.id, c.short_id.clone()).await;
         }
+
+        // The per-commit warnings scroll past in a large release. Close with
+        // one line naming the scale, so a partially linked changelog is
+        // obvious rather than something to reconstruct from the log.
+        let failed = self.failed_pr_lookups.borrow();
+        let lost = commits.iter().filter(|c| failed.contains(&c.id)).count();
+
+        if lost > 0 {
+            log::warn!(
+                "{}: {lost} of {} commits could not be linked to a pull \
+                 request: their changelog entries will have no PR link",
+                package.name,
+                commits.len(),
+            );
+        }
     }
 
     /// Looks up the PR that introduced `sha`, memoized per sha.
@@ -248,6 +260,7 @@ impl CommitFetcher {
                     "failed to fetch related PR for commit {short_sha}: \
                      {err}: omitting its PR link"
                 );
+                self.failed_pr_lookups.borrow_mut().insert(sha.to_string());
                 None
             }
         };
@@ -1427,6 +1440,65 @@ mod tests {
             commits[1].pr.as_ref().map(|pr| pr.id.as_str()),
             Some("7"),
             "one failure must not drop the others"
+        );
+    }
+
+    /// The summary counts links lost to failure, so a commit that simply has
+    /// no PR must not be counted. Both memoize as `None`, so only the
+    /// separate failure set can tell them apart.
+    #[tokio::test]
+    async fn fetch_merged_commit_prs_records_failures_not_absent_prs() {
+        let mut mock = MockForge::new();
+        mock.expect_get_merged_pull_request_for_commit()
+            .returning(|sha, _| {
+                if sha == "aaa1111" {
+                    Err(crate::result::ReleasaurusError::RateLimitExceeded)
+                } else {
+                    // succeeded, and this commit genuinely has no PR
+                    Ok(None)
+                }
+            });
+
+        let fetcher = create_pr_link_fetcher(true, mock);
+        let pkg = pr_link_package(&fetcher.config);
+        let mut commits = pr_commits(&["aaa1111", "bbb2222"]);
+
+        fetcher.fetch_merged_commit_prs(pkg, &mut commits).await;
+
+        let failed = fetcher.failed_pr_lookups.borrow();
+
+        assert!(
+            failed.contains("aaa1111"),
+            "the errored sha must be tracked"
+        );
+        assert!(
+            !failed.contains("bbb2222"),
+            "a successful lookup with no PR is not a failure"
+        );
+    }
+
+    /// A sha that failed stays counted on later packages, which read it from
+    /// the memo rather than re-requesting it.
+    #[tokio::test]
+    async fn fetch_merged_commit_prs_keeps_failures_across_packages() {
+        let mut mock = MockForge::new();
+        mock.expect_get_merged_pull_request_for_commit()
+            .times(1)
+            .returning(|_, _| {
+                Err(crate::result::ReleasaurusError::RateLimitExceeded)
+            });
+
+        let fetcher = create_pr_link_fetcher(true, mock);
+        let pkg = pr_link_package(&fetcher.config);
+
+        for _ in 0..2 {
+            let mut commits = pr_commits(&["aaa1111"]);
+            fetcher.fetch_merged_commit_prs(pkg, &mut commits).await;
+        }
+
+        assert!(
+            fetcher.failed_pr_lookups.borrow().contains("aaa1111"),
+            "a cache hit on a failed sha must still count as a lost link"
         );
     }
 

--- a/crates/core/src/resolver/resolvers/versioning.rs
+++ b/crates/core/src/resolver/resolvers/versioning.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use merge::Merge;
+use regex::Regex;
 
 use crate::{
     config::{
@@ -77,6 +78,24 @@ pub fn resolve_versioning(
     );
 
     validate_named_parsers(&named_parsers)?;
+
+    let breaking = &named_parsers[&Group::Breaking];
+
+    if let Some(pattern) = breaking.pattern.as_ref() {
+        final_versioning.custom_major_increment_regex =
+            if let Some(custom_breaking_regex) =
+                final_versioning.custom_major_increment_regex.as_ref()
+            {
+                let new_regex = Regex::new(&format!(
+                    "(?:{})|(?:{})",
+                    custom_breaking_regex.as_str(),
+                    pattern.as_str()
+                ))?;
+                Some(new_regex)
+            } else {
+                Some(pattern.clone())
+            };
+    }
 
     final_versioning.named_parsers = Some(named_parsers);
 
@@ -252,6 +271,86 @@ mod tests {
             versioning: Some(versioning),
             ..PackageConfig::default()
         }
+    }
+
+    fn resolve_with_breaking_pattern(
+        pattern: Option<&str>,
+        custom_major: Option<&str>,
+    ) -> VersioningConfig {
+        let mut named_parsers = NAMED_PARSERS.clone();
+
+        if let Some(pattern) = pattern {
+            named_parsers.get_mut(&Group::Breaking).unwrap().pattern =
+                Some(Regex::new(pattern).unwrap());
+        }
+
+        resolve_versioning(
+            "",
+            &package_with_versioning(VersioningConfig {
+                named_parsers: Some(named_parsers),
+                custom_major_increment_regex: custom_major
+                    .map(|c| Regex::new(c).unwrap()),
+                ..VersioningConfig::default()
+            }),
+            None,
+            &HashMap::new(),
+            &GlobalOverrides::default(),
+        )
+        .unwrap()
+    }
+
+    /// `breaking.pattern` is not consulted where the other parser patterns
+    /// are - grouping reads [`Commit::breaking`], which is set during commit
+    /// parsing from `custom_major_increment_regex`. Resolution is what bridges
+    /// the two, so a pattern that never lands in that field is a pattern that
+    /// does nothing at all.
+    #[test]
+    fn resolve_versioning_folds_breaking_pattern_into_major_regex() {
+        let resolved = resolve_with_breaking_pattern(Some("^breaking"), None);
+
+        assert_eq!(
+            resolved.custom_major_increment_regex.unwrap().as_str(),
+            "^breaking"
+        );
+    }
+
+    /// Both spellings are additive, so setting both must keep both. An
+    /// alternation is the only shape that does.
+    #[test]
+    fn resolve_versioning_combines_breaking_pattern_with_major_regex() {
+        let resolved = resolve_with_breaking_pattern(
+            Some("^breaking"),
+            Some(r"\[BREAKING\]"),
+        );
+
+        let combined = resolved.custom_major_increment_regex.unwrap();
+
+        assert!(
+            combined.is_match("breaking: drop the v1 endpoint"),
+            "breaking.pattern must survive the combine: {}",
+            combined.as_str()
+        );
+        assert!(
+            combined.is_match("fix: something [BREAKING] here"),
+            "the pre-existing regex must survive the combine: {}",
+            combined.as_str()
+        );
+        // An earlier version built this by concatenating an empty branch when
+        // one side was absent, which matches every string.
+        assert!(
+            !combined.is_match("chore: tidy up"),
+            "the combine must not match everything: {}",
+            combined.as_str()
+        );
+    }
+
+    /// Nothing is invented when no pattern is set, so an unset field stays
+    /// unset rather than becoming a match-everything regex.
+    #[test]
+    fn resolve_versioning_leaves_major_regex_unset_without_breaking_pattern() {
+        let resolved = resolve_with_breaking_pattern(None, None);
+
+        assert!(resolved.custom_major_increment_regex.is_none());
     }
 
     #[test]
@@ -450,18 +549,22 @@ mod tests {
 
     #[test]
     fn resolve_versioning_package_increment_flags_win_over_global() {
+        let global_regex = Regex::new("^global").unwrap();
+
         let default_versioning = VersioningConfig {
             breaking_always_increment_major: Some(false),
-            custom_minor_increment_regex: Some("^global".into()),
+            custom_minor_increment_regex: Some(global_regex),
             auto_start_next: Some(false),
             ..VersioningConfig::default()
         };
+
+        let package_regex = Regex::new("^package").unwrap();
 
         let resolved = resolve_versioning(
             "",
             &package_with_versioning(VersioningConfig {
                 breaking_always_increment_major: Some(true),
-                custom_minor_increment_regex: Some("^package".into()),
+                custom_minor_increment_regex: Some(package_regex.clone()),
                 auto_start_next: Some(true),
                 ..VersioningConfig::default()
             }),
@@ -473,8 +576,8 @@ mod tests {
 
         assert_eq!(resolved.breaking_always_increment_major, Some(true));
         assert_eq!(
-            resolved.custom_minor_increment_regex,
-            Some("^package".into())
+            resolved.custom_minor_increment_regex.unwrap().as_str(),
+            package_regex.as_str()
         );
         assert_eq!(resolved.auto_start_next, Some(true));
     }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -325,14 +325,16 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "custom_minor_increment_regex": {
           "description": "Custom regex pattern matched against commit messages to trigger a\nminor version bump. This is additive — `feat:` commits always trigger\nminor bumps regardless of this setting. In TOML double-quoted strings,\nescape backslashes (e.g. `\"\\\\[FEATURE\\\\]\"` matches `[FEATURE]`).",
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "default": null
         },
         "skip_merge_commits": {
           "description": "Skips including merge commits in changelog",


### PR DESCRIPTION
## Description

Additionally performs some cleanup around docs and testing and prepares project for major version release

BREAKING CHANGE: This commit fixes an issue where setting custom_major_increment_regex never affected grouping in the changelog. It now correctly marks a commit as "breaking" when the custom regex matches; however, this is technically a breaking change to previous changelog output, so marking as so here.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing completed
- [x] Documentation tested (if applicable)
