### PR TITLE
feat: adds support for prerelease flags in forge releases

### DIFF
--- a/book/src/library-api.md
+++ b/book/src/library-api.md
@@ -90,7 +90,7 @@ use releasaurus_core::{
         request::Tag,
         request::{
             Commit, CreateCommitRequest, CreatePrRequest,
-            CreateReleaseBranchRequest, ForgeCommit,
+            CreateReleaseBranchRequest, CreateReleaseRequest, ForgeCommit,
             GetFileContentRequest, GetPrRequest, PrLabelsRequest,
             PullRequest, ReleaseByTagResponse, UpdatePrRequest,
         },
@@ -143,7 +143,7 @@ impl Forge for MyForge {
     #     -> Result<()> { todo!() }
     # async fn replace_pr_labels(&self, _: PrLabelsRequest)
     #     -> Result<()> { todo!() }
-    # async fn create_release(&self, _: &str, _: &str, _: &str)
+    # async fn create_release(&self, _: CreateReleaseRequest)
     #     -> Result<()> { todo!() }
 }
 ```

--- a/crates/core/src/forge/azure_devops.rs
+++ b/crates/core/src/forge/azure_devops.rs
@@ -38,12 +38,12 @@ use crate::{
             resolve_token,
         },
         request::{
-            Commit, CreatePrRequest, ForgeCommit, ForgeCommitPR,
-            GetFileContentRequest, GetPrRequest, PrLabelsRequest,
-            PrMetadataBlock, PullRequest, ReleaseByTagResponse,
-            ResolvedCreateCommitRequest, ResolvedCreateReleaseBranchRequest,
-            ResolvedFileChange, ResolvedFileChangeAction, Tag, TagResponse,
-            UpdatePrRequest,
+            Commit, CreatePrRequest, CreateReleaseRequest, ForgeCommit,
+            ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+            PrLabelsRequest, PrMetadataBlock, PullRequest,
+            ReleaseByTagResponse, ResolvedCreateCommitRequest,
+            ResolvedCreateReleaseBranchRequest, ResolvedFileChange,
+            ResolvedFileChangeAction, Tag, TagResponse, UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -993,15 +993,11 @@ impl Forge for AzureDevops {
         Ok(())
     }
 
-    async fn create_release(
-        &self,
-        tag: &str,
-        _sha: &str,
-        _notes: &str,
-    ) -> Result<()> {
+    async fn create_release(&self, req: CreateReleaseRequest) -> Result<()> {
         log::info!(
-            "azure devops has no native release object — skipping release publish for tag {tag}; \
-             changelog commit and tag have already been pushed"
+            "azure devops has no native release object — skipping release publish for tag {}; \
+             changelog commit and tag have already been pushed",
+            req.tag
         );
         Ok(())
     }

--- a/crates/core/src/forge/forgejo.rs
+++ b/crates/core/src/forge/forgejo.rs
@@ -16,11 +16,11 @@ use crate::{
         },
         gitea::Gitea,
         request::{
-            Commit, CreatePrRequest, ForgeCommit, ForgeCommitPR,
-            GetFileContentRequest, GetPrRequest, PrLabelsRequest, PullRequest,
-            ReleaseByTagResponse, ResolvedCreateCommitRequest,
-            ResolvedCreateReleaseBranchRequest, ResolvedFileChangeAction, Tag,
-            TagResponse, UpdatePrRequest,
+            Commit, CreatePrRequest, CreateReleaseRequest, ForgeCommit,
+            ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+            PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            ResolvedCreateCommitRequest, ResolvedCreateReleaseBranchRequest,
+            ResolvedFileChangeAction, Tag, TagResponse, UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -287,12 +287,7 @@ impl Forge for Forgejo {
         self.gitea.replace_pr_labels(req).await
     }
 
-    async fn create_release(
-        &self,
-        tag: &str,
-        sha: &str,
-        notes: &str,
-    ) -> Result<()> {
-        self.gitea.create_release(tag, sha, notes).await
+    async fn create_release(&self, req: CreateReleaseRequest) -> Result<()> {
+        self.gitea.create_release(req).await
     }
 }

--- a/crates/core/src/forge/gitea.rs
+++ b/crates/core/src/forge/gitea.rs
@@ -29,11 +29,11 @@ use crate::{
             UpdatePullLabels,
         },
         request::{
-            Commit, CreatePrRequest, ForgeCommit, ForgeCommitPR,
-            GetFileContentRequest, GetPrRequest, PrLabelsRequest, PullRequest,
-            ReleaseByTagResponse, ResolvedCreateCommitRequest,
-            ResolvedCreateReleaseBranchRequest, ResolvedFileChangeAction, Tag,
-            TagResponse, UpdatePrRequest,
+            Commit, CreatePrRequest, CreateReleaseRequest, ForgeCommit,
+            ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+            PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            ResolvedCreateCommitRequest, ResolvedCreateReleaseBranchRequest,
+            ResolvedFileChangeAction, Tag, TagResponse, UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -871,19 +871,14 @@ impl Forge for Gitea {
         Ok(())
     }
 
-    async fn create_release(
-        &self,
-        tag: &str,
-        sha: &str,
-        notes: &str,
-    ) -> Result<()> {
+    async fn create_release(&self, req: CreateReleaseRequest) -> Result<()> {
         let data = CreateRelease {
-            tag_name: tag.to_string(),
-            target_commitish: sha.to_string(),
-            name: tag.to_string(),
-            body: notes.to_string(),
+            tag_name: req.tag.clone(),
+            target_commitish: req.sha,
+            name: req.tag,
+            body: req.notes,
             draft: false,
-            prerelease: false,
+            prerelease: req.prerelease,
         };
 
         let releases_url = self.base_url.join("releases")?;

--- a/crates/core/src/forge/github.rs
+++ b/crates/core/src/forge/github.rs
@@ -37,11 +37,11 @@ use crate::{
             },
         },
         request::{
-            Commit, CreatePrRequest, ForgeCommit, ForgeCommitPR,
-            GetFileContentRequest, GetPrRequest, PrLabelsRequest, PullRequest,
-            ReleaseByTagResponse, ResolvedCreateCommitRequest,
-            ResolvedCreateReleaseBranchRequest, ResolvedFileChange, Tag,
-            TagResponse, UpdatePrRequest,
+            Commit, CreatePrRequest, CreateReleaseRequest, ForgeCommit,
+            ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+            PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            ResolvedCreateCommitRequest, ResolvedCreateReleaseBranchRequest,
+            ResolvedFileChange, Tag, TagResponse, UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -919,21 +919,16 @@ impl Forge for Github {
         Ok(())
     }
 
-    async fn create_release(
-        &self,
-        tag: &str,
-        sha: &str,
-        notes: &str,
-    ) -> Result<()> {
+    async fn create_release(&self, req: CreateReleaseRequest) -> Result<()> {
         self.instance
             .repos(&self.url.owner, &self.url.name)
             .releases()
-            .create(tag)
-            .name(tag)
-            .body(notes)
-            .target_commitish(sha)
+            .create(&req.tag)
+            .name(&req.tag)
+            .body(&req.notes)
+            .target_commitish(&req.sha)
             .draft(false)
-            .prerelease(false)
+            .prerelease(req.prerelease)
             .send()
             .await?;
 

--- a/crates/core/src/forge/gitlab.rs
+++ b/crates/core/src/forge/gitlab.rs
@@ -59,11 +59,11 @@ use crate::{
             },
         },
         request::{
-            Commit, CreatePrRequest, ForgeCommit, ForgeCommitPR,
-            GetFileContentRequest, GetPrRequest, PrLabelsRequest, PullRequest,
-            ReleaseByTagResponse, ResolvedCreateCommitRequest,
-            ResolvedCreateReleaseBranchRequest, ResolvedFileChangeAction, Tag,
-            TagResponse, UpdatePrRequest,
+            Commit, CreatePrRequest, CreateReleaseRequest, ForgeCommit,
+            ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+            PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            ResolvedCreateCommitRequest, ResolvedCreateReleaseBranchRequest,
+            ResolvedFileChangeAction, Tag, TagResponse, UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -781,19 +781,16 @@ impl Forge for Gitlab {
         Ok(())
     }
 
-    async fn create_release(
-        &self,
-        tag: &str,
-        sha: &str,
-        notes: &str,
-    ) -> Result<()> {
-        // Create the release
+    async fn create_release(&self, req: CreateReleaseRequest) -> Result<()> {
+        // `req.prerelease` is ignored: the GitLab releases API has no
+        // prerelease flag. Upcoming/historical releases are expressed
+        // through `released_at`, which is a different concept.
         let endpoint = CreateRelease::builder()
             .project(&self.project_id)
-            .tag_name(tag)
-            .name(tag)
-            .description(notes)
-            .ref_sha(sha)
+            .tag_name(&req.tag)
+            .name(&req.tag)
+            .description(&req.notes)
+            .ref_sha(&req.sha)
             .build()?;
 
         // Execute the creation using ignore since we don't need the response

--- a/crates/core/src/forge/local.rs
+++ b/crates/core/src/forge/local.rs
@@ -21,11 +21,11 @@ use crate::{
     forge::{
         config::RepoUrl,
         request::{
-            Commit, CreatePrRequest, ForgeCommit, ForgeCommitPR,
-            GetFileContentRequest, GetPrRequest, PrLabelsRequest, PullRequest,
-            ReleaseByTagResponse, ResolvedCreateCommitRequest,
-            ResolvedCreateReleaseBranchRequest, ResolvedFileChange, Tag,
-            TagResponse, UpdatePrRequest,
+            Commit, CreatePrRequest, CreateReleaseRequest, ForgeCommit,
+            ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+            PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            ResolvedCreateCommitRequest, ResolvedCreateReleaseBranchRequest,
+            ResolvedFileChange, Tag, TagResponse, UpdatePrRequest,
         },
         traits::Forge,
     },
@@ -735,17 +735,17 @@ impl Forge for LocalRepo {
         }
     }
 
-    async fn create_release(
-        &self,
-        tag: &str,
-        sha: &str,
-        notes: &str,
-    ) -> Result<()> {
+    async fn create_release(&self, req: CreateReleaseRequest) -> Result<()> {
         if let Some(remote) = self.remote.as_ref() {
-            remote.forge.create_release(tag, sha, notes).await
+            remote.forge.create_release(req).await
         } else {
             log::warn!(
-                "local_mode: would create release: tag: {tag}, sha: {sha}, notes: {notes}"
+                "local_mode: would create release: tag: {}, sha: {}, \
+                 prerelease: {}, notes: {}",
+                req.tag,
+                req.sha,
+                req.prerelease,
+                req.notes
             );
             Ok(())
         }

--- a/crates/core/src/forge/manager.rs
+++ b/crates/core/src/forge/manager.rs
@@ -7,8 +7,8 @@ use crate::{
     forge::{
         request::{
             Commit, CreateCommitRequest, CreatePrRequest,
-            CreateReleaseBranchRequest, FileUpdateType, ForgeCommit,
-            ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+            CreateReleaseBranchRequest, CreateReleaseRequest, FileUpdateType,
+            ForgeCommit, ForgeCommitPR, GetFileContentRequest, GetPrRequest,
             PrLabelsRequest, PrMetadataBlock, PullRequest,
             ReleaseByTagResponse, ResolvedCreateCommitRequest,
             ResolvedCreateReleaseBranchRequest, ResolvedFileChange,
@@ -435,20 +435,31 @@ impl ForgeManager {
 
     pub async fn create_release(
         &self,
-        tag: &str,
-        sha: &str,
-        notes: &str,
+        req: CreateReleaseRequest,
     ) -> Result<()> {
         if self.options.dry_run {
             log::warn!(
-                "dry_run: would create release: tag: {tag}, sha: {sha}, notes {notes}"
+                "dry_run: would create release: tag: {}, sha: {}, \
+                 prerelease: {}, notes {}",
+                req.tag,
+                req.sha,
+                req.prerelease,
+                req.notes
             );
             return Ok(());
         }
 
-        log::info!("Creating release: tag={}, sha={}", tag, sha);
+        log::info!(
+            "Creating release: tag={}, sha={}, prerelease={}",
+            req.tag,
+            req.sha,
+            req.prerelease
+        );
 
-        let result = self.forge.create_release(tag, sha, notes).await;
+        // Retained for the post-publish log lines: the request is moved
+        // into the forge call.
+        let tag = req.tag.clone();
+        let result = self.forge.create_release(req).await;
 
         match &result {
             Ok(_) => log::info!("Successfully created release: {}", tag),
@@ -1097,7 +1108,12 @@ mod tests {
         );
 
         manager
-            .create_release("v1.0.0", "abc123", "Release notes")
+            .create_release(CreateReleaseRequest {
+                tag: "v1.0.0".into(),
+                sha: "abc123".into(),
+                notes: "Release notes".into(),
+                prerelease: false,
+            })
             .await
             .unwrap();
     }

--- a/crates/core/src/forge/request.rs
+++ b/crates/core/src/forge/request.rs
@@ -76,6 +76,17 @@ pub struct PrLabelsRequest {
     pub labels: Vec<String>,
 }
 
+/// Request to publish a release on the forge.
+#[derive(Debug)]
+pub struct CreateReleaseRequest {
+    pub tag: String,
+    pub sha: String,
+    pub notes: String,
+    /// Marks the release as a prerelease on forges that support it.
+    /// Derived from the version's semver pre-release field, not config.
+    pub prerelease: bool,
+}
+
 /// How to apply file content changes during branch creation.
 #[derive(Debug, Copy, Clone, Serialize, PartialEq)]
 pub enum FileUpdateType {

--- a/crates/core/src/forge/tests/common/run.rs
+++ b/crates/core/src/forge/tests/common/run.rs
@@ -8,8 +8,8 @@ use crate::{
         manager::ForgeManager,
         request::{
             CreateCommitRequest, CreatePrRequest, CreateReleaseBranchRequest,
-            FileChange, FileUpdateType, GetFileContentRequest, GetPrRequest,
-            PrLabelsRequest,
+            CreateReleaseRequest, FileChange, FileUpdateType,
+            GetFileContentRequest, GetPrRequest, PrLabelsRequest,
         },
         tests::common::traits::ForgeTestHelper,
     },
@@ -403,10 +403,13 @@ pub async fn run_forge_test(
     // create_release -> succeeds
     ////////////////////////////////////////////////////////////////////////////
     log::info!("creating release for tag");
-    forge
-        .create_release(&current_tag.name, &current_tag.sha, "release notes")
-        .await
-        .unwrap();
+    let release_req = CreateReleaseRequest {
+        tag: current_tag.name.clone(),
+        sha: current_tag.sha.clone(),
+        notes: "release notes".into(),
+        prerelease: !current_tag.semver.pre.is_empty(),
+    };
+    forge.create_release(release_req).await.unwrap();
     sleep(SHORT_WAIT).await;
 
     if helper.supports_native_releases() {

--- a/crates/core/src/forge/traits.rs
+++ b/crates/core/src/forge/traits.rs
@@ -9,10 +9,11 @@ use mockall::automock;
 use crate::{
     forge::request::{
         Commit, CreateCommitRequest, CreatePrRequest,
-        CreateReleaseBranchRequest, FileChange, ForgeCommit, ForgeCommitPR,
-        GetFileContentRequest, GetPrRequest, PrLabelsRequest, PrMetadataBlock,
-        PullRequest, ReleaseByTagResponse, ResolvedCreateCommitRequest,
-        ResolvedCreateReleaseBranchRequest, Tag, TagResponse, UpdatePrRequest,
+        CreateReleaseBranchRequest, CreateReleaseRequest, FileChange,
+        ForgeCommit, ForgeCommitPR, GetFileContentRequest, GetPrRequest,
+        PrLabelsRequest, PrMetadataBlock, PullRequest, ReleaseByTagResponse,
+        ResolvedCreateCommitRequest, ResolvedCreateReleaseBranchRequest, Tag,
+        TagResponse, UpdatePrRequest,
     },
     result::Result,
 };
@@ -104,12 +105,7 @@ pub trait Forge: Any + Send + Sync {
     /// Replace all labels on a pull request with the provided set.
     async fn replace_pr_labels(&self, req: PrLabelsRequest) -> Result<()>;
     /// Publish a release on the forge platform with notes and tag reference.
-    async fn create_release(
-        &self,
-        tag: &str,
-        sha: &str,
-        notes: &str,
-    ) -> Result<()>;
+    async fn create_release(&self, req: CreateReleaseRequest) -> Result<()>;
     /// Encode metadata JSON for embedding in the PR body.
     ///
     /// The default writes metadata as an HTML comment inside the div. Forges

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -13,8 +13,9 @@ use crate::{
         config::{PENDING_LABEL, TAGGED_LABEL},
         manager::ForgeManager,
         request::{
-            CreateCommitRequest, GetPrRequest, PrLabelsRequest, PullRequest,
-            ReleaseByTagResponse, UpdatePrRequest,
+            CreateCommitRequest, CreateReleaseRequest, GetPrRequest,
+            PrLabelsRequest, PullRequest, ReleaseByTagResponse,
+            UpdatePrRequest,
         },
     },
     orchestrator::{
@@ -555,8 +556,22 @@ impl Orchestrator {
         // The tag is on the commit by now, so a publish failure leaves the
         // same split state `release-direct` reports — except here the PR
         // keeps its pending label and re-running picks it back up.
+
+        // Only the tag name survives in the merged PR body, so the
+        // prerelease flag is recovered from it. An unparseable tag falls
+        // back to a normal release rather than guessing.
+        let prerelease = tag
+            .strip_prefix(&package.tag_prefix)
+            .and_then(|v| semver::Version::parse(v).ok())
+            .is_some_and(|v| !v.pre.is_empty());
+
         self.forge
-            .create_release(&tag, &merged_pr.sha, notes.trim())
+            .create_release(CreateReleaseRequest {
+                tag: tag.clone(),
+                sha: merged_pr.sha.clone(),
+                notes: notes.trim().to_string(),
+                prerelease,
+            })
             .await
             .map_err(|e| {
                 ReleasaurusError::release_not_published(
@@ -645,7 +660,12 @@ impl Orchestrator {
             );
 
             self.forge
-                .create_release(&pkg.tag.name, commit_sha, &pkg.notes)
+                .create_release(CreateReleaseRequest {
+                    tag: pkg.tag.name.clone(),
+                    sha: commit_sha.to_string(),
+                    notes: pkg.notes.clone(),
+                    prerelease: !pkg.tag.semver.pre.is_empty(),
+                })
                 .await
                 .map_err(|e| {
                     self.partial_direct_release(

--- a/crates/core/src/orchestrator/tests/package_releases.rs
+++ b/crates/core/src/orchestrator/tests/package_releases.rs
@@ -42,10 +42,12 @@ async fn create_package_release_parses_metadata_from_pr_body() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .withf(|tag, sha, notes| {
-            tag == "v1.2.3" && sha == "abc123" && notes == "Release notes here"
+        .withf(|req| {
+            req.tag == "v1.2.3"
+                && req.sha == "abc123"
+                && req.notes == "Release notes here"
         })
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     // Then create orchestrator with the mock
     let orchestrator = create_test_orchestrator(mock_forge);
@@ -134,8 +136,8 @@ async fn create_package_release_matches_correct_package_by_name() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .withf(|_, _, notes| notes == "Correct notes")
-        .returning(|_, _, _| Ok(()));
+        .withf(|req| req.notes == "Correct notes")
+        .returning(|_| Ok(()));
 
     let orchestrator = create_test_orchestrator(mock_forge);
 
@@ -176,8 +178,8 @@ async fn create_package_release_trims_notes() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .withf(|_, _, notes| notes == "Release notes")
-        .returning(|_, _, _| Ok(()));
+        .withf(|req| req.notes == "Release notes")
+        .returning(|_| Ok(()));
 
     let orchestrator = create_test_orchestrator(mock_forge);
 

--- a/crates/core/src/orchestrator/tests/release_direct.rs
+++ b/crates/core/src/orchestrator/tests/release_direct.rs
@@ -13,8 +13,12 @@ use std::{
 
 use crate::{
     config::{
-        Config, package::PackageConfigBuilder, release_type::ReleaseType,
+        Config,
+        package::PackageConfigBuilder,
+        prerelease::{PrereleaseConfig, PrereleaseStrategy},
+        release_type::ReleaseType,
         repository::RepositoryConfig,
+        versioning::VersioningConfig,
     },
     forge::{
         request::{Commit, ForgeCommitBuilder, PullRequest, Tag},
@@ -113,7 +117,7 @@ async fn release_direct_commits_tags_and_releases_a_single_package() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     // no PR machinery should be touched by this flow
     mock_forge.expect_get_open_release_pr().times(0);
@@ -156,7 +160,7 @@ async fn release_direct_creates_one_commit_for_a_monorepo_release() {
     mock_forge
         .expect_create_release()
         .times(2)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     let orchestrator =
         create_test_orchestrator_with_config(mock_forge, two_packages(), None);
@@ -205,7 +209,7 @@ async fn release_direct_creates_a_commit_per_package_when_prs_are_separate() {
     mock_forge
         .expect_create_release()
         .times(2)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     let config = Config {
         repository: RepositoryConfig {
@@ -251,9 +255,9 @@ async fn release_direct_targets_a_specific_package() {
 
     mock_forge
         .expect_create_release()
-        .withf(|tag, _, _| tag.contains("pkg-a"))
+        .withf(|req| req.tag.contains("pkg-a"))
         .times(1)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     let orchestrator =
         create_test_orchestrator_with_config(mock_forge, two_packages(), None);
@@ -386,7 +390,7 @@ async fn release_direct_ignores_a_pending_release_on_an_unrelated_package() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     let config = Config {
         repository: RepositoryConfig {
@@ -493,7 +497,7 @@ async fn release_direct_reports_a_partial_release_when_publishing_fails() {
 
     mock_forge
         .expect_create_release()
-        .returning(|_, _, _| Err(ReleasaurusError::forge("409 conflict")));
+        .returning(|_| Err(ReleasaurusError::forge("409 conflict")));
 
     let orchestrator =
         create_test_orchestrator_with_config(mock_forge, two_packages(), None);
@@ -534,12 +538,10 @@ async fn release_direct_tags_every_package_before_publishing_any() {
     });
 
     let sink = Arc::clone(&order);
-    mock_forge
-        .expect_create_release()
-        .returning(move |_, _, _| {
-            sink.lock().unwrap().push("release".to_string());
-            Ok(())
-        });
+    mock_forge.expect_create_release().returning(move |_| {
+        sink.lock().unwrap().push("release".to_string());
+        Ok(())
+    });
 
     let orchestrator =
         create_test_orchestrator_with_config(mock_forge, two_packages(), None);
@@ -619,9 +621,7 @@ async fn release_direct_separate_commits_do_not_revert_each_other() {
     expect_two_package_history(&mut mock_forge);
 
     mock_forge.expect_tag_commit().returning(|_, _| Ok(()));
-    mock_forge
-        .expect_create_release()
-        .returning(|_, _, _| Ok(()));
+    mock_forge.expect_create_release().returning(|_| Ok(()));
 
     let tree = expect_committing_tree(
         &mut mock_forge,
@@ -671,4 +671,128 @@ async fn release_direct_separate_commits_do_not_revert_each_other() {
         workspace.contains("pkg-b = \"0.1.0\""),
         "pkg-b's bump was reverted by pkg-a's commit: {workspace}"
     );
+}
+
+// The direct flow still holds the computed `Tag`, so the prerelease flag
+// comes straight off the parsed semver rather than the tag string.
+
+#[tokio::test]
+async fn release_direct_marks_a_prerelease_version_as_a_prerelease() {
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _, _| {
+            Ok(vec![Tag {
+                name: "v1.0.0".to_string(),
+                semver: semver::Version::parse("1.0.0").unwrap(),
+                sha: "old-sha".to_string(),
+                ..Default::default()
+            }])
+        });
+
+    mock_forge.expect_get_commits().returning(|_, _| {
+        Ok(vec![
+            ForgeCommitBuilder::default()
+                .id("abc123")
+                .message("feat: a new feature")
+                .files(vec!["dummy.txt".into()])
+                .build()
+                .unwrap(),
+        ])
+    });
+
+    mock_forge.expect_get_file_content().returning(|_| Ok(None));
+
+    mock_forge.expect_create_commit().times(1).returning(|_| {
+        Ok(Commit {
+            sha: "release-sha".to_string(),
+        })
+    });
+
+    mock_forge.expect_tag_commit().returning(|_, _| Ok(()));
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| req.tag == "v1.1.0-rc.1" && req.prerelease)
+        .returning(|_| Ok(()));
+
+    let versioning = VersioningConfig {
+        prerelease: Some(PrereleaseConfig {
+            suffix: "rc".to_string(),
+            strategy: PrereleaseStrategy::Versioned,
+        }),
+        ..Default::default()
+    };
+
+    let orchestrator = create_test_orchestrator_with_config(
+        mock_forge,
+        vec![
+            PackageConfigBuilder::default()
+                .name(TEST_PKG_NAME)
+                .path(".")
+                .versioning(versioning)
+                .build()
+                .unwrap(),
+        ],
+        None,
+    );
+
+    orchestrator.release_direct(None).await.unwrap();
+}
+
+#[tokio::test]
+async fn release_direct_does_not_mark_a_stable_version_as_a_prerelease() {
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(|_| Ok(None));
+
+    mock_forge
+        .expect_get_latest_tags_for_prefix()
+        .returning(|_, _, _| {
+            Ok(vec![Tag {
+                name: "v1.0.0".to_string(),
+                semver: semver::Version::parse("1.0.0").unwrap(),
+                sha: "old-sha".to_string(),
+                ..Default::default()
+            }])
+        });
+
+    mock_forge.expect_get_commits().returning(|_, _| {
+        Ok(vec![
+            ForgeCommitBuilder::default()
+                .id("abc123")
+                .message("feat: a new feature")
+                .files(vec!["dummy.txt".into()])
+                .build()
+                .unwrap(),
+        ])
+    });
+
+    mock_forge.expect_get_file_content().returning(|_| Ok(None));
+
+    mock_forge.expect_create_commit().times(1).returning(|_| {
+        Ok(Commit {
+            sha: "release-sha".to_string(),
+        })
+    });
+
+    mock_forge.expect_tag_commit().returning(|_, _| Ok(()));
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| req.tag == "v1.1.0" && !req.prerelease)
+        .returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator(mock_forge);
+
+    orchestrator.release_direct(None).await.unwrap();
 }

--- a/crates/core/src/orchestrator/tests/release_workflow.rs
+++ b/crates/core/src/orchestrator/tests/release_workflow.rs
@@ -123,7 +123,7 @@ async fn create_releases_handles_separate_pull_requests() {
     mock_forge
         .expect_create_release()
         .times(2)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
     mock_forge
         .expect_replace_pr_labels()
         .times(2)
@@ -191,9 +191,9 @@ async fn create_releases_targets_specific_package() {
         .returning(|_, _| Ok(()));
     mock_forge
         .expect_create_release()
-        .withf(|tag, _, _| tag.contains("pkg-a"))
+        .withf(|req| req.tag.contains("pkg-a"))
         .times(1)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
     mock_forge
         .expect_replace_pr_labels()
         .times(1)
@@ -259,9 +259,7 @@ async fn create_releases_triggers_auto_start_next() {
 
     mock_forge.expect_get_tag().returning(|_| Ok(None));
     mock_forge.expect_tag_commit().returning(|_, _| Ok(()));
-    mock_forge
-        .expect_create_release()
-        .returning(|_, _, _| Ok(()));
+    mock_forge.expect_create_release().returning(|_| Ok(()));
     mock_forge.expect_replace_pr_labels().returning(|_| Ok(()));
 
     mock_forge
@@ -341,12 +339,12 @@ async fn create_releases_uses_edited_notes_from_pr_body() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .withf(|tag, sha, notes| {
-            tag == "v1.0.0"
-                && sha == "abc123"
-                && notes.contains("User-edited release notes")
+        .withf(|req| {
+            req.tag == "v1.0.0"
+                && req.sha == "abc123"
+                && req.notes.contains("User-edited release notes")
         })
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     mock_forge.expect_replace_pr_labels().returning(|_| Ok(()));
 
@@ -396,12 +394,12 @@ async fn create_releases_includes_header_and_footer_in_release_notes() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .withf(|_, _, notes| {
-            notes.contains("Custom header text")
-                && notes.contains("Release notes")
-                && notes.contains("Custom footer text")
+        .withf(|req| {
+            req.notes.contains("Custom header text")
+                && req.notes.contains("Release notes")
+                && req.notes.contains("Custom footer text")
         })
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     mock_forge.expect_replace_pr_labels().returning(|_| Ok(()));
 
@@ -459,8 +457,8 @@ async fn create_releases_skips_tagging_when_the_tag_already_exists() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .withf(|tag, sha, _| tag == "v1.0.0" && sha == "abc123")
-        .returning(|_, _, _| Ok(()));
+        .withf(|req| req.tag == "v1.0.0" && req.sha == "abc123")
+        .returning(|_| Ok(()));
 
     mock_forge
         .expect_replace_pr_labels()
@@ -514,11 +512,329 @@ async fn create_releases_still_tags_when_an_existing_tag_points_elsewhere() {
     mock_forge
         .expect_create_release()
         .times(1)
-        .returning(|_, _, _| Ok(()));
+        .returning(|_| Ok(()));
 
     mock_forge.expect_replace_pr_labels().returning(|_| Ok(()));
 
     let orchestrator = create_test_orchestrator(mock_forge);
+
+    orchestrator.create_releases(None).await.unwrap();
+}
+
+// Prerelease flag on the published release. The merged PR body carries
+// only the tag name, so the flag is recovered by stripping the package's
+// tag prefix and parsing the remainder as semver.
+
+#[tokio::test]
+async fn create_releases_marks_a_prerelease_tag_as_a_prerelease() {
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: TEST_PKG_NAME,
+        tag: "v1.0.0-rc.1",
+        notes: "Release notes",
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "",
+        footer: "",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge.expect_get_tag().returning(|tag| {
+        Ok(Some(TagResponse {
+            tag: tag.to_string(),
+            sha: "abc123".to_string(),
+        }))
+    });
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| req.tag == "v1.0.0-rc.1" && req.prerelease)
+        .returning(|_| Ok(()));
+
+    mock_forge
+        .expect_replace_pr_labels()
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator(mock_forge);
+
+    orchestrator.create_releases(None).await.unwrap();
+}
+
+#[tokio::test]
+async fn create_releases_does_not_mark_a_stable_tag_as_a_prerelease() {
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: TEST_PKG_NAME,
+        tag: "v1.0.0",
+        notes: "Release notes",
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "",
+        footer: "",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge.expect_get_tag().returning(|tag| {
+        Ok(Some(TagResponse {
+            tag: tag.to_string(),
+            sha: "abc123".to_string(),
+        }))
+    });
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| !req.prerelease)
+        .returning(|_| Ok(()));
+
+    mock_forge
+        .expect_replace_pr_labels()
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator(mock_forge);
+
+    orchestrator.create_releases(None).await.unwrap();
+}
+
+/// The prefix itself contains a hyphen, so prefix stripping must not
+/// break prerelease detection. Paired with the stable case below, which
+/// is what actually rules out looking for a hyphen in the whole tag.
+#[tokio::test]
+async fn create_releases_detects_a_prerelease_behind_a_hyphenated_tag_prefix() {
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: "mypkg",
+        tag: "mypkg-v1.0.0-rc.1",
+        notes: "Release notes",
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "",
+        footer: "",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge.expect_get_tag().returning(|tag| {
+        Ok(Some(TagResponse {
+            tag: tag.to_string(),
+            sha: "abc123".to_string(),
+        }))
+    });
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| req.tag == "mypkg-v1.0.0-rc.1" && req.prerelease)
+        .returning(|_| Ok(()));
+
+    mock_forge
+        .expect_replace_pr_labels()
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator_with_config(
+        mock_forge,
+        vec![
+            PackageConfigBuilder::default()
+                .name("mypkg")
+                .path(".")
+                .tag_prefix("mypkg-v")
+                .build()
+                .unwrap(),
+        ],
+        None,
+    );
+
+    orchestrator.create_releases(None).await.unwrap();
+}
+
+/// Build metadata lands in semver's `build`, not `pre`, so a version
+/// carrying it is still a normal release.
+#[tokio::test]
+async fn create_releases_treats_build_metadata_as_a_stable_release() {
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: TEST_PKG_NAME,
+        tag: "v1.0.0+20260824.abc123",
+        notes: "Release notes",
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "",
+        footer: "",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge.expect_get_tag().returning(|tag| {
+        Ok(Some(TagResponse {
+            tag: tag.to_string(),
+            sha: "abc123".to_string(),
+        }))
+    });
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| !req.prerelease)
+        .returning(|_| Ok(()));
+
+    mock_forge
+        .expect_replace_pr_labels()
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator(mock_forge);
+
+    orchestrator.create_releases(None).await.unwrap();
+}
+
+/// A hand-edited `data-tag` that doesn't parse must not block the
+/// release — it falls back to publishing a normal release.
+#[tokio::test]
+async fn create_releases_falls_back_to_stable_for_an_unparseable_tag() {
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: TEST_PKG_NAME,
+        tag: "v-not-a-version",
+        notes: "Release notes",
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "",
+        footer: "",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge.expect_get_tag().returning(|tag| {
+        Ok(Some(TagResponse {
+            tag: tag.to_string(),
+            sha: "abc123".to_string(),
+        }))
+    });
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| !req.prerelease)
+        .returning(|_| Ok(()));
+
+    mock_forge
+        .expect_replace_pr_labels()
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator(mock_forge);
+
+    orchestrator.create_releases(None).await.unwrap();
+}
+
+/// The discriminating case for the hyphenated prefix: a hyphen appears in
+/// `mypkg-v1.0.0`, but only in the prefix, so this is a stable release.
+#[tokio::test]
+async fn create_releases_does_not_mark_a_stable_tag_behind_a_hyphenated_prefix()
+{
+    let pr_body = make_pr_body(&PrBodyInput {
+        pkg: "mypkg",
+        tag: "mypkg-v1.0.0",
+        notes: "Release notes",
+        tag_link: "tag-link",
+        sha_link: "sha-link",
+        header: "",
+        footer: "",
+    });
+
+    let mut mock_forge = MockForge::new();
+
+    mock_forge
+        .expect_get_merged_release_pr()
+        .returning(move |_| {
+            Ok(Some(PullRequest {
+                number: 123,
+                sha: "abc123".to_string(),
+                body: pr_body.clone(),
+            }))
+        });
+
+    mock_forge.expect_get_tag().returning(|tag| {
+        Ok(Some(TagResponse {
+            tag: tag.to_string(),
+            sha: "abc123".to_string(),
+        }))
+    });
+
+    mock_forge
+        .expect_create_release()
+        .times(1)
+        .withf(|req| req.tag == "mypkg-v1.0.0" && !req.prerelease)
+        .returning(|_| Ok(()));
+
+    mock_forge
+        .expect_replace_pr_labels()
+        .times(1)
+        .returning(|_| Ok(()));
+
+    let orchestrator = create_test_orchestrator_with_config(
+        mock_forge,
+        vec![
+            PackageConfigBuilder::default()
+                .name("mypkg")
+                .path(".")
+                .tag_prefix("mypkg-v")
+                .build()
+                .unwrap(),
+        ],
+        None,
+    );
 
     orchestrator.create_releases(None).await.unwrap();
 }


### PR DESCRIPTION
## Description

Github, Gitea, and Forgejo support prerelease flags when creating releases. This commit extends the Forge trait to support setting those flags where appropriate

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Testing

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing completed
- [x] Documentation tested (if applicable)
